### PR TITLE
Add web-based visualizer and refactor biomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,8 @@ name = "Tome"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
+ "chrono",
  "dotenv",
  "fastnbt",
  "fastsnbt",
@@ -27,6 +29,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
+ "tower-http",
 ]
 
 [[package]]
@@ -43,6 +46,15 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anyhow"
@@ -72,6 +84,61 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -105,6 +172,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -146,6 +222,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "colored"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,12 +261,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -214,6 +322,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -253,6 +367,16 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -481,6 +605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,10 +711,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -595,6 +741,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -652,6 +799,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -861,6 +1032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,7 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_xorshift",
 ]
 
@@ -1173,8 +1350,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1184,7 +1371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1197,12 +1394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1284,7 +1490,7 @@ dependencies = [
  "nom",
  "pin-project-lite",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1298,7 +1504,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tower-service",
 ]
 
@@ -1318,7 +1524,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-timer",
@@ -1330,7 +1536,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1484,10 +1690,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1501,10 +1708,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1535,6 +1751,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1771,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1706,7 +1944,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1714,6 +1961,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1813,6 +2071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2108,33 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1858,6 +2155,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1890,6 +2188,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +2240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2256,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2086,10 +2419,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -2097,8 +2471,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -2108,7 +2482,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2117,7 +2500,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,11 @@ simple_logger = "5.0.0"
 strum = "0.27.1"
 strum_macros = "0.27.1"
 tokio = {version = "1.44.2", features = ["full"]}
+
+# Optional visualizer dependencies
+axum = { version = "0.8", features = ["ws"], optional = true }
+tower-http = { version = "0.6", features = ["fs", "cors"], optional = true }
+chrono = "0.4.44"
+
+[features]
+visualizer = ["axum", "tower-http"]

--- a/src/ai/ai.rs
+++ b/src/ai/ai.rs
@@ -3,7 +3,7 @@ use openai::{chat::{ChatCompletion, ChatCompletionMessage, ChatCompletionMessage
 use schemars::schema_for;
 use serde::Deserialize;
 
-pub async fn get_ai_message(system :&str, user:&str) -> String {
+pub async fn get_ai_message(system :&str, user:&str) -> anyhow::Result<String> {
     // Relies on OPENAI_KEY and optionally OPENAI_BASE_URL.
     let credentials = Credentials::from_env();
     let messages = vec![
@@ -13,13 +13,14 @@ pub async fn get_ai_message(system :&str, user:&str) -> String {
     let chat_completion = ChatCompletion::builder("gpt-4o", messages.clone())
         .credentials(credentials.clone())
         .create()
-        .await
-        .unwrap();
-    let returned_message = chat_completion.choices.first().unwrap().message.clone();
+        .await?;
+    let returned_message = chat_completion.choices.first()
+        .ok_or_else(|| anyhow::anyhow!("No choices returned from AI"))?.message.clone();
 
-    let content = returned_message.content.unwrap();
+    let content = returned_message.content
+        .ok_or_else(|| anyhow::anyhow!("AI returned empty content"))?;
     let string_content = content.trim();
-    string_content.to_string()
+    Ok(string_content.to_string())
 }
 
 pub fn extract_json(response : &str) -> Option<String> {
@@ -36,10 +37,16 @@ pub fn extract_json(response : &str) -> Option<String> {
     None
 }
 
-pub async fn try_ai_json<T>(query : &str) -> Option<T> 
+pub async fn try_ai_json<T>(query : &str) -> Option<T>
 where T: for<'de> Deserialize<'de> + schemars::JsonSchema {
     let schema = serde_json::to_string_pretty(&schema_for!(T)).unwrap();
-    let response = get_ai_message(&format!("You are a helpful assistant. Format your response in JSON according to the following schema: {}. Do NOT include the schema in the response.", schema), query).await;
+    let response = match get_ai_message(&format!("You are a helpful assistant. Format your response in JSON according to the following schema: {}. Do NOT include the schema in the response.", schema), query).await {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("AI request failed: {e}");
+            return None;
+        }
+    };
 
     info!("AI Response: {}", response);
 

--- a/src/ai/test.rs
+++ b/src/ai/test.rs
@@ -12,7 +12,7 @@ mod tests {
 
         let system = "You are a helpful assistant.";
         let user = "Generate a town name that sounds japanese, as well as a description of the town. Make it a JSON string with keys 'name' and 'description'.";
-        let message = get_ai_message(system, user).await;
+        let message = get_ai_message(system, user).await.expect("AI call failed");
 
         println!("AI Response: {}", extract_json(&message).unwrap_or("No JSON found".to_string()));
     }

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -46,7 +46,7 @@ mod tests {
         for x in 0..build_area.length() {
             for z in 0..build_area.width() {
                 let biome = world.get_surface_biome_at(Point2D::new(x, z));
-                assert_ne!(biome, Biome::Unknown, "Biome should not be unknown");
+                assert!(!biome.is_unknown(), "Biome should not be unknown");
             }
         }
     }

--- a/src/editor/world.rs
+++ b/src/editor/world.rs
@@ -86,7 +86,7 @@ impl World {
         let motion_blocking_height_map = vec![vec![0; size_z_usize]; size_x_usize];
         let ground_block_map = vec![vec![Block::new(Default::default(), None, None); size_z_usize]; size_x_usize];
         let build_claim_map = vec![vec![BuildClaim::None; size_z_usize]; size_x_usize];
-        let ground_biome_map = vec![vec![Biome::Unknown; size_z_usize]; size_x_usize];
+        let ground_biome_map = vec![vec![Biome::unknown(); size_z_usize]; size_x_usize];
 
         let mut world = World {
             build_area,
@@ -163,7 +163,23 @@ impl World {
 
     pub fn get_height_map(&self) -> &Vec<Vec<i32>> {
         &self.ground_height_map
-    }   
+    }
+
+    pub fn get_ground_block_map(&self) -> &Vec<Vec<Block>> {
+        &self.ground_block_map
+    }
+
+    pub fn get_ground_biome_map(&self) -> &Vec<Vec<Biome>> {
+        &self.ground_biome_map
+    }
+
+    pub fn get_ocean_floor_height_map(&self) -> &Vec<Vec<i32>> {
+        &self.ocean_floor_height_map
+    }
+
+    pub fn get_build_claim_map(&self) -> &Vec<Vec<BuildClaim>> {
+        &self.build_claim_map
+    }
 
     pub fn set_heights(&mut self, points : &HashSet<Point3D>) {
         for point in points {

--- a/src/generator/buildings/placement.rs
+++ b/src/generator/buildings/placement.rs
@@ -99,7 +99,7 @@ pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &Loade
         let woods = superdistrict_data.biome_count().keys().into_iter()
             .map(|biome| {
                 println!("Processing biome: {:?}", biome);
-                BiomeWoodtype::from_biome(*biome)
+                BiomeWoodtype::from_biome(biome.clone())
                     .map(|wood_type| 
                         data.borrow().palettes.get(&wood_type.get_wood_palette_id())
                             .expect("Wood palette not found")
@@ -111,7 +111,7 @@ pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &Loade
         let stones = superdistrict_data.biome_count().into_iter()
             .max_by_key(|item| item.1)
             .map(|(biome, _)| 
-                BiomeStonetype::from_biome(*biome)
+                BiomeStonetype::from_biome(biome.clone())
                     .into_iter()
                     .map(|stone_type| 
                         stone_type.get_stone_palette_ids().iter().map(|id| 
@@ -128,7 +128,7 @@ pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &Loade
     }
     
     let urban_area_edge = get_edge(&editor.world().get_urban_points());
-    smooth_and_pave_road(editor, rng, &outers.difference(&urban_area_edge).cloned().collect(), PavingType::from_biome(settlement_info.top_three_biomes[0])).await;
+    smooth_and_pave_road(editor, rng, &outers.difference(&urban_area_edge).cloned().collect(), PavingType::from_biome(settlement_info.top_three_biomes[0].clone())).await;
 
     let sets = data.borrow().building_sets.iter().filter(|(_, set)| {
         set.style == style
@@ -216,9 +216,9 @@ enum PavingType {
 
 impl PavingType {
     fn from_biome(biome : Biome) -> Self {
-        match biome {
-            Biome::Desert | Biome::DesertHills | Biome::DesertLakes | Biome::Beach => PavingType::Sandstone,
-            Biome::Badlands | Biome::ErodedBadlands | Biome::WoodedBadlands | Biome::Savanna | Biome::SavannaPlateau | Biome::ShatteredSavanna | Biome::ShatteredSavannaPlateau => PavingType::RedSandstone,
+        match biome.name() {
+            "desert" | "desert_hills" | "desert_lakes" | "beach" => PavingType::Sandstone,
+            "badlands" | "eroded_badlands" | "wooded_badlands" | "savanna" | "savanna_plateau" | "shattered_savanna" | "shattered_savanna_plateau" => PavingType::RedSandstone,
             _ => PavingType::Stone,
         }
     }

--- a/src/generator/chronicle.rs
+++ b/src/generator/chronicle.rs
@@ -32,7 +32,7 @@ impl SettlementInfo {
             top_three_biomes: biomes_by_count.iter()
                 .rev()
                 .take(3)
-                .map(|(biome, _)| **biome)
+                .map(|(biome, _)| (*biome).clone())
                 .collect(),
             house_count : world.buildings.len(),
         }
@@ -123,7 +123,8 @@ pub async fn give_player_book(editor : &Editor, instruction : &str) -> anyhow::R
             DO NOT USE § codes with section symbols
             DO NOT USE UNICODE ESCAPE CODES
             Instead do formatting using json elements."#, instruction);
-    let book: Book = try_ai_json::<Book>(user).await.expect("Failed to parse AI response");
+    let book: Book = try_ai_json::<Book>(user).await
+        .ok_or_else(|| anyhow::anyhow!("Failed to get or parse AI response for book"))?;
 
     let pages: Vec<String> = book.pages.iter().map(|page| {
             let mut components = page.iter();

--- a/src/http_mod/provider.rs
+++ b/src/http_mod/provider.rs
@@ -11,6 +11,16 @@ use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 
 const PROVIDER_LOG_LIMIT : usize = 300;
 
+/// Try to gunzip bytes. Returns decompressed data on success, or the original bytes if not gzip.
+fn try_gunzip(bytes: &[u8]) -> Vec<u8> {
+    let mut decoder = GzDecoder::new(bytes);
+    let mut buf = vec![];
+    match decoder.read_to_end(&mut buf) {
+        std::result::Result::Ok(_) => buf,
+        Err(_) => bytes.to_vec(),
+    }
+}
+
 
 #[derive(Debug, Clone)]
 pub struct GDMCHTTPProvider {
@@ -159,24 +169,16 @@ impl GDMCHTTPProvider {
             .await?;
 
         let raw_bytes = response.bytes().await?;
-        let mut decoder = GzDecoder::new(&raw_bytes[..]);
-        let mut buf = vec![];
-        decoder.read_to_end(&mut buf)?;
-        debug!("Decompressed {} bytes from chunk data", buf.len());
+        let data = try_gunzip(&raw_bytes);
+        debug!("Chunk data: {} bytes (gzip: {})", data.len(), data.len() != raw_bytes.len());
 
-        if let std::result::Result::Ok(chunks) = fastnbt::from_bytes::<Chunks>(&buf) {
-            debug!("Decompressed NBT value: {:?}", chunks);
+        if let std::result::Result::Ok(chunks) = fastnbt::from_bytes::<Chunks>(&data) {
             return Ok(chunks.chunks);
         }
 
-        let mut decoder = GzDecoder::new(buf.as_slice());
-        let mut buf = vec![];
-        decoder.read_to_end(&mut buf)?;
-        debug!("Decompressed {} bytes from NBT data", buf.len());
-
-        let chunks : Chunks = fastnbt::from_bytes(&buf)?;
-        debug!("Decompressed NBT value: {:?}", chunks);
-
+        // Some responses are double-gzipped
+        let data2 = try_gunzip(&data);
+        let chunks: Chunks = fastnbt::from_bytes(&data2)?;
         Ok(chunks.chunks)
     }
 
@@ -233,20 +235,15 @@ impl GDMCHTTPProvider {
             .await?;
 
         let raw_bytes = response.bytes().await?;
-        let mut decoder = GzDecoder::new(&raw_bytes[..]);
-        let mut buf = vec![];
-        decoder.read_to_end(&mut buf)?;
-        debug!("Decompressed {} bytes from chunk data", buf.len());
+        let data = try_gunzip(&raw_bytes);
 
-        if let std::result::Result::Ok(val) = fastnbt::from_bytes::<NBTStructure>(&buf) {
+        if let std::result::Result::Ok(val) = fastnbt::from_bytes::<NBTStructure>(&data) {
             return Ok(val);
         }
 
-        let mut decoder = GzDecoder::new(buf.as_slice());
-        let mut buf = vec![];
-        decoder.read_to_end(&mut buf)?;
-        
-        if let std::result::Result::Ok(val) = fastnbt::from_bytes::<NBTStructure>(&buf) {
+        // Some responses are double-gzipped
+        let data2 = try_gunzip(&data);
+        if let std::result::Result::Ok(val) = fastnbt::from_bytes::<NBTStructure>(&data2) {
             return Ok(val);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,37 +12,127 @@ pub mod data;
 pub mod config;
 pub mod ai;
 
-#[tokio::main]
-async fn main() {
-    println!("Running placement_in_districts test");
-    dotenv::dotenv().ok();
-    init_logger();
+#[cfg(feature = "visualizer")]
+pub mod visualizer;
 
+#[cfg(feature = "visualizer")]
+async fn run_generation(server: &visualizer::VisualizerServer) {
+    let provider = GDMCHTTPProvider::new();
+    let world = match World::new(&provider).await {
+        Ok(w) => w,
+        Err(e) => {
+            log::error!("Failed to create world: {e}");
+            server.update_error(format!("Failed to create world: {e}"));
+            return;
+        }
+    };
+    let mut editor = world.get_editor();
+    let mut rng = RNG::new(32);
+
+    // === Districts ===
+    server.update_phase(visualizer::GenerationPhase::Districts);
+    generate_districts(rng.next_i64().into(), &mut editor).await;
+    let mut info = SettlementInfo::new(editor.world());
+    let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Districts);
+    server.update_snapshot(snap);
+
+    // === Load data ===
+    let data = LoadedData::load().expect("Failed to load generator data");
+    let materials = Material::load().expect("Failed to load materials");
+    let material = MaterialId::new("spruce_planks".to_string());
+    let mut placer_rng = rng.derive();
+    let mut placer: Placer = Placer::new(&materials, &mut placer_rng);
+    let urban_points = &editor.world().get_urban_points();
+
+    // === Terrain (trees) ===
+    server.update_phase(visualizer::GenerationPhase::Terrain);
+    log_trees(&mut editor, urban_points.clone()).await;
+    let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Terrain);
+    server.update_snapshot(snap);
+
+    // === Buildings ===
+    server.update_phase(visualizer::GenerationPhase::Buildings);
+    place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()], &info).await;
+    info = SettlementInfo::new(editor.world());
+    let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Buildings);
+    server.update_snapshot(snap);
+
+    // === Walls ===
+    server.update_phase(visualizer::GenerationPhase::Walls);
+    build_wall(urban_points, &mut editor, &mut rng.derive(), &mut placer, &material, &data.structures, WallType::Palisade).await;
+    let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Walls);
+    server.update_snapshot(snap);
+
+    // === Flush ===
+    server.update_phase(visualizer::GenerationPhase::Flush);
+    editor.flush_buffer().await;
+
+    // === Chronicle ===
+    server.update_phase(visualizer::GenerationPhase::Chronicle);
+    if let Err(e) = generate_chronicle(&mut editor, &mut info).await {
+        server.log("warn", &format!("Chronicle generation failed: {e}"));
+    }
+
+    // === Done ===
+    let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Done);
+    server.update_snapshot(snap);
+    server.update_phase(visualizer::GenerationPhase::Done);
+}
+
+async fn run_generation_once() {
     let provider = GDMCHTTPProvider::new();
     let world = World::new(&provider).await.unwrap();
     let mut editor = world.get_editor();
-
     let mut rng = RNG::new(32);
 
     generate_districts(rng.next_i64().into(), &mut editor).await;
     let mut info = SettlementInfo::new(editor.world());
 
     let data = LoadedData::load().expect("Failed to load generator data");
-
     let materials = Material::load().expect("Failed to load materials");
     let material = MaterialId::new("spruce_planks".to_string());
-
     let mut placer_rng = rng.derive();
-    let mut placer: Placer = Placer::new(
-        &materials,
-        &mut placer_rng,
-    );
+    let mut placer: Placer = Placer::new(&materials, &mut placer_rng);
     let urban_points = &editor.world().get_urban_points();
-    log_trees(&mut editor, urban_points.clone()).await;
 
+    log_trees(&mut editor, urban_points.clone()).await;
     place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()], &info).await;
     info = SettlementInfo::new(editor.world());
     build_wall(urban_points, &mut editor, &mut rng.derive(), &mut placer, &material, &data.structures, WallType::Palisade).await;
     editor.flush_buffer().await;
     let _ = generate_chronicle(&mut editor, &mut info).await;
+}
+
+#[tokio::main]
+async fn main() {
+    println!("Running placement_in_districts test");
+    dotenv::dotenv().ok();
+    init_logger();
+
+    let use_visualizer = std::env::args().any(|arg| arg == "--visualize");
+
+    #[cfg(feature = "visualizer")]
+    if use_visualizer {
+        let server = visualizer::VisualizerServer::new();
+        server.start().await;
+        server.update_phase(visualizer::GenerationPhase::Idle);
+        println!("Visualizer running at http://localhost:3000");
+        println!("Click 'Generate' in the browser to start generation.");
+
+        loop {
+            server.wait_for_generate().await;
+            println!("Generation requested, starting...");
+            run_generation(&server).await;
+            println!("Generation complete. Waiting for next request...");
+        }
+    }
+
+    #[cfg(not(feature = "visualizer"))]
+    if use_visualizer {
+        eprintln!("Warning: --visualize flag requires the 'visualizer' feature. Rebuild with: cargo build --features visualizer");
+    }
+
+    if !use_visualizer {
+        run_generation_once().await;
+    }
 }

--- a/src/minecraft/biomes/biome.rs
+++ b/src/minecraft/biomes/biome.rs
@@ -1,216 +1,41 @@
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Biome {
-    Unknown, // Placeholder for unknown biomes
-    #[serde(rename = "minecraft:ocean")]
-    Ocean,
-    #[serde(rename = "minecraft:plains")]
-    Plains,
-    #[serde(rename = "minecraft:desert")]
-    Desert,
-    #[serde(rename = "minecraft:mountains")]
-    Mountains,
-    #[serde(rename = "minecraft:forest")]
-    Forest,
-    #[serde(rename = "minecraft:taiga")]
-    Taiga,
-    #[serde(rename = "minecraft:swamp")]
-    Swamp,
-    #[serde(rename = "minecraft:river")]
-    River,
-    #[serde(rename = "minecraft:nether")]
-    Nether,
-    #[serde(rename = "minecraft:the_end")]
-    TheEnd,
-    #[serde(rename = "minecraft:frozen_ocean")]
-    FrozenOcean,
-    #[serde(rename = "minecraft:frozen_river")]
-    FrozenRiver,
-    #[serde(rename = "minecraft:snowy_tundra")]
-    SnowyTundra,
-    #[serde(rename = "minecraft:snowy_mountains")]
-    SnowyMountains,
-    #[serde(rename = "minecraft:mushroom_fields")]
-    MushroomFields,
-    #[serde(rename = "minecraft:mushroom_field_shore")]
-    MushroomFieldShore,
-    #[serde(rename = "minecraft:beach")]
-    Beach,
-    #[serde(rename = "minecraft:desert_hills")]
-    DesertHills,
-    #[serde(rename = "minecraft:wooded_hills")]
-    WoodedHills,
-    #[serde(rename = "minecraft:taiga_hills")]
-    TaigaHills,
-    #[serde(rename = "minecraft:mountain_edge")]
-    MountainEdge,
-    #[serde(rename = "minecraft:jungle")]
-    Jungle,
-    #[serde(rename = "minecraft:jungle_hills")]
-    JungleHills,
-    #[serde(rename = "minecraft:jungle_edge")]
-    JungleEdge,
-    #[serde(rename = "minecraft:deep_ocean")]
-    DeepOcean,
-    #[serde(rename = "minecraft:stone_shore")]
-    StoneShore,
-    #[serde(rename = "minecraft:snowy_beach")]
-    SnowyBeach,
-    #[serde(rename = "minecraft:birch_forest")]
-    BirchForest,
-    #[serde(rename = "minecraft:birch_forest_hills")]
-    BirchForestHills,
-    #[serde(rename = "minecraft:dark_forest")]
-    DarkForest,
-    #[serde(rename = "minecraft:snowy_taiga")]
-    SnowyTaiga,
-    #[serde(rename = "minecraft:snowy_taiga_hills")]
-    SnowyTaigaHills,
-    #[serde(rename = "minecraft:giant_tree_taiga")]
-    GiantTreeTaiga,
-    #[serde(rename = "minecraft:giant_tree_taiga_hills")]
-    GiantTreeTaigaHills,
-    #[serde(rename = "minecraft:wooded_mountains")]
-    WoodedMountains,
-    #[serde(rename = "minecraft:savanna")]
-    Savanna,
-    #[serde(rename = "minecraft:savanna_plateau")]
-    SavannaPlateau,
-    #[serde(rename = "minecraft:badlands")]
-    Badlands,
-    #[serde(rename = "minecraft:wooded_badlands_plateau")]
-    WoodedBadlandsPlateau,
-    #[serde(rename = "minecraft:badlands_plateau")]
-    BadlandsPlateau,
-    #[serde(rename = "minecraft:small_end_islands")]
-    SmallEndIslands,
-    #[serde(rename = "minecraft:end_midlands")]
-    EndMidlands,
-    #[serde(rename = "minecraft:end_highlands")]
-    EndHighlands,
-    #[serde(rename = "minecraft:end_barrens")]
-    EndBarrens,
-    #[serde(rename = "minecraft:warm_ocean")]
-    WarmOcean,
-    #[serde(rename = "minecraft:lukewarm_ocean")]
-    LukewarmOcean,
-    #[serde(rename = "minecraft:cold_ocean")]
-    ColdOcean,
-    #[serde(rename = "minecraft:deep_warm_ocean")]
-    DeepWarmOcean,
-    #[serde(rename = "minecraft:deep_lukewarm_ocean")]
-    DeepLukewarmOcean,
-    #[serde(rename = "minecraft:deep_cold_ocean")]
-    DeepColdOcean,
-    #[serde(rename = "minecraft:deep_frozen_ocean")]
-    DeepFrozenOcean,
-    #[serde(rename = "minecraft:sunflower_plains")]
-    SunflowerPlains,
-    #[serde(rename = "minecraft:desert_lakes")]
-    DesertLakes,
-    #[serde(rename = "minecraft:gravelly_mountains")]
-    GravellyMountains,
-    #[serde(rename = "minecraft:flower_forest")]
-    FlowerForest,
-    #[serde(rename = "minecraft:taiga_mountains")]
-    TaigaMountains,
-    #[serde(rename = "minecraft:swamp_hills")]
-    SwampHills,
-    #[serde(rename = "minecraft:ice_spikes")]
-    IceSpikes,
-    #[serde(rename = "minecraft:modified_jungle")]
-    ModifiedJungle,
-    #[serde(rename = "minecraft:modified_jungle_edge")]
-    ModifiedJungleEdge,
-    #[serde(rename = "minecraft:tall_birch_forest")]
-    TallBirchForest,
-    #[serde(rename = "minecraft:tall_birch_hills")]
-    TallBirchHills,
-    #[serde(rename = "minecraft:dark_forest_hills")]
-    DarkForestHills,
-    #[serde(rename = "minecraft:snowy_taiga_mountains")]
-    SnowyTaigaMountains,
-    #[serde(rename = "minecraft:giant_spruce_taiga")]
-    GiantSpruceTaiga,
-    #[serde(rename = "minecraft:giant_spruce_taiga_hills")]
-    GiantSpruceTaigaHills,
-    #[serde(rename = "minecraft:modified_gravelly_mountains")]
-    ModifiedGravellyMountains,
-    #[serde(rename = "minecraft:shattered_savanna")]
-    ShatteredSavanna,
-    #[serde(rename = "minecraft:shattered_savanna_plateau")]
-    ShatteredSavannaPlateau,
-    #[serde(rename = "minecraft:eroded_badlands")]
-    ErodedBadlands,
-    #[serde(rename = "minecraft:modified_wooded_badlands_plateau")]
-    ModifiedWoodedBadlandsPlateau,
-    #[serde(rename = "minecraft:modified_badlands_plateau")]
-    ModifiedBadlandsPlateau,
-    #[serde(rename = "minecraft:bamboo_jungle")]
-    BambooJungle,
-    #[serde(rename = "minecraft:bamboo_jungle_hills")]
-    BambooJungleHills,
-    #[serde(rename = "minecraft:soul_sand_valley")]
-    SoulSandValley,
-    #[serde(rename = "minecraft:crimson_forest")]
-    CrimsonForest,
-    #[serde(rename = "minecraft:warped_forest")]
-    WarpedForest,
-    #[serde(rename = "minecraft:basalt_deltas")]
-    BasaltDeltas,
-    #[serde(rename = "minecraft:nether_wastes")]
-    NetherWastes,
-    #[serde(rename = "minecraft:dripstone_caves")]
-    DripstoneCaves,
-    #[serde(rename = "minecraft:lush_caves")]
-    LushCaves,
-    #[serde(rename = "minecraft:meadow")]
-    Meadow,
-    #[serde(rename = "minecraft:grove")]
-    Grove,
-    #[serde(rename = "minecraft:snowy_slopes")]
-    SnowySlopes,
-    #[serde(rename = "minecraft:frozen_peaks")]
-    FrozenPeaks,
-    #[serde(rename = "minecraft:jagged_peaks")]
-    JaggedPeaks,
-    #[serde(rename = "minecraft:stony_peaks")]
-    StonyPeaks,
-    #[serde(rename = "minecraft:deep_dark")]
-    DeepDark,
-    #[serde(rename = "minecraft:mangrove_swamp")]
-    MangroveSwamp,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Biome(String);
 
-    // 1.18+ and 1.19+ biomes (Caves & Cliffs, Wild Update, Trails & Tales)
-    #[serde(rename = "minecraft:old_growth_birch_forest")]
-    OldGrowthBirchForest,
-    #[serde(rename = "minecraft:old_growth_pine_taiga")]
-    OldGrowthPineTaiga,
-    #[serde(rename = "minecraft:old_growth_spruce_taiga")]
-    OldGrowthSpruceTaiga,
-    #[serde(rename = "minecraft:sparse_jungle")]
-    SparseJungle,
-    #[serde(rename = "minecraft:stony_shore")]
-    StonyShore,
-    #[serde(rename = "minecraft:windswept_hills")]
-    WindsweptHills,
-    #[serde(rename = "minecraft:windswept_gravelly_hills")]
-    WindsweptGravellyHills,
-    #[serde(rename = "minecraft:windswept_forest")]
-    WindsweptForest,
-    #[serde(rename = "minecraft:windswept_savanna")]
-    WindsweptSavanna,
-    #[serde(rename = "minecraft:snowy_plains")]
-    SnowyPlains,
-    #[serde(rename = "minecraft:snowy_forest")]
-    SnowyForest,
-    #[serde(rename = "minecraft:wooded_badlands")]
-    WoodedBadlands,
+impl Biome {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 
-    // 1.20 (Trails & Tales)
-    #[serde(rename = "minecraft:cherry_grove")]
-    CherryGroveNew, // To avoid duplicate with old name
+    /// Strip "minecraft:" prefix for cleaner matching
+    pub fn name(&self) -> &str {
+        self.0.strip_prefix("minecraft:").unwrap_or(&self.0)
+    }
 
-    // Add more as new biomes are introduced
+    pub fn unknown() -> Self {
+        Biome("Unknown".to_string())
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        self.0 == "Unknown"
+    }
+}
+
+impl From<&str> for Biome {
+    fn from(s: &str) -> Self {
+        Biome(s.to_string())
+    }
+}
+
+impl Default for Biome {
+    fn default() -> Self {
+        Biome::unknown()
+    }
+}
+
+impl std::fmt::Display for Biome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
 }

--- a/src/minecraft/biomes/stone.rs
+++ b/src/minecraft/biomes/stone.rs
@@ -23,11 +23,9 @@ impl BiomeStonetype {
     }
 
     pub fn from_biome(biome: Biome) -> Vec<BiomeStonetype> {
-        use super::Biome::*;
-        match biome {
-            Desert | DesertHills | DesertLakes => vec![BiomeStonetype::Sandstone],
-            Beach => vec![BiomeStonetype::Sandstone],
-            Badlands | ErodedBadlands | WoodedBadlands | Savanna | SavannaPlateau | ShatteredSavanna | ShatteredSavannaPlateau => vec![BiomeStonetype::RedSandstone],
+        match biome.name() {
+            "desert" | "desert_hills" | "desert_lakes" | "beach" => vec![BiomeStonetype::Sandstone],
+            "badlands" | "eroded_badlands" | "wooded_badlands" | "savanna" | "savanna_plateau" | "shattered_savanna" | "shattered_savanna_plateau" => vec![BiomeStonetype::RedSandstone],
             _ => vec![BiomeStonetype::Stone, BiomeStonetype::Deepslate, BiomeStonetype::Blackstone],
         }
     }

--- a/src/minecraft/biomes/wood.rs
+++ b/src/minecraft/biomes/wood.rs
@@ -24,47 +24,42 @@ impl BiomeWoodtype {
             Acacia => "acacia".into(),
             DarkOak => "dark_oak".into(),
             Mangrove => "mangrove".into(),
-            Cherry => "cherry".into(), // 1.20+
+            Cherry => "cherry".into(),
         }
     }
 
     pub fn from_biome(biome: Biome) -> Option<BiomeWoodtype> {
-        use super::Biome::*;
-        match biome {
-            Unknown => None,
+        if biome.is_unknown() { return None; }
+        match biome.name() {
             // Oak: temperate, generic, or mixed forests/plains
-            Plains | Forest | SunflowerPlains | FlowerForest | Meadow | Grove | WindsweptForest | SnowyForest => Some(BiomeWoodtype::Oak),
+            "plains" | "forest" | "sunflower_plains" | "flower_forest" | "meadow" | "grove" | "windswept_forest" | "snowy_forest" => Some(BiomeWoodtype::Oak),
             // Birch: cool, pale, or birch-dominated
-            BirchForest | BirchForestHills | TallBirchForest | TallBirchHills | OldGrowthBirchForest | Desert => Some(BiomeWoodtype::Birch),
+            "birch_forest" | "birch_forest_hills" | "tall_birch_forest" | "tall_birch_hills" | "old_growth_birch_forest" | "desert" | "desert_hills" | "desert_lakes" => Some(BiomeWoodtype::Birch),
             // Spruce: cold, taiga, snowy, or pine/spruce
-            Taiga | TaigaHills | TaigaMountains | SnowyTaiga | SnowyTaigaHills | SnowyTaigaMountains | GiantTreeTaiga | GiantTreeTaigaHills | GiantSpruceTaiga | GiantSpruceTaigaHills | OldGrowthPineTaiga | OldGrowthSpruceTaiga | SnowyTundra | SnowyMountains | SnowyPlains | FrozenPeaks | JaggedPeaks | StonyPeaks | IceSpikes | FrozenRiver | FrozenOcean | SnowyBeach | SnowySlopes => Some(BiomeWoodtype::Spruce),
+            "taiga" | "taiga_hills" | "taiga_mountains" | "snowy_taiga" | "snowy_taiga_hills" | "snowy_taiga_mountains" | "giant_tree_taiga" | "giant_tree_taiga_hills" | "giant_spruce_taiga" | "giant_spruce_taiga_hills" | "old_growth_pine_taiga" | "old_growth_spruce_taiga" | "snowy_tundra" | "snowy_mountains" | "snowy_plains" | "frozen_peaks" | "jagged_peaks" | "stony_peaks" | "ice_spikes" | "frozen_river" | "frozen_ocean" | "snowy_beach" | "snowy_slopes" => Some(BiomeWoodtype::Spruce),
             // Jungle: jungle, bamboo, lush
-            Jungle | JungleHills | JungleEdge | ModifiedJungle | ModifiedJungleEdge | SparseJungle | BambooJungle | BambooJungleHills | LushCaves => Some(BiomeWoodtype::Jungle),
-            // Acacia: savanna, badlands, dry, orange
-            Savanna | SavannaPlateau | ShatteredSavanna | ShatteredSavannaPlateau | Badlands | BadlandsPlateau | WoodedBadlandsPlateau | ModifiedBadlandsPlateau | ModifiedWoodedBadlandsPlateau | ErodedBadlands | WoodedBadlands | WindsweptSavanna => Some(BiomeWoodtype::Acacia),
-            // Dark Oak: dark forest, wooded mountains, wooded hills
-            DarkForest | DarkForestHills | WoodedHills | WoodedMountains | ModifiedGravellyMountains | GravellyMountains | WindsweptHills | WindsweptGravellyHills => Some(BiomeWoodtype::DarkOak),
-            // Mangrove: mangrove swamp
-            MangroveSwamp => Some(BiomeWoodtype::Mangrove),
-            // Cherry: cherry grove (1.20+)
-            CherryGroveNew => Some(BiomeWoodtype::Cherry),
-            // Swamp: oak or mangrove, but vanilla is oak
-            Swamp | SwampHills => Some(BiomeWoodtype::Oak),
-            // River, ocean, beach, stone shore, stony shore: oak (neutral)
-            River | Beach | StoneShore | StonyShore | DeepOcean | Ocean | WarmOcean | LukewarmOcean | ColdOcean | DeepWarmOcean | DeepLukewarmOcean | DeepColdOcean | DeepFrozenOcean | MushroomFields | MushroomFieldShore => Some(BiomeWoodtype::Oak),
-            // Nether: crimson/warped, but not a vanilla wood, so None
-            Nether | SoulSandValley | CrimsonForest | WarpedForest | BasaltDeltas | NetherWastes => None,
+            "jungle" | "jungle_hills" | "jungle_edge" | "modified_jungle" | "modified_jungle_edge" | "sparse_jungle" | "bamboo_jungle" | "bamboo_jungle_hills" | "lush_caves" => Some(BiomeWoodtype::Jungle),
+            // Acacia: savanna, badlands, dry
+            "savanna" | "savanna_plateau" | "shattered_savanna" | "shattered_savanna_plateau" | "badlands" | "badlands_plateau" | "wooded_badlands_plateau" | "modified_badlands_plateau" | "modified_wooded_badlands_plateau" | "eroded_badlands" | "wooded_badlands" | "windswept_savanna" => Some(BiomeWoodtype::Acacia),
+            // Dark Oak: dark forest, wooded mountains
+            "dark_forest" | "dark_forest_hills" | "wooded_hills" | "wooded_mountains" | "modified_gravelly_mountains" | "gravelly_mountains" | "windswept_hills" | "windswept_gravelly_hills" | "mountain_edge" => Some(BiomeWoodtype::DarkOak),
+            // Mangrove
+            "mangrove_swamp" => Some(BiomeWoodtype::Mangrove),
+            // Cherry
+            "cherry_grove" => Some(BiomeWoodtype::Cherry),
+            // Swamp: oak
+            "swamp" | "swamp_hills" => Some(BiomeWoodtype::Oak),
+            // River, ocean, beach, etc: oak (neutral)
+            "river" | "beach" | "stone_shore" | "stony_shore" | "deep_ocean" | "ocean" | "warm_ocean" | "lukewarm_ocean" | "cold_ocean" | "deep_warm_ocean" | "deep_lukewarm_ocean" | "deep_cold_ocean" | "deep_frozen_ocean" | "mushroom_fields" | "mushroom_field_shore" => Some(BiomeWoodtype::Oak),
+            // Nether: no wood
+            "nether" | "soul_sand_valley" | "crimson_forest" | "warped_forest" | "basalt_deltas" | "nether_wastes" => None,
             // The End: no wood
-            TheEnd | SmallEndIslands | EndMidlands | EndHighlands | EndBarrens | DeepDark => None,
+            "the_end" | "small_end_islands" | "end_midlands" | "end_highlands" | "end_barrens" | "deep_dark" => None,
             // Caves: no wood
-            DripstoneCaves => None,
-            // Misc: default to oak if not matched above
-            DesertHills | DesertLakes => Some(BiomeWoodtype::Birch),
-            MountainEdge => Some(BiomeWoodtype::DarkOak),
-            // If not matched, default to oak
+            "dripstone_caves" => None,
+            // Default to oak for any unknown biome
             _ => Some(BiomeWoodtype::Oak),
         }
     }
 
 }
-

--- a/src/minecraft/block_id.rs
+++ b/src/minecraft/block_id.rs
@@ -10,6 +10,10 @@ impl From<&str> for BlockID {
 }
 
 impl BlockID {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
     pub fn is_water(&self) -> bool {
         let id_string = &self.0;
         matches!(

--- a/src/visualizer/api.rs
+++ b/src/visualizer/api.rs
@@ -1,0 +1,207 @@
+use std::sync::{Arc, RwLock};
+
+use axum::{extract::State, Json};
+use axum::http::StatusCode;
+use tokio::sync::broadcast;
+
+use super::types::*;
+
+pub type SharedState = Arc<RwLock<VisualizerState>>;
+
+fn push_log(state: &SharedState, event_tx: &broadcast::Sender<VisualizerEvent>, level: &str, message: &str) {
+    let entry = LogEntry {
+        timestamp: chrono::Utc::now().format("%H:%M:%S").to_string(),
+        level: level.to_string(),
+        message: message.to_string(),
+    };
+    if let Ok(mut s) = state.write() {
+        if s.logs.len() >= 200 {
+            s.logs.remove(0);
+        }
+        s.logs.push(entry.clone());
+    }
+    let _ = event_tx.send(VisualizerEvent::LogMessage(entry));
+}
+
+pub struct VisualizerState {
+    pub phase: GenerationPhase,
+    pub error: Option<String>,
+    pub snapshot: Option<WorldSnapshot>,
+    pub logs: Vec<LogEntry>,
+}
+
+impl VisualizerState {
+    pub fn new() -> Self {
+        Self {
+            phase: GenerationPhase::Idle,
+            error: None,
+            snapshot: None,
+            logs: Vec::new(),
+        }
+    }
+}
+
+pub async fn get_status(
+    State(state): State<SharedState>,
+) -> Result<Json<StatusResponse>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if let Some(ref snap) = state.snapshot {
+        Ok(Json(StatusResponse {
+            phase: state.phase.clone(),
+            width: snap.width,
+            depth: snap.depth,
+            origin_x: snap.origin_x,
+            origin_z: snap.origin_z,
+            error: state.error.clone(),
+        }))
+    } else {
+        Ok(Json(StatusResponse {
+            phase: state.phase.clone(),
+            width: 0,
+            depth: 0,
+            origin_x: 0,
+            origin_z: 0,
+            error: state.error.clone(),
+        }))
+    }
+}
+
+pub async fn get_logs(
+    State(state): State<SharedState>,
+) -> Result<Json<Vec<LogEntry>>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(state.logs.clone()))
+}
+
+pub async fn post_generate(
+    State(state): State<SharedState>,
+    axum::Extension(notify): axum::Extension<Arc<tokio::sync::Notify>>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let phase = {
+        let s = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        s.phase.clone()
+    };
+    match phase {
+        GenerationPhase::Idle | GenerationPhase::Done | GenerationPhase::Error => {
+            notify.notify_one();
+            Ok(Json(serde_json::json!({ "status": "started" })))
+        }
+        _ => Err(StatusCode::CONFLICT),
+    }
+}
+
+pub async fn get_snapshot(
+    State(state): State<SharedState>,
+) -> Result<Json<WorldSnapshot>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match &state.snapshot {
+        Some(snap) => Ok(Json(snap.clone())),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_heightmap(
+    State(state): State<SharedState>,
+) -> Result<Json<HeightmapData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.heightmap.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_biomes(
+    State(state): State<SharedState>,
+) -> Result<Json<BiomeMapData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.biomes.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_blocks(
+    State(state): State<SharedState>,
+) -> Result<Json<BlockMapData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.blocks.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_districts(
+    State(state): State<SharedState>,
+) -> Result<Json<DistrictMapData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.districts.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_buildings(
+    State(state): State<SharedState>,
+) -> Result<Json<BuildingsData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.buildings.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn get_claims(
+    State(state): State<SharedState>,
+) -> Result<Json<ClaimMapData>, StatusCode> {
+    let state = state.read().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match state.snapshot.as_ref().and_then(|s| s.claims.clone()) {
+        Some(data) => Ok(Json(data)),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+pub async fn post_refresh(
+    State(state): State<SharedState>,
+    axum::Extension(event_tx): axum::Extension<broadcast::Sender<VisualizerEvent>>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    push_log(&state, &event_tx, "info", "Refresh: loading world from build area...");
+    {
+        let mut s = state.write().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        s.phase = GenerationPhase::Refreshing;
+        s.error = None;
+    }
+    let _ = event_tx.send(VisualizerEvent::PhaseChanged(GenerationPhase::Refreshing));
+
+    let state_clone = state.clone();
+    let event_tx_clone = event_tx.clone();
+    tokio::spawn(async move {
+        use crate::http_mod::GDMCHTTPProvider;
+        use crate::editor::World;
+        use super::snapshot::extract_full_snapshot;
+
+        let provider = GDMCHTTPProvider::new();
+        match World::new(&provider).await {
+            Ok(world) => {
+                let snap = extract_full_snapshot(&world, &GenerationPhase::Idle);
+                if let Ok(mut s) = state_clone.write() {
+                    s.snapshot = Some(snap);
+                    s.phase = GenerationPhase::Idle;
+                }
+                let _ = event_tx_clone.send(VisualizerEvent::SnapshotUpdated);
+                let _ = event_tx_clone.send(VisualizerEvent::PhaseChanged(GenerationPhase::Idle));
+                push_log(&state_clone, &event_tx_clone, "info", "Refresh: world loaded successfully");
+            }
+            Err(e) => {
+                let msg = format!("Refresh failed: {e}");
+                push_log(&state_clone, &event_tx_clone, "error", &msg);
+                if let Ok(mut s) = state_clone.write() {
+                    s.error = Some(msg);
+                    s.phase = GenerationPhase::Error;
+                }
+                let _ = event_tx_clone.send(VisualizerEvent::PhaseChanged(GenerationPhase::Error));
+            }
+        }
+    });
+
+    Ok(Json(serde_json::json!({ "status": "loading" })))
+}

--- a/src/visualizer/mod.rs
+++ b/src/visualizer/mod.rs
@@ -1,0 +1,8 @@
+pub mod types;
+pub mod snapshot;
+pub mod api;
+pub mod ws;
+pub mod server;
+
+pub use server::VisualizerServer;
+pub use types::GenerationPhase;

--- a/src/visualizer/server.rs
+++ b/src/visualizer/server.rs
@@ -1,0 +1,123 @@
+use std::sync::{Arc, RwLock};
+
+use axum::Router;
+use axum::routing::{get, post};
+use tower_http::cors::{CorsLayer, Any};
+use tower_http::services::ServeDir;
+use tokio::sync::{broadcast, Notify};
+
+use super::api::*;
+use super::ws::{ws_handler, EventSender};
+use super::types::{GenerationPhase, VisualizerEvent};
+
+pub struct VisualizerServer {
+    pub state: SharedState,
+    pub event_tx: EventSender,
+    pub generate_notify: Arc<Notify>,
+}
+
+impl VisualizerServer {
+    pub fn new() -> Self {
+        let state = Arc::new(RwLock::new(VisualizerState::new()));
+        let (event_tx, _) = broadcast::channel::<VisualizerEvent>(64);
+        Self { state, event_tx, generate_notify: Arc::new(Notify::new()) }
+    }
+
+    pub fn log(&self, level: &str, message: &str) {
+        let entry = super::types::LogEntry {
+            timestamp: chrono::Utc::now().format("%H:%M:%S").to_string(),
+            level: level.to_string(),
+            message: message.to_string(),
+        };
+        if let Ok(mut state) = self.state.write() {
+            // Keep last 200 log entries
+            if state.logs.len() >= 200 {
+                state.logs.remove(0);
+            }
+            state.logs.push(entry.clone());
+        }
+        let _ = self.event_tx.send(VisualizerEvent::LogMessage(entry));
+    }
+
+    pub fn update_phase(&self, phase: GenerationPhase) {
+        self.log("info", &format!("Phase: {:?}", phase));
+        if let Ok(mut state) = self.state.write() {
+            state.phase = phase.clone();
+            if phase != GenerationPhase::Error {
+                state.error = None;
+            }
+        }
+        let _ = self.event_tx.send(VisualizerEvent::PhaseChanged(phase));
+    }
+
+    pub fn update_error(&self, message: String) {
+        self.log("error", &message);
+        if let Ok(mut state) = self.state.write() {
+            state.phase = GenerationPhase::Error;
+            state.error = Some(message.clone());
+        }
+        let _ = self.event_tx.send(VisualizerEvent::PhaseChanged(GenerationPhase::Error));
+    }
+
+    pub fn update_snapshot(&self, snapshot: super::types::WorldSnapshot) {
+        if let Ok(mut state) = self.state.write() {
+            state.snapshot = Some(snapshot);
+        }
+        let _ = self.event_tx.send(VisualizerEvent::SnapshotUpdated);
+    }
+
+    pub async fn wait_for_generate(&self) {
+        self.generate_notify.notified().await;
+    }
+
+    pub async fn start(&self) {
+        let state = self.state.clone();
+        let event_tx = self.event_tx.clone();
+        let notify = self.generate_notify.clone();
+
+        let api_routes = Router::new()
+            .route("/api/status", get(get_status))
+            .route("/api/snapshot", get(get_snapshot))
+            .route("/api/heightmap", get(get_heightmap))
+            .route("/api/blocks", get(get_blocks))
+            .route("/api/biomes", get(get_biomes))
+            .route("/api/districts", get(get_districts))
+            .route("/api/buildings", get(get_buildings))
+            .route("/api/claims", get(get_claims))
+            .route("/api/logs", get(get_logs))
+            .route("/api/generate", post(post_generate))
+            .route("/api/refresh", post(post_refresh))
+            .with_state(state)
+            .layer(axum::Extension(notify))
+            .layer(axum::Extension(event_tx.clone()));
+
+        let ws_routes = Router::new()
+            .route("/ws", get(ws_handler))
+            .with_state(event_tx);
+
+        let cors = CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any);
+
+        // Serve the React build from visualizer/dist/ if it exists,
+        // otherwise just serve the API
+        let app = Router::new()
+            .merge(api_routes)
+            .merge(ws_routes)
+            .layer(cors)
+            .fallback_service(ServeDir::new("visualizer/dist"));
+
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
+            .await
+            .expect("Failed to bind visualizer to port 3000");
+
+        log::info!("Visualizer server running at http://localhost:3000");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("Visualizer server failed");
+        });
+    }
+}

--- a/src/visualizer/snapshot.rs
+++ b/src/visualizer/snapshot.rs
@@ -1,0 +1,242 @@
+use crate::editor::World;
+use crate::generator::build_claim::BuildClaim;
+
+use super::types::*;
+
+pub fn extract_status(world: &World, phase: &GenerationPhase) -> StatusResponse {
+    StatusResponse {
+        phase: phase.clone(),
+        width: world.size().x as usize,
+        depth: world.size().z as usize,
+        origin_x: world.origin().x,
+        origin_z: world.origin().z,
+        error: None,
+    }
+}
+
+pub fn extract_heightmap(world: &World) -> HeightmapData {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+    let height_map = world.get_height_map();
+
+    let mut heights = vec![0i32; width * depth];
+    let mut min_height = i32::MAX;
+    let mut max_height = i32::MIN;
+
+    for x in 0..width {
+        for z in 0..depth {
+            let h = height_map[x][z];
+            heights[x * depth + z] = h;
+            if h < min_height {
+                min_height = h;
+            }
+            if h > max_height {
+                max_height = h;
+            }
+        }
+    }
+
+    HeightmapData {
+        width,
+        depth,
+        heights,
+        min_height,
+        max_height,
+    }
+}
+
+pub fn extract_biomes(world: &World) -> BiomeMapData {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+    let biome_map = world.get_ground_biome_map();
+
+    let mut biomes = Vec::with_capacity(width * depth);
+    for x in 0..width {
+        for z in 0..depth {
+            biomes.push(biome_map[x][z].name().to_string());
+        }
+    }
+
+    BiomeMapData {
+        width,
+        depth,
+        biomes,
+    }
+}
+
+pub fn extract_districts(world: &World) -> DistrictMapData {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+
+    let mut districts = vec![-1i32; width * depth];
+    let mut super_districts = vec![-1i32; width * depth];
+    let mut district_types = vec![String::new(); width * depth];
+
+    for x in 0..width {
+        for z in 0..depth {
+            if let Some(did) = world.district_map[x][z] {
+                districts[x * depth + z] = did.0 as i32;
+            }
+            if let Some(sid) = world.super_district_map[x][z] {
+                super_districts[x * depth + z] = sid.0 as i32;
+                if let Some(sd) = world.super_districts.get(&sid) {
+                    district_types[x * depth + z] = format!("{:?}", sd.data.district_type);
+                }
+            }
+        }
+    }
+
+    let mut district_info: Vec<DistrictInfo> = world
+        .districts
+        .values()
+        .map(|d| {
+            let dtype = world
+                .super_district_map
+                .get(d.data.origin.x as usize)
+                .and_then(|row| row.get(d.data.origin.z as usize))
+                .and_then(|sid| sid.as_ref())
+                .and_then(|sid| world.super_districts.get(sid))
+                .map(|sd| format!("{:?}", sd.data.district_type))
+                .unwrap_or_else(|| "Unknown".to_string());
+
+            DistrictInfo {
+                id: d.id.0,
+                district_type: dtype,
+                is_border: d.data.is_border,
+                size: d.data.points_2d.len(),
+                origin_x: d.data.origin.x,
+                origin_z: d.data.origin.z,
+            }
+        })
+        .collect();
+    district_info.sort_by_key(|d| d.id);
+
+    DistrictMapData {
+        width,
+        depth,
+        districts,
+        super_districts,
+        district_types,
+        district_info,
+    }
+}
+
+pub fn extract_buildings(world: &World) -> BuildingsData {
+    let buildings = world
+        .buildings
+        .iter()
+        .map(|b| {
+            let footprint: Vec<[i32; 2]> = b
+                .shape
+                .get_footprint(&b.grid)
+                .into_iter()
+                .map(|p| [p.x, p.y])
+                .collect();
+
+            BuildingInfo {
+                id: b.id.0,
+                origin_x: b.grid.origin.x,
+                origin_y: b.grid.origin.y,
+                origin_z: b.grid.origin.z,
+                footprint,
+            }
+        })
+        .collect();
+
+    BuildingsData { buildings }
+}
+
+pub fn extract_claims(world: &World) -> ClaimMapData {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+    let claim_map = world.get_build_claim_map();
+
+    let mut claims = Vec::with_capacity(width * depth);
+    for x in 0..width {
+        for z in 0..depth {
+            let claim_str = match &claim_map[x][z] {
+                BuildClaim::None => "none",
+                BuildClaim::Nature => "nature",
+                BuildClaim::Wall => "wall",
+                BuildClaim::Gate => "gate",
+                BuildClaim::Path(_) => "path",
+                BuildClaim::Building(_) => "building",
+            };
+            claims.push(claim_str.to_string());
+        }
+    }
+
+    ClaimMapData {
+        width,
+        depth,
+        claims,
+    }
+}
+
+pub fn extract_blocks(world: &World) -> BlockMapData {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+    // height_map: MOTION_BLOCKING — the highest non-air block, including water surfaces
+    // ocean_floor: OCEAN_FLOOR — the highest solid block, ignoring water
+    // When the water surface is above the ocean floor, the cell is submerged.
+    let surface_map = world.get_height_map();
+    let ocean_floor_map = world.get_ocean_floor_height_map();
+
+    let mut blocks = Vec::with_capacity(width * depth);
+    for x in 0..width {
+        for z in 0..depth {
+            let surface_y = surface_map[x][z];
+            let floor_y = ocean_floor_map[x][z];
+            let is_water = surface_y > floor_y;
+
+            if is_water {
+                blocks.push("water".to_string());
+            } else {
+                // Read the block at ground level; if air/plant, try one below
+                let block = world.get_block(crate::geometry::Point3D::new(x as i32, surface_y, z as i32));
+                let block_id = block.as_ref().map(|b| b.id.as_str()).unwrap_or("air");
+
+                // Strip minecraft: prefix for consistent lookup
+                let id = block_id.strip_prefix("minecraft:").unwrap_or(block_id);
+
+                if id == "air" || id == "cave_air" || id.contains("grass") || id.contains("flower")
+                    || id.contains("tulip") || id.contains("daisy") || id.contains("bush")
+                    || id.contains("dandelion") || id.contains("poppy") || id.contains("bluet")
+                    || id.contains("fern") || id.contains("orchid") || id.contains("allium")
+                    || id.contains("cornflower") || id == "dead_bush" || id == "sugar_cane"
+                {
+                    // Non-solid surface block — read one below for the actual ground
+                    let below = world.get_block(crate::geometry::Point3D::new(x as i32, surface_y - 1, z as i32));
+                    blocks.push(below.map(|b| b.id.as_str().to_string()).unwrap_or_else(|| id.to_string()));
+                } else {
+                    blocks.push(block_id.to_string());
+                }
+            }
+        }
+    }
+
+    BlockMapData {
+        width,
+        depth,
+        blocks,
+    }
+}
+
+pub fn extract_full_snapshot(world: &World, phase: &GenerationPhase) -> WorldSnapshot {
+    let width = world.size().x as usize;
+    let depth = world.size().z as usize;
+
+    WorldSnapshot {
+        phase: phase.clone(),
+        width,
+        depth,
+        origin_x: world.origin().x,
+        origin_z: world.origin().z,
+        heightmap: Some(extract_heightmap(world)),
+        blocks: Some(extract_blocks(world)),
+        biomes: Some(extract_biomes(world)),
+        districts: Some(extract_districts(world)),
+        buildings: Some(extract_buildings(world)),
+        claims: Some(extract_claims(world)),
+    }
+}

--- a/src/visualizer/types.rs
+++ b/src/visualizer/types.rs
@@ -1,0 +1,133 @@
+use serde_derive::Serialize;
+
+/// Current generation phase
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationPhase {
+    Idle,
+    Refreshing,
+    Districts,
+    Terrain,
+    Buildings,
+    Walls,
+    Flush,
+    Chronicle,
+    Done,
+    Error,
+}
+
+/// WebSocket event sent to frontend
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "data")]
+#[serde(rename_all = "snake_case")]
+pub enum VisualizerEvent {
+    PhaseChanged(GenerationPhase),
+    SnapshotUpdated,
+    LogMessage(LogEntry),
+}
+
+/// A single log entry
+#[derive(Debug, Clone, Serialize)]
+pub struct LogEntry {
+    pub timestamp: String,
+    pub level: String,
+    pub message: String,
+}
+
+/// Status response for /api/status
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusResponse {
+    pub phase: GenerationPhase,
+    pub width: usize,
+    pub depth: usize,
+    pub origin_x: i32,
+    pub origin_z: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Heightmap data — flat row-major array [x * depth + z]
+#[derive(Debug, Clone, Serialize)]
+pub struct HeightmapData {
+    pub width: usize,
+    pub depth: usize,
+    pub heights: Vec<i32>,
+    pub min_height: i32,
+    pub max_height: i32,
+}
+
+/// Biome map data — flat row-major, biome names as strings
+#[derive(Debug, Clone, Serialize)]
+pub struct BiomeMapData {
+    pub width: usize,
+    pub depth: usize,
+    pub biomes: Vec<String>,
+}
+
+/// District map data — flat row-major, None encoded as -1
+#[derive(Debug, Clone, Serialize)]
+pub struct DistrictMapData {
+    pub width: usize,
+    pub depth: usize,
+    pub districts: Vec<i32>,
+    pub super_districts: Vec<i32>,
+    pub district_types: Vec<String>,
+    pub district_info: Vec<DistrictInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DistrictInfo {
+    pub id: usize,
+    pub district_type: String,
+    pub is_border: bool,
+    pub size: usize,
+    pub origin_x: i32,
+    pub origin_z: i32,
+}
+
+/// Building info for the buildings endpoint
+#[derive(Debug, Clone, Serialize)]
+pub struct BuildingInfo {
+    pub id: usize,
+    pub origin_x: i32,
+    pub origin_y: i32,
+    pub origin_z: i32,
+    pub footprint: Vec<[i32; 2]>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BuildingsData {
+    pub buildings: Vec<BuildingInfo>,
+}
+
+/// Claim map data — flat row-major
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimMapData {
+    pub width: usize,
+    pub depth: usize,
+    pub claims: Vec<String>,
+}
+
+/// Block map data — flat row-major, block IDs as strings
+#[derive(Debug, Clone, Serialize)]
+pub struct BlockMapData {
+    pub width: usize,
+    pub depth: usize,
+    pub blocks: Vec<String>,
+}
+
+/// Full snapshot combining all layer data
+#[derive(Debug, Clone, Serialize)]
+pub struct WorldSnapshot {
+    pub phase: GenerationPhase,
+    pub width: usize,
+    pub depth: usize,
+    pub origin_x: i32,
+    pub origin_z: i32,
+    pub heightmap: Option<HeightmapData>,
+    pub blocks: Option<BlockMapData>,
+    pub biomes: Option<BiomeMapData>,
+    pub districts: Option<DistrictMapData>,
+    pub buildings: Option<BuildingsData>,
+    pub claims: Option<ClaimMapData>,
+}

--- a/src/visualizer/ws.rs
+++ b/src/visualizer/ws.rs
@@ -1,0 +1,43 @@
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::IntoResponse,
+};
+use tokio::sync::broadcast;
+
+use super::types::VisualizerEvent;
+
+pub type EventSender = broadcast::Sender<VisualizerEvent>;
+
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    axum::extract::State(tx): axum::extract::State<EventSender>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, tx))
+}
+
+async fn handle_socket(mut socket: WebSocket, tx: EventSender) {
+    let mut rx = tx.subscribe();
+
+    loop {
+        tokio::select! {
+            result = rx.recv() => {
+                match result {
+                    Ok(event) => {
+                        let json = serde_json::to_string(&event).unwrap_or_default();
+                        if socket.send(Message::Text(json.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    _ => {} // Ignore other messages from client
+                }
+            }
+        }
+    }
+}

--- a/visualizer/.gitignore
+++ b/visualizer/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -1,0 +1,73 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## React Compiler
+
+The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+
+```js
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+
+      // Remove tseslint.configs.recommended and replace with this
+      tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      tseslint.configs.stylisticTypeChecked,
+
+      // Other configs...
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```
+
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+
+```js
+// eslint.config.js
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+      // Enable lint rules for React
+      reactX.configs['recommended-typescript'],
+      // Enable lint rules for React DOM
+      reactDom.configs.recommended,
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```

--- a/visualizer/eslint.config.js
+++ b/visualizer/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>visualizer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/visualizer/package-lock.json
+++ b/visualizer/package-lock.json
@@ -1,0 +1,3298 @@
+{
+  "name": "visualizer",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "visualizer",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "eslint": "^9.39.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.5.0",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.48.0",
+        "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.3",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
+      "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.3",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/visualizer/package.json
+++ b/visualizer/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "globals": "^16.5.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.1"
+  }
+}

--- a/visualizer/src/App.tsx
+++ b/visualizer/src/App.tsx
@@ -1,0 +1,103 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import MapCanvas, { type LayerConfig } from "./components/MapCanvas";
+import LayerPanel from "./components/LayerPanel";
+import InfoPanel from "./components/InfoPanel";
+import StatusBar from "./components/StatusBar";
+import { useViewport } from "./hooks/useViewport";
+import { useMapData } from "./hooks/useMapData";
+import { useWebSocket } from "./hooks/useWebSocket";
+import BiomeLegend from "./components/BiomeLegend";
+import DistrictLegend from "./components/DistrictLegend";
+import LogPanel from "./components/LogPanel";
+import { api } from "./api/client";
+
+const DEFAULT_LAYERS: LayerConfig = {
+  heightmap: { visible: true, opacity: 1.0 },
+  biomes: { visible: false, opacity: 0.8 },
+  districts: { visible: true, opacity: 0.5 },
+  buildings: { visible: true, opacity: 0.8 },
+  claims: { visible: false, opacity: 0.6 },
+};
+
+export default function App() {
+  const [layers, setLayers] = useState<LayerConfig>(DEFAULT_LAYERS);
+  const [hoverPos, setHoverPos] = useState({ x: -1, z: -1 });
+  const { data, fetchAll } = useMapData();
+  const { viewport, onMouseDown, onMouseMove, onMouseUp, onWheel, resetViewport } =
+    useViewport();
+
+  const handleSnapshotUpdated = useCallback(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const { phase, connected, logs, clearLogs } = useWebSocket(handleSnapshotUpdated);
+
+  // Auto-refresh from build area on page load
+  const didAutoRefresh = useRef(false);
+  useEffect(() => {
+    if (!didAutoRefresh.current) {
+      didAutoRefresh.current = true;
+      api.postRefresh();
+    }
+  }, []);
+
+  // Auto-fit viewport when data first loads
+  useEffect(() => {
+    if (data.status && data.status.width > 0) {
+      resetViewport(
+        data.status.depth,
+        data.status.width,
+        window.innerWidth,
+        window.innerHeight,
+      );
+    }
+  }, [data.status?.width, data.status?.depth]);
+
+  const handleGenerate = useCallback(() => {
+    api.postGenerate();
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    await api.postRefresh();
+    fetchAll();
+  }, [fetchAll]);
+
+  const handleHover = useCallback((x: number, z: number) => {
+    setHoverPos({ x, z });
+  }, []);
+
+  return (
+    <div style={{ width: "100vw", height: "100vh", overflow: "hidden", position: "relative" }}>
+      <MapCanvas
+        data={data}
+        viewport={viewport}
+        layers={layers}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onWheel={onWheel}
+        onHover={handleHover}
+      />
+      <StatusBar
+        phase={phase}
+        connected={connected}
+        mapSize={
+          data.status
+            ? { width: data.status.width, depth: data.status.depth }
+            : null
+        }
+        onGenerate={handleGenerate}
+        onRefresh={handleRefresh}
+      />
+      <LayerPanel layers={layers} onChange={setLayers} />
+      <div style={{ position: "absolute", bottom: 10, right: 10, display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end" }}>
+        {layers.biomes.visible && data.biomes && (
+          <BiomeLegend biomes={data.biomes} />
+        )}
+        {layers.districts.visible && <DistrictLegend />}
+      </div>
+      <InfoPanel data={data} hoverX={hoverPos.x} hoverZ={hoverPos.z} />
+      <LogPanel logs={logs} onClear={clearLogs} />
+    </div>
+  );
+}

--- a/visualizer/src/api/client.ts
+++ b/visualizer/src/api/client.ts
@@ -1,0 +1,51 @@
+import type {
+  StatusResponse,
+  HeightmapData,
+  BlockMapData,
+  BiomeMapData,
+  DistrictMapData,
+  BuildingsData,
+  ClaimMapData,
+  WorldSnapshot,
+  LogEntry,
+} from "./types";
+
+const BASE_URL = `${window.location.protocol}//${window.location.hostname}:3000`;
+
+async function fetchJson<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${BASE_URL}${path}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export const api = {
+  getStatus: () => fetchJson<StatusResponse>("/api/status"),
+  getSnapshot: () => fetchJson<WorldSnapshot>("/api/snapshot"),
+  getHeightmap: () => fetchJson<HeightmapData>("/api/heightmap"),
+  getBlocks: () => fetchJson<BlockMapData>("/api/blocks"),
+  getBiomes: () => fetchJson<BiomeMapData>("/api/biomes"),
+  getDistricts: () => fetchJson<DistrictMapData>("/api/districts"),
+  getBuildings: () => fetchJson<BuildingsData>("/api/buildings"),
+  getClaims: () => fetchJson<ClaimMapData>("/api/claims"),
+  getLogs: () => fetchJson<LogEntry[]>("/api/logs"),
+  postGenerate: async (): Promise<boolean> => {
+    try {
+      const res = await fetch(`${BASE_URL}/api/generate`, { method: "POST" });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  },
+  postRefresh: async (): Promise<boolean> => {
+    try {
+      const res = await fetch(`${BASE_URL}/api/refresh`, { method: "POST" });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  },
+};

--- a/visualizer/src/api/types.ts
+++ b/visualizer/src/api/types.ts
@@ -1,0 +1,101 @@
+export type GenerationPhase =
+  | "idle"
+  | "refreshing"
+  | "districts"
+  | "terrain"
+  | "buildings"
+  | "walls"
+  | "flush"
+  | "chronicle"
+  | "done"
+  | "error";
+
+export interface StatusResponse {
+  phase: GenerationPhase;
+  width: number;
+  depth: number;
+  origin_x: number;
+  origin_z: number;
+  error?: string;
+}
+
+export interface HeightmapData {
+  width: number;
+  depth: number;
+  heights: number[];
+  min_height: number;
+  max_height: number;
+}
+
+export interface BlockMapData {
+  width: number;
+  depth: number;
+  blocks: string[];
+}
+
+export interface BiomeMapData {
+  width: number;
+  depth: number;
+  biomes: string[];
+}
+
+export interface DistrictInfo {
+  id: number;
+  district_type: string;
+  is_border: boolean;
+  size: number;
+  origin_x: number;
+  origin_z: number;
+}
+
+export interface DistrictMapData {
+  width: number;
+  depth: number;
+  districts: number[];
+  super_districts: number[];
+  district_types: string[];
+  district_info: DistrictInfo[];
+}
+
+export interface BuildingInfo {
+  id: number;
+  origin_x: number;
+  origin_y: number;
+  origin_z: number;
+  footprint: [number, number][];
+}
+
+export interface BuildingsData {
+  buildings: BuildingInfo[];
+}
+
+export interface ClaimMapData {
+  width: number;
+  depth: number;
+  claims: string[];
+}
+
+export interface WorldSnapshot {
+  phase: GenerationPhase;
+  width: number;
+  depth: number;
+  origin_x: number;
+  origin_z: number;
+  heightmap: HeightmapData | null;
+  blocks: BlockMapData | null;
+  biomes: BiomeMapData | null;
+  districts: DistrictMapData | null;
+  buildings: BuildingsData | null;
+  claims: ClaimMapData | null;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  message: string;
+}
+
+export type VisualizerEvent =
+  | { type: "phase_changed"; data: GenerationPhase }
+  | { type: "snapshot_updated"; data: null }
+  | { type: "log_message"; data: LogEntry };

--- a/visualizer/src/api/websocket.ts
+++ b/visualizer/src/api/websocket.ts
@@ -1,0 +1,43 @@
+import type { VisualizerEvent } from "./types";
+
+export type EventHandler = (event: VisualizerEvent) => void;
+
+export function createWebSocket(onEvent: EventHandler): () => void {
+  const wsUrl = `ws://${window.location.hostname}:3000/ws`;
+  let ws: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+
+  function connect() {
+    if (closed) return;
+    ws = new WebSocket(wsUrl);
+
+    ws.onmessage = (msg) => {
+      try {
+        const event: VisualizerEvent = JSON.parse(msg.data);
+        onEvent(event);
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    ws.onclose = () => {
+      if (!closed) {
+        reconnectTimer = setTimeout(connect, 2000);
+      }
+    };
+
+    ws.onerror = () => {
+      ws?.close();
+    };
+  }
+
+  connect();
+
+  // Return cleanup function
+  return () => {
+    closed = true;
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    ws?.close();
+  };
+}

--- a/visualizer/src/components/BiomeLegend.tsx
+++ b/visualizer/src/components/BiomeLegend.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import type { BiomeMapData } from "../api/types";
+import { biomeToColor } from "../utils/colors";
+
+interface Props {
+  biomes: BiomeMapData;
+}
+
+export default function BiomeLegend({ biomes }: Props) {
+  const entries = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const b of biomes.biomes) {
+      counts[b] = (counts[b] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, count]) => ({
+        name,
+        count,
+        color: biomeToColor(name),
+      }));
+  }, [biomes]);
+
+  return (
+    <div style={panelStyle}>
+      <h3 style={{ margin: "0 0 8px", fontSize: 14 }}>Biomes</h3>
+      <div style={{ maxHeight: 300, overflowY: "auto" }}>
+        {entries.map(({ name, count, color }) => (
+          <div key={name} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+            <span
+              style={{
+                width: 12,
+                height: 12,
+                borderRadius: 2,
+                flexShrink: 0,
+                background: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+                border: "1px solid rgba(255,255,255,0.2)",
+              }}
+            />
+            <span style={{ fontSize: 12, flex: 1 }}>{name}</span>
+            <span style={{ fontSize: 10, color: "#888" }}>{count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  padding: "12px 16px",
+  borderRadius: 8,
+  minWidth: 180,
+  backdropFilter: "blur(8px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+};

--- a/visualizer/src/components/DistrictLegend.tsx
+++ b/visualizer/src/components/DistrictLegend.tsx
@@ -1,0 +1,58 @@
+const TYPE_COLORS: Record<string, [number, number, number]> = {
+  Urban: [220, 180, 60],
+  Rural: [60, 170, 80],
+  OffLimits: [160, 60, 60],
+  Unknown: [128, 128, 128],
+};
+
+const BOUNDARY_ENTRIES = [
+  { label: "Super-district boundary", color: [30, 30, 30] as [number, number, number] },
+];
+
+export default function DistrictLegend() {
+  return (
+    <div style={panelStyle}>
+      <h3 style={{ margin: "0 0 8px", fontSize: 14 }}>Districts</h3>
+      {Object.entries(TYPE_COLORS).map(([name, color]) => (
+        <div key={name} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+          <span
+            style={{
+              width: 12,
+              height: 12,
+              borderRadius: 2,
+              flexShrink: 0,
+              background: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+              border: "1px solid rgba(255,255,255,0.2)",
+            }}
+          />
+          <span style={{ fontSize: 12 }}>{name}</span>
+        </div>
+      ))}
+      <div style={{ borderTop: "1px solid rgba(255,255,255,0.1)", margin: "6px 0" }} />
+      {BOUNDARY_ENTRIES.map(({ label, color }) => (
+        <div key={label} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+          <span
+            style={{
+              width: 12,
+              height: 4,
+              flexShrink: 0,
+              background: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+              borderRadius: 1,
+            }}
+          />
+          <span style={{ fontSize: 12 }}>{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  padding: "12px 16px",
+  borderRadius: 8,
+  minWidth: 180,
+  backdropFilter: "blur(8px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+};

--- a/visualizer/src/components/InfoPanel.tsx
+++ b/visualizer/src/components/InfoPanel.tsx
@@ -1,0 +1,74 @@
+import type { MapData } from "../hooks/useMapData";
+
+interface Props {
+  data: MapData;
+  hoverX: number;
+  hoverZ: number;
+}
+
+export default function InfoPanel({ data, hoverX, hoverZ }: Props) {
+  const width = data.status?.width ?? 0;
+  const depth = data.status?.depth ?? 0;
+
+  if (hoverX < 0 || hoverZ < 0 || hoverX >= width || hoverZ >= depth) {
+    return (
+      <div style={panelStyle}>
+        <span style={{ fontSize: 12, color: "#888" }}>
+          Hover over the map for details
+        </span>
+      </div>
+    );
+  }
+
+  const idx = hoverX * depth + hoverZ;
+  const worldX = hoverX + (data.status?.origin_x ?? 0);
+  const worldZ = hoverZ + (data.status?.origin_z ?? 0);
+
+  const height = data.heightmap?.heights[idx] ?? "?";
+  const biome = data.biomes?.biomes[idx] ?? "?";
+  const district = data.districts?.districts[idx] ?? -1;
+  const districtType = data.districts?.district_types[idx] ?? "";
+  const claim = data.claims?.claims[idx] ?? "?";
+
+  return (
+    <div style={panelStyle}>
+      <div style={{ fontSize: 11, color: "#888", marginBottom: 4 }}>
+        Local: ({hoverX}, {hoverZ}) | World: ({worldX}, {worldZ})
+      </div>
+      <div style={rowStyle}>
+        <span>Height:</span> <span>{height}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>Biome:</span> <span>{biome}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>District:</span>{" "}
+        <span>{district >= 0 ? `#${district} (${districtType})` : "none"}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>Claim:</span> <span>{claim}</span>
+      </div>
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  position: "absolute",
+  bottom: 10,
+  left: 10,
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  padding: "10px 14px",
+  borderRadius: 8,
+  minWidth: 200,
+  backdropFilter: "blur(8px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  fontSize: 13,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: 12,
+  marginBottom: 2,
+};

--- a/visualizer/src/components/LayerPanel.tsx
+++ b/visualizer/src/components/LayerPanel.tsx
@@ -1,0 +1,72 @@
+import type { LayerConfig } from "./MapCanvas";
+
+interface Props {
+  layers: LayerConfig;
+  onChange: (layers: LayerConfig) => void;
+}
+
+const LAYER_NAMES: { key: keyof LayerConfig; label: string }[] = [
+  { key: "heightmap", label: "Heightmap" },
+  { key: "biomes", label: "Biomes" },
+  { key: "districts", label: "Districts" },
+  { key: "buildings", label: "Buildings" },
+  { key: "claims", label: "Claims" },
+];
+
+export default function LayerPanel({ layers, onChange }: Props) {
+  const toggle = (key: keyof LayerConfig) => {
+    onChange({
+      ...layers,
+      [key]: { ...layers[key], visible: !layers[key].visible },
+    });
+  };
+
+  const setOpacity = (key: keyof LayerConfig, opacity: number) => {
+    onChange({
+      ...layers,
+      [key]: { ...layers[key], opacity },
+    });
+  };
+
+  return (
+    <div style={panelStyle}>
+      <h3 style={{ margin: "0 0 8px", fontSize: 14 }}>Layers</h3>
+      {LAYER_NAMES.map(({ key, label }) => (
+        <div key={key} style={{ marginBottom: 8 }}>
+          <label style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={layers[key].visible}
+              onChange={() => toggle(key)}
+            />
+            <span style={{ fontSize: 13, minWidth: 70 }}>{label}</span>
+          </label>
+          {layers[key].visible && (
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={layers[key].opacity}
+              onChange={(e) => setOpacity(key, parseFloat(e.target.value))}
+              style={{ width: "100%", marginTop: 2 }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  position: "absolute",
+  top: 10,
+  right: 10,
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  padding: "12px 16px",
+  borderRadius: 8,
+  minWidth: 160,
+  backdropFilter: "blur(8px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+};

--- a/visualizer/src/components/LogPanel.tsx
+++ b/visualizer/src/components/LogPanel.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from "react";
+import type { LogEntry } from "../api/types";
+
+interface Props {
+  logs: LogEntry[];
+  onClear: () => void;
+}
+
+const LEVEL_COLORS: Record<string, string> = {
+  info: "#8cb4ff",
+  warn: "#ffc107",
+  error: "#f44336",
+  debug: "#888",
+};
+
+export default function LogPanel({ logs, onClear }: Props) {
+  const [open, setOpen] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [logs.length, open]);
+
+  return (
+    <div style={containerStyle}>
+      <button style={toggleStyle} onClick={() => setOpen(!open)}>
+        Logs ({logs.length}) {open ? "\u25BC" : "\u25B2"}
+      </button>
+      {open && (
+        <div style={panelStyle}>
+          <div style={headerStyle}>
+            <span style={{ fontSize: 11, color: "#888" }}>Server Logs</span>
+            <button style={clearStyle} onClick={onClear}>
+              Clear
+            </button>
+          </div>
+          <div style={scrollStyle}>
+            {logs.length === 0 && (
+              <div style={{ color: "#666", fontSize: 11, padding: 8 }}>
+                No logs yet
+              </div>
+            )}
+            {logs.map((entry, i) => (
+              <div key={i} style={entryStyle}>
+                <span style={{ color: "#666", fontSize: 10, marginRight: 6 }}>
+                  {entry.timestamp}
+                </span>
+                <span
+                  style={{
+                    color: LEVEL_COLORS[entry.level] ?? "#ccc",
+                    fontSize: 10,
+                    fontWeight: 600,
+                    marginRight: 6,
+                    textTransform: "uppercase",
+                    minWidth: 36,
+                    display: "inline-block",
+                  }}
+                >
+                  {entry.level}
+                </span>
+                <span style={{ color: "#ddd", fontSize: 11 }}>
+                  {entry.message}
+                </span>
+              </div>
+            ))}
+            <div ref={bottomRef} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  position: "absolute",
+  bottom: 10,
+  left: 10,
+  right: 10,
+  zIndex: 20,
+  pointerEvents: "none",
+};
+
+const toggleStyle: React.CSSProperties = {
+  pointerEvents: "auto",
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "6px 6px 0 0",
+  padding: "4px 12px",
+  fontSize: 11,
+  cursor: "pointer",
+  backdropFilter: "blur(8px)",
+};
+
+const panelStyle: React.CSSProperties = {
+  pointerEvents: "auto",
+  background: "rgba(10, 10, 25, 0.95)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "0 6px 6px 6px",
+  backdropFilter: "blur(8px)",
+  overflow: "hidden",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "4px 8px",
+  borderBottom: "1px solid rgba(255,255,255,0.05)",
+};
+
+const clearStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "#666",
+  fontSize: 10,
+  cursor: "pointer",
+};
+
+const scrollStyle: React.CSSProperties = {
+  maxHeight: 200,
+  overflowY: "auto",
+  fontFamily: "monospace",
+};
+
+const entryStyle: React.CSSProperties = {
+  padding: "2px 8px",
+  borderBottom: "1px solid rgba(255,255,255,0.03)",
+  whiteSpace: "nowrap",
+};

--- a/visualizer/src/components/MapCanvas.tsx
+++ b/visualizer/src/components/MapCanvas.tsx
@@ -1,0 +1,159 @@
+import { useRef, useEffect, useMemo } from "react";
+import type { MapData } from "../hooks/useMapData";
+import type { Viewport } from "../hooks/useViewport";
+import { renderHeightmap } from "../layers/heightmap";
+import { renderBiomes } from "../layers/biomes";
+import { renderDistricts } from "../layers/districts";
+import { renderBuildings } from "../layers/buildings";
+import { renderClaims } from "../layers/claims";
+
+export interface LayerConfig {
+  heightmap: { visible: boolean; opacity: number };
+  biomes: { visible: boolean; opacity: number };
+  districts: { visible: boolean; opacity: number };
+  buildings: { visible: boolean; opacity: number };
+  claims: { visible: boolean; opacity: number };
+}
+
+interface Props {
+  data: MapData;
+  viewport: Viewport;
+  layers: LayerConfig;
+  onMouseDown: (e: React.MouseEvent) => void;
+  onMouseMove: (e: React.MouseEvent) => void;
+  onMouseUp: () => void;
+  onWheel: (e: React.WheelEvent) => void;
+  onHover: (x: number, z: number) => void;
+}
+
+export default function MapCanvas({
+  data,
+  viewport,
+  layers,
+  onMouseDown,
+  onMouseMove,
+  onMouseUp,
+  onWheel,
+  onHover,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Pre-render each layer to offscreen canvases
+  const offscreenLayers = useMemo(() => {
+    const result: Record<string, HTMLCanvasElement> = {};
+    const width = data.status?.width ?? 0;
+    const depth = data.status?.depth ?? 0;
+    if (width === 0 || depth === 0) return result;
+
+    if (data.heightmap) {
+      const c = document.createElement("canvas");
+      c.width = depth;
+      c.height = width;
+      const ctx = c.getContext("2d")!;
+      ctx.putImageData(renderHeightmap(data.heightmap, data.blocks), 0, 0);
+      result.heightmap = c;
+    }
+
+    if (data.biomes) {
+      const c = document.createElement("canvas");
+      c.width = depth;
+      c.height = width;
+      const ctx = c.getContext("2d")!;
+      ctx.putImageData(renderBiomes(data.biomes), 0, 0);
+      result.biomes = c;
+    }
+
+    if (data.districts) {
+      const c = document.createElement("canvas");
+      c.width = depth;
+      c.height = width;
+      const ctx = c.getContext("2d")!;
+      ctx.putImageData(renderDistricts(data.districts), 0, 0);
+      result.districts = c;
+    }
+
+    if (data.buildings) {
+      const c = document.createElement("canvas");
+      c.width = depth;
+      c.height = width;
+      const ctx = c.getContext("2d")!;
+      ctx.putImageData(renderBuildings(data.buildings, width, depth), 0, 0);
+      result.buildings = c;
+    }
+
+    if (data.claims) {
+      const c = document.createElement("canvas");
+      c.width = depth;
+      c.height = width;
+      const ctx = c.getContext("2d")!;
+      ctx.putImageData(renderClaims(data.claims), 0, 0);
+      result.claims = c;
+    }
+
+    return result;
+  }, [data]);
+
+  // Composite visible layers
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    canvas.width = canvas.clientWidth;
+    canvas.height = canvas.clientHeight;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#1a1a2e";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    ctx.translate(viewport.offsetX, viewport.offsetY);
+    ctx.scale(viewport.zoom, viewport.zoom);
+
+    // Draw layers in order
+    const layerOrder: (keyof LayerConfig)[] = [
+      "heightmap",
+      "biomes",
+      "districts",
+      "claims",
+      "buildings",
+    ];
+
+    for (const name of layerOrder) {
+      const cfg = layers[name];
+      if (!cfg.visible || !offscreenLayers[name]) continue;
+      ctx.globalAlpha = cfg.opacity;
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(offscreenLayers[name], 0, 0);
+    }
+
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }, [viewport, layers, offscreenLayers]);
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    onMouseMove(e);
+    // Calculate map coordinates under cursor
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const mapX = Math.floor((mx - viewport.offsetX) / viewport.zoom);
+    const mapZ = Math.floor((my - viewport.offsetY) / viewport.zoom);
+    onHover(mapZ, mapX); // x=row, z=col in our layout
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width: "100%", height: "100%", cursor: "grab" }}
+      onMouseDown={onMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseUp}
+      onWheel={onWheel}
+    />
+  );
+}

--- a/visualizer/src/components/StatusBar.tsx
+++ b/visualizer/src/components/StatusBar.tsx
@@ -1,0 +1,91 @@
+import type { GenerationPhase } from "../api/types";
+
+interface Props {
+  phase: GenerationPhase;
+  connected: boolean;
+  mapSize: { width: number; depth: number } | null;
+  onGenerate: () => void;
+  onRefresh: () => void;
+}
+
+const PHASE_LABELS: Record<GenerationPhase, string> = {
+  idle: "Waiting for generation...",
+  refreshing: "Loading build area...",
+  districts: "Generating districts",
+  terrain: "Processing terrain",
+  buildings: "Placing buildings",
+  walls: "Building walls",
+  flush: "Flushing blocks",
+  chronicle: "Writing chronicle",
+  done: "Generation complete",
+  error: "Generation error",
+};
+
+export default function StatusBar({ phase, connected, mapSize, onGenerate, onRefresh }: Props) {
+  const isActive = !["idle", "done", "error"].includes(phase);
+  const canGenerate = phase === "idle" || phase === "done" || phase === "error";
+
+  return (
+    <div style={barStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: connected ? "#4caf50" : "#f44336",
+            display: "inline-block",
+          }}
+        />
+        <span style={{ fontSize: 13 }}>
+          {PHASE_LABELS[phase]}
+          {isActive && <span style={spinnerStyle}>...</span>}
+        </span>
+      </div>
+      {mapSize && (
+        <span style={{ fontSize: 11, color: "#888" }}>
+          {mapSize.width} x {mapSize.depth}
+        </span>
+      )}
+      <div style={{ display: "flex", gap: 6 }}>
+        {canGenerate && (
+          <button style={buttonStyle} onClick={onGenerate}>
+            Generate
+          </button>
+        )}
+        <button style={buttonStyle} onClick={onRefresh}>
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const barStyle: React.CSSProperties = {
+  position: "absolute",
+  top: 10,
+  left: 10,
+  background: "rgba(20, 20, 40, 0.9)",
+  color: "#eee",
+  padding: "8px 14px",
+  borderRadius: 8,
+  display: "flex",
+  alignItems: "center",
+  gap: 16,
+  backdropFilter: "blur(8px)",
+  border: "1px solid rgba(255,255,255,0.1)",
+};
+
+const buttonStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.1)",
+  color: "#eee",
+  border: "1px solid rgba(255, 255, 255, 0.2)",
+  borderRadius: 4,
+  padding: "4px 10px",
+  fontSize: 12,
+  cursor: "pointer",
+};
+
+const spinnerStyle: React.CSSProperties = {
+  animation: "pulse 1.5s infinite",
+};

--- a/visualizer/src/hooks/useMapData.ts
+++ b/visualizer/src/hooks/useMapData.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+import { api } from "../api/client";
+import type {
+  HeightmapData,
+  BlockMapData,
+  BiomeMapData,
+  DistrictMapData,
+  BuildingsData,
+  ClaimMapData,
+  StatusResponse,
+} from "../api/types";
+
+export interface MapData {
+  status: StatusResponse | null;
+  heightmap: HeightmapData | null;
+  blocks: BlockMapData | null;
+  biomes: BiomeMapData | null;
+  districts: DistrictMapData | null;
+  buildings: BuildingsData | null;
+  claims: ClaimMapData | null;
+}
+
+export function useMapData() {
+  const [data, setData] = useState<MapData>({
+    status: null,
+    heightmap: null,
+    blocks: null,
+    biomes: null,
+    districts: null,
+    buildings: null,
+    claims: null,
+  });
+  const [loading, setLoading] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    const [status, heightmap, blocks, biomes, districts, buildings, claims] =
+      await Promise.all([
+        api.getStatus(),
+        api.getHeightmap(),
+        api.getBlocks(),
+        api.getBiomes(),
+        api.getDistricts(),
+        api.getBuildings(),
+        api.getClaims(),
+      ]);
+    setData({ status, heightmap, blocks, biomes, districts, buildings, claims });
+    setLoading(false);
+  }, []);
+
+  return { data, loading, fetchAll };
+}

--- a/visualizer/src/hooks/useViewport.ts
+++ b/visualizer/src/hooks/useViewport.ts
@@ -1,0 +1,76 @@
+import { useState, useCallback, useRef } from "react";
+
+export interface Viewport {
+  offsetX: number;
+  offsetY: number;
+  zoom: number;
+}
+
+export function useViewport() {
+  const [viewport, setViewport] = useState<Viewport>({
+    offsetX: 0,
+    offsetY: 0,
+    zoom: 1,
+  });
+
+  const dragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    dragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    setViewport((v) => ({
+      ...v,
+      offsetX: v.offsetX + dx,
+      offsetY: v.offsetY + dy,
+    }));
+  }, []);
+
+  const onMouseUp = useCallback(() => {
+    dragging.current = false;
+  }, []);
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const scaleBy = e.deltaY > 0 ? 0.9 : 1.1;
+    setViewport((v) => {
+      const newZoom = Math.max(0.1, Math.min(50, v.zoom * scaleBy));
+      // Zoom toward mouse position
+      const rect = (e.target as HTMLElement).getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+      return {
+        zoom: newZoom,
+        offsetX: mouseX - ((mouseX - v.offsetX) / v.zoom) * newZoom,
+        offsetY: mouseY - ((mouseY - v.offsetY) / v.zoom) * newZoom,
+      };
+    });
+  }, []);
+
+  const resetViewport = useCallback((width: number, height: number, canvasW: number, canvasH: number) => {
+    const scaleX = canvasW / width;
+    const scaleY = canvasH / height;
+    const zoom = Math.min(scaleX, scaleY) * 0.9;
+    setViewport({
+      offsetX: (canvasW - width * zoom) / 2,
+      offsetY: (canvasH - height * zoom) / 2,
+      zoom,
+    });
+  }, []);
+
+  return {
+    viewport,
+    onMouseDown,
+    onMouseMove,
+    onMouseUp,
+    onWheel,
+    resetViewport,
+  };
+}

--- a/visualizer/src/hooks/useWebSocket.ts
+++ b/visualizer/src/hooks/useWebSocket.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { createWebSocket } from "../api/websocket";
+import type { GenerationPhase, LogEntry } from "../api/types";
+import { api } from "../api/client";
+
+export function useWebSocket(onSnapshotUpdated: () => void) {
+  const [phase, setPhase] = useState<GenerationPhase>("idle");
+  const [connected, setConnected] = useState(false);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  // Fetch existing logs on mount
+  useEffect(() => {
+    api.getLogs().then((existing) => {
+      if (existing) setLogs(existing);
+    });
+  }, []);
+
+  useEffect(() => {
+    const cleanup = createWebSocket((event) => {
+      setConnected(true);
+      if (event.type === "phase_changed") {
+        setPhase(event.data);
+      } else if (event.type === "snapshot_updated") {
+        onSnapshotUpdated();
+      } else if (event.type === "log_message") {
+        setLogs((prev) => {
+          const next = [...prev, event.data];
+          return next.length > 200 ? next.slice(-200) : next;
+        });
+      }
+    });
+    cleanupRef.current = cleanup;
+
+    return () => {
+      cleanup();
+      cleanupRef.current = null;
+    };
+  }, [onSnapshotUpdated]);
+
+  const clearLogs = useCallback(() => setLogs([]), []);
+
+  return { phase, connected, logs, clearLogs };
+}

--- a/visualizer/src/index.css
+++ b/visualizer/src/index.css
@@ -1,0 +1,16 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #1a1a2e;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  overflow: hidden;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}

--- a/visualizer/src/layers/biomes.ts
+++ b/visualizer/src/layers/biomes.ts
@@ -1,0 +1,21 @@
+import type { BiomeMapData } from "../api/types";
+import { biomeToColor } from "../utils/colors";
+
+export function renderBiomes(data: BiomeMapData): ImageData {
+  const { width, depth, biomes } = data;
+  const imageData = new ImageData(depth, width);
+
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      const [r, g, b] = biomeToColor(biomes[idx]);
+      const pixelIdx = idx * 4;
+      imageData.data[pixelIdx] = r;
+      imageData.data[pixelIdx + 1] = g;
+      imageData.data[pixelIdx + 2] = b;
+      imageData.data[pixelIdx + 3] = 255;
+    }
+  }
+
+  return imageData;
+}

--- a/visualizer/src/layers/buildings.ts
+++ b/visualizer/src/layers/buildings.ts
@@ -1,0 +1,29 @@
+import type { BuildingsData } from "../api/types";
+
+export function renderBuildings(
+  data: BuildingsData,
+  width: number,
+  depth: number,
+): ImageData {
+  const imageData = new ImageData(depth, width);
+
+  for (const building of data.buildings) {
+    // Use a unique color per building based on ID
+    const hue = (building.id * 137.508) % 360;
+    const r = Math.round(180 + 75 * Math.cos((hue * Math.PI) / 180));
+    const g = Math.round(180 + 75 * Math.cos(((hue - 120) * Math.PI) / 180));
+    const b = Math.round(180 + 75 * Math.cos(((hue + 120) * Math.PI) / 180));
+
+    for (const [fx, fz] of building.footprint) {
+      if (fx >= 0 && fx < width && fz >= 0 && fz < depth) {
+        const pixelIdx = (fx * depth + fz) * 4;
+        imageData.data[pixelIdx] = r;
+        imageData.data[pixelIdx + 1] = g;
+        imageData.data[pixelIdx + 2] = b;
+        imageData.data[pixelIdx + 3] = 200;
+      }
+    }
+  }
+
+  return imageData;
+}

--- a/visualizer/src/layers/claims.ts
+++ b/visualizer/src/layers/claims.ts
@@ -1,0 +1,22 @@
+import type { ClaimMapData } from "../api/types";
+import { CLAIM_COLORS } from "../utils/colors";
+
+export function renderClaims(data: ClaimMapData): ImageData {
+  const { width, depth, claims } = data;
+  const imageData = new ImageData(depth, width);
+
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      const claim = claims[idx];
+      const color = CLAIM_COLORS[claim] ?? [0, 0, 0, 0];
+      const pixelIdx = idx * 4;
+      imageData.data[pixelIdx] = color[0];
+      imageData.data[pixelIdx + 1] = color[1];
+      imageData.data[pixelIdx + 2] = color[2];
+      imageData.data[pixelIdx + 3] = color[3];
+    }
+  }
+
+  return imageData;
+}

--- a/visualizer/src/layers/districts.ts
+++ b/visualizer/src/layers/districts.ts
@@ -1,0 +1,126 @@
+import type { DistrictMapData } from "../api/types";
+
+const TYPE_COLORS: Record<string, [number, number, number]> = {
+  Urban: [220, 180, 60],
+  Rural: [60, 170, 80],
+  OffLimits: [160, 60, 60],
+  Unknown: [128, 128, 128],
+};
+
+function typeColor(dtype: string): [number, number, number] {
+  return TYPE_COLORS[dtype] ?? TYPE_COLORS.Unknown;
+}
+
+export function renderDistricts(data: DistrictMapData): ImageData {
+  const { width, depth, districts, super_districts, district_types } = data;
+  const imageData = new ImageData(depth, width);
+
+  // Precompute boundary info
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      const did = districts[idx];
+      const sid = super_districts[idx];
+      const dtype = district_types[idx];
+      const [r, g, b] = typeColor(dtype);
+      const pixelIdx = idx * 4;
+
+      if (did < 0) {
+        imageData.data[pixelIdx + 3] = 0;
+        continue;
+      }
+
+      // Base fill color from district type
+      imageData.data[pixelIdx] = r;
+      imageData.data[pixelIdx + 1] = g;
+      imageData.data[pixelIdx + 2] = b;
+      imageData.data[pixelIdx + 3] = 120;
+
+      // Check neighbors for boundaries
+      const neighbors: [number, number][] = [
+        [x - 1, z], [x + 1, z], [x, z - 1], [x, z + 1],
+      ];
+
+      let isSuperEdge = false;
+      let isDistrictEdge = false;
+
+      for (const [nx, nz] of neighbors) {
+        if (nx < 0 || nx >= width || nz < 0 || nz >= depth) {
+          isSuperEdge = true;
+          continue;
+        }
+        const nIdx = nx * depth + nz;
+        const nSid = super_districts[nIdx];
+        const nDid = districts[nIdx];
+
+        if (nSid !== sid) {
+          isSuperEdge = true;
+        } else if (nDid !== did) {
+          isDistrictEdge = true;
+        }
+      }
+
+      if (isSuperEdge) {
+        // Thick super-district boundary — also check diagonal neighbors for thicker lines
+        imageData.data[pixelIdx] = 30;
+        imageData.data[pixelIdx + 1] = 30;
+        imageData.data[pixelIdx + 2] = 30;
+        imageData.data[pixelIdx + 3] = 230;
+      } else if (isDistrictEdge) {
+        // Thin district boundary — darken the type color
+        imageData.data[pixelIdx] = Math.round(r * 0.4);
+        imageData.data[pixelIdx + 1] = Math.round(g * 0.4);
+        imageData.data[pixelIdx + 2] = Math.round(b * 0.4);
+        imageData.data[pixelIdx + 3] = 180;
+      }
+    }
+  }
+
+  // Second pass: thicken super-district boundaries by marking pixels adjacent to them
+  const superEdge = new Uint8Array(width * depth);
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      const sid = super_districts[idx];
+      const neighbors: [number, number][] = [
+        [x - 1, z], [x + 1, z], [x, z - 1], [x, z + 1],
+      ];
+      for (const [nx, nz] of neighbors) {
+        if (nx < 0 || nx >= width || nz < 0 || nz >= depth) {
+          superEdge[idx] = 1;
+          break;
+        }
+        if (super_districts[nx * depth + nz] !== sid) {
+          superEdge[idx] = 1;
+          break;
+        }
+      }
+    }
+  }
+
+  // Dilate super-district edges by 1 pixel for thickness
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      if (superEdge[idx]) continue;
+      if (districts[idx] < 0) continue;
+
+      const neighbors: [number, number][] = [
+        [x - 1, z], [x + 1, z], [x, z - 1], [x, z + 1],
+      ];
+      for (const [nx, nz] of neighbors) {
+        if (nx < 0 || nx >= width || nz < 0 || nz >= depth) continue;
+        if (superEdge[nx * depth + nz]) {
+          const pixelIdx = idx * 4;
+          imageData.data[pixelIdx] = 30;
+          imageData.data[pixelIdx + 1] = 30;
+          imageData.data[pixelIdx + 2] = 30;
+          imageData.data[pixelIdx + 3] = 200;
+          break;
+        }
+      }
+    }
+  }
+
+  return imageData;
+}

--- a/visualizer/src/layers/heightmap.ts
+++ b/visualizer/src/layers/heightmap.ts
@@ -1,0 +1,33 @@
+import type { HeightmapData, BlockMapData } from "../api/types";
+import { blockToColor } from "../utils/colors";
+
+export function renderHeightmap(
+  data: HeightmapData,
+  blocks: BlockMapData | null,
+): ImageData {
+  const { width, depth, heights, min_height, max_height } = data;
+  const imageData = new ImageData(depth, width);
+  const range = max_height - min_height || 1;
+
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      const idx = x * depth + z;
+      const normalized = (heights[idx] - min_height) / range;
+
+      // Block color as base, height as brightness modifier
+      const blockId = blocks?.blocks[idx] ?? "";
+      const [br, bg, bb] = blockToColor(blockId);
+
+      // Shade: map normalized height to a brightness multiplier (0.5 – 1.2)
+      const shade = 0.5 + normalized * 0.7;
+
+      const pixelIdx = idx * 4;
+      imageData.data[pixelIdx] = Math.min(255, Math.round(br * shade));
+      imageData.data[pixelIdx + 1] = Math.min(255, Math.round(bg * shade));
+      imageData.data[pixelIdx + 2] = Math.min(255, Math.round(bb * shade));
+      imageData.data[pixelIdx + 3] = 255;
+    }
+  }
+
+  return imageData;
+}

--- a/visualizer/src/main.tsx
+++ b/visualizer/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/visualizer/src/utils/colors.ts
+++ b/visualizer/src/utils/colors.ts
@@ -1,0 +1,339 @@
+/** Interpolate between two RGB colors. t in [0, 1] */
+function lerpColor(
+  a: [number, number, number],
+  b: [number, number, number],
+  t: number,
+): [number, number, number] {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+/** Height gradient: deep water (blue) -> shore (sand) -> grass (green) -> mountain (brown) -> snow (white) */
+const HEIGHT_STOPS: { t: number; color: [number, number, number] }[] = [
+  { t: 0.0, color: [30, 60, 150] },   // deep water
+  { t: 0.2, color: [60, 120, 200] },   // shallow water
+  { t: 0.3, color: [194, 178, 128] },  // sand/shore
+  { t: 0.4, color: [34, 139, 34] },    // grass
+  { t: 0.6, color: [0, 100, 0] },      // forest green
+  { t: 0.8, color: [139, 90, 43] },    // mountain brown
+  { t: 1.0, color: [255, 255, 255] },  // snow
+];
+
+export function heightToColor(normalizedHeight: number): [number, number, number] {
+  const t = Math.max(0, Math.min(1, normalizedHeight));
+  for (let i = 1; i < HEIGHT_STOPS.length; i++) {
+    if (t <= HEIGHT_STOPS[i].t) {
+      const segT =
+        (t - HEIGHT_STOPS[i - 1].t) /
+        (HEIGHT_STOPS[i].t - HEIGHT_STOPS[i - 1].t);
+      return lerpColor(HEIGHT_STOPS[i - 1].color, HEIGHT_STOPS[i].color, segT);
+    }
+  }
+  return HEIGHT_STOPS[HEIGHT_STOPS.length - 1].color;
+}
+
+/** Golden-angle hue distribution for district coloring */
+export function districtColor(id: number): [number, number, number] {
+  const hue = (id * 137.508) % 360;
+  return hslToRgb(hue, 0.6, 0.55);
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) { r = c; g = x; }
+  else if (h < 120) { r = x; g = c; }
+  else if (h < 180) { g = c; b = x; }
+  else if (h < 240) { g = x; b = c; }
+  else if (h < 300) { r = x; b = c; }
+  else { r = c; b = x; }
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+}
+
+/** Biome color map — keys are snake_case names (without minecraft: prefix) */
+const BIOME_COLORS: Record<string, [number, number, number]> = {
+  // Oceans
+  ocean: [30, 60, 180],
+  deep_ocean: [20, 40, 140],
+  warm_ocean: [50, 100, 200],
+  lukewarm_ocean: [40, 80, 190],
+  cold_ocean: [25, 50, 160],
+  frozen_ocean: [140, 170, 220],
+  deep_warm_ocean: [40, 80, 170],
+  deep_lukewarm_ocean: [30, 60, 160],
+  deep_cold_ocean: [15, 35, 130],
+  deep_frozen_ocean: [120, 150, 200],
+  // Rivers & shores
+  river: [50, 90, 210],
+  frozen_river: [140, 180, 230],
+  beach: [220, 210, 160],
+  snowy_beach: [230, 225, 220],
+  stone_shore: [140, 140, 140],
+  stony_shore: [140, 140, 140],
+  // Plains
+  plains: [100, 180, 60],
+  sunflower_plains: [120, 190, 50],
+  snowy_plains: [220, 230, 240],
+  snowy_tundra: [220, 230, 240],
+  // Forests
+  forest: [30, 120, 30],
+  flower_forest: [80, 150, 60],
+  birch_forest: [60, 150, 60],
+  birch_forest_hills: [55, 145, 55],
+  tall_birch_forest: [55, 145, 55],
+  tall_birch_hills: [50, 140, 50],
+  dark_forest: [20, 80, 20],
+  dark_forest_hills: [25, 85, 25],
+  old_growth_birch_forest: [55, 145, 55],
+  snowy_forest: [180, 200, 210],
+  // Taiga
+  taiga: [40, 100, 50],
+  taiga_hills: [35, 95, 45],
+  taiga_mountains: [30, 90, 40],
+  snowy_taiga: [50, 110, 70],
+  snowy_taiga_hills: [45, 105, 65],
+  snowy_taiga_mountains: [40, 100, 60],
+  giant_tree_taiga: [35, 90, 45],
+  giant_tree_taiga_hills: [30, 85, 40],
+  giant_spruce_taiga: [30, 85, 40],
+  giant_spruce_taiga_hills: [25, 80, 35],
+  old_growth_pine_taiga: [35, 90, 45],
+  old_growth_spruce_taiga: [30, 85, 40],
+  // Jungle
+  jungle: [50, 150, 20],
+  jungle_hills: [45, 140, 18],
+  jungle_edge: [55, 145, 25],
+  modified_jungle: [48, 148, 22],
+  modified_jungle_edge: [52, 142, 24],
+  sparse_jungle: [60, 140, 30],
+  bamboo_jungle: [70, 160, 30],
+  bamboo_jungle_hills: [65, 155, 28],
+  // Desert
+  desert: [220, 200, 130],
+  desert_hills: [210, 190, 120],
+  desert_lakes: [200, 185, 125],
+  // Badlands
+  badlands: [200, 120, 50],
+  badlands_plateau: [195, 115, 48],
+  wooded_badlands: [180, 110, 40],
+  wooded_badlands_plateau: [180, 110, 40],
+  eroded_badlands: [190, 110, 45],
+  modified_badlands_plateau: [192, 118, 48],
+  modified_wooded_badlands_plateau: [178, 108, 42],
+  // Savanna
+  savanna: [170, 180, 60],
+  savanna_plateau: [160, 170, 55],
+  windswept_savanna: [155, 165, 50],
+  shattered_savanna: [155, 165, 50],
+  shattered_savanna_plateau: [150, 160, 48],
+  // Swamp
+  swamp: [50, 80, 40],
+  swamp_hills: [45, 75, 38],
+  mangrove_swamp: [40, 70, 35],
+  // Mountains & hills
+  mountains: [130, 130, 130],
+  snowy_mountains: [210, 220, 230],
+  wooded_mountains: [80, 110, 70],
+  wooded_hills: [40, 110, 40],
+  mountain_edge: [120, 125, 120],
+  gravelly_mountains: [110, 110, 110],
+  modified_gravelly_mountains: [105, 105, 105],
+  windswept_hills: [130, 130, 130],
+  windswept_forest: [80, 110, 70],
+  windswept_gravelly_hills: [110, 110, 110],
+  // Meadow & peaks
+  meadow: [100, 190, 80],
+  grove: [60, 130, 80],
+  snowy_slopes: [200, 210, 220],
+  frozen_peaks: [180, 200, 230],
+  jagged_peaks: [170, 170, 190],
+  stony_peaks: [150, 150, 160],
+  // Special
+  cherry_grove: [200, 140, 170],
+  pale_garden: [190, 185, 175],
+  dripstone_caves: [120, 100, 80],
+  lush_caves: [50, 130, 50],
+  deep_dark: [15, 15, 25],
+  mushroom_fields: [160, 100, 160],
+  mushroom_field_shore: [155, 95, 155],
+  ice_spikes: [160, 200, 230],
+  // Nether
+  nether_wastes: [97, 38, 38],
+  soul_sand_valley: [81, 62, 50],
+  crimson_forest: [130, 20, 30],
+  warped_forest: [20, 100, 100],
+  basalt_deltas: [70, 70, 75],
+  // End
+  the_end: [60, 50, 80],
+  small_end_islands: [55, 45, 75],
+  end_midlands: [65, 55, 85],
+  end_highlands: [70, 60, 90],
+  end_barrens: [50, 40, 70],
+};
+
+export function biomeToColor(biome: string): [number, number, number] {
+  return BIOME_COLORS[biome] ?? [128, 128, 128];
+}
+
+/** Minecraft block color map — surface blocks only */
+const BLOCK_COLORS: Record<string, [number, number, number]> = {
+  // Air — typically above grass, use grass color as fallback
+  air: [90, 150, 60],
+  cave_air: [90, 150, 60],
+  void_air: [20, 20, 20],
+
+  // Grass & dirt
+  grass_block: [90, 150, 60],
+  dirt: [134, 96, 67],
+  coarse_dirt: [119, 85, 59],
+  rooted_dirt: [115, 82, 56],
+  podzol: [91, 63, 24],
+  mycelium: [111, 99, 107],
+  mud: [60, 52, 45],
+  farmland: [110, 78, 50],
+  dirt_path: [148, 121, 65],
+
+  // Sand & gravel
+  sand: [219, 207, 163],
+  red_sand: [190, 102, 33],
+  gravel: [131, 127, 126],
+  clay: [160, 166, 179],
+  soul_sand: [81, 62, 50],
+  soul_soil: [75, 57, 46],
+
+  // Stone types
+  stone: [125, 125, 125],
+  cobblestone: [120, 120, 120],
+  deepslate: [80, 80, 82],
+  granite: [149, 103, 85],
+  diorite: [188, 182, 183],
+  andesite: [136, 136, 136],
+  tuff: [108, 109, 102],
+  calcite: [223, 224, 220],
+  dripstone_block: [134, 107, 92],
+  smooth_basalt: [72, 72, 78],
+  basalt: [80, 80, 84],
+
+  // Water & ice
+  water: [55, 100, 190],
+  flowing_water: [55, 100, 190],
+  ice: [145, 183, 255],
+  packed_ice: [130, 170, 248],
+  blue_ice: [100, 150, 240],
+  frosted_ice: [155, 193, 255],
+
+  // Snow
+  snow: [240, 250, 255],
+  snow_block: [240, 250, 255],
+  powder_snow: [230, 240, 248],
+
+  // Wood (logs)
+  oak_log: [109, 85, 51],
+  spruce_log: [58, 37, 16],
+  birch_log: [216, 210, 193],
+  jungle_log: [85, 67, 25],
+  acacia_log: [103, 96, 86],
+  dark_oak_log: [60, 46, 26],
+  cherry_log: [53, 26, 33],
+  mangrove_log: [84, 56, 30],
+
+  // Leaves
+  oak_leaves: [53, 120, 25],
+  spruce_leaves: [40, 80, 40],
+  birch_leaves: [70, 130, 50],
+  jungle_leaves: [45, 130, 15],
+  acacia_leaves: [60, 120, 30],
+  dark_oak_leaves: [35, 90, 20],
+  cherry_leaves: [220, 160, 180],
+  mangrove_leaves: [50, 110, 30],
+  azalea_leaves: [60, 120, 35],
+  flowering_azalea_leaves: [75, 115, 45],
+
+  // Plants & flowers
+  short_grass: [85, 145, 55],
+  tall_grass: [80, 140, 50],
+  fern: [70, 130, 45],
+  large_fern: [65, 125, 40],
+  dead_bush: [120, 90, 45],
+  seagrass: [30, 90, 50],
+  tall_seagrass: [25, 85, 45],
+  kelp: [50, 110, 55],
+  kelp_plant: [45, 105, 50],
+  lily_pad: [30, 100, 30],
+  moss_block: [80, 120, 40],
+  moss_carpet: [80, 120, 40],
+
+  // Flowers — show as grass-ish, they sit on grass
+  dandelion: [95, 155, 60],
+  poppy: [95, 145, 55],
+  blue_orchid: [85, 150, 65],
+  allium: [90, 145, 60],
+  azure_bluet: [90, 150, 60],
+  red_tulip: [90, 148, 58],
+  orange_tulip: [90, 148, 58],
+  white_tulip: [90, 148, 58],
+  pink_tulip: [90, 148, 58],
+  oxeye_daisy: [92, 152, 60],
+  cornflower: [88, 148, 62],
+  lily_of_the_valley: [90, 150, 60],
+  sunflower: [95, 155, 60],
+  lilac: [90, 150, 60],
+  rose_bush: [90, 145, 55],
+  peony: [90, 150, 60],
+  bush: [55, 120, 35],
+  firefly_bush: [60, 125, 40],
+
+  // Terracotta
+  terracotta: [152, 94, 67],
+  red_terracotta: [143, 61, 46],
+  orange_terracotta: [161, 83, 37],
+  yellow_terracotta: [186, 133, 35],
+  brown_terracotta: [77, 51, 35],
+  white_terracotta: [209, 178, 161],
+  light_gray_terracotta: [135, 106, 97],
+
+  // Ores & special
+  coal_ore: [105, 105, 105],
+  iron_ore: [136, 129, 122],
+  copper_ore: [124, 125, 120],
+  gold_ore: [145, 133, 106],
+  lapis_ore: [100, 110, 140],
+
+  // Misc
+  obsidian: [15, 10, 24],
+  crying_obsidian: [30, 10, 50],
+  bedrock: [85, 85, 85],
+  netherrack: [97, 38, 38],
+  end_stone: [219, 222, 158],
+  magma_block: [140, 60, 20],
+  lava: [207, 92, 15],
+  flowing_lava: [207, 92, 15],
+
+  // Coral
+  bubble_column: [55, 100, 190],
+};
+
+export function blockToColor(block: string): [number, number, number] {
+  // Strip "minecraft:" prefix if present
+  const id = block.startsWith("minecraft:") ? block.slice(10) : block;
+  return BLOCK_COLORS[id] ?? [128, 128, 128];
+}
+
+/** Claim type colors */
+export const CLAIM_COLORS: Record<string, [number, number, number, number]> = {
+  none: [0, 0, 0, 0],
+  nature: [34, 139, 34, 100],
+  wall: [139, 69, 19, 180],
+  gate: [218, 165, 32, 200],
+  path: [180, 160, 120, 150],
+  building: [180, 50, 50, 160],
+};

--- a/visualizer/tsconfig.app.json
+++ b/visualizer/tsconfig.app.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/visualizer/tsconfig.json
+++ b/visualizer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/visualizer/tsconfig.node.json
+++ b/visualizer/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/visualizer/vite.config.ts
+++ b/visualizer/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- **Visualizer**: New axum-based web server (feature-gated behind `--features visualizer`) with WebSocket push notifications, REST API for world data (heightmap, biomes, districts, buildings, claims), and a React/TypeScript frontend with canvas-based map rendering
- **Biome refactor**: Replaced 80+ variant `Biome` enum with a string-based `Biome` struct, eliminating maintenance burden when new Minecraft biomes are added
- **Error handling**: Replaced `unwrap()` calls in AI module with proper `Result`/`anyhow` error propagation
- **HTTP provider cleanup**: Deduplicated gzip decoding logic into a shared `try_gunzip` helper
- **Bug fix**: Removed unreachable match arms in biome wood type mapping

## Test plan
- [ ] `cargo build` compiles without warnings
- [ ] `cargo build --features visualizer` compiles the visualizer server
- [ ] `cargo test` passes existing tests
- [ ] Run with `--visualize` flag and verify the web UI at localhost:3000
- [ ] Verify biome detection still works correctly in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)