### PR TITLE
Chronicle: gpt-5-mini, JSON mode, formatted lore books

### DIFF
--- a/src/ai/ai.rs
+++ b/src/ai/ai.rs
@@ -1,19 +1,33 @@
 use log::info;
-use openai::{chat::{ChatCompletion, ChatCompletionMessage, ChatCompletionMessageRole}, Credentials};
+use openai::{chat::{ChatCompletion, ChatCompletionMessage, ChatCompletionMessageRole, ChatCompletionResponseFormat}, Credentials};
 use schemars::schema_for;
 use serde::Deserialize;
 
-pub async fn get_ai_message(system :&str, user:&str) -> anyhow::Result<String> {
+/// Model used for chronicle naming + lore. `gpt-5-mini` is plenty for this
+/// light creative/structured work and ~5x cheaper than the old `gpt-4o`
+/// (pennies per settlement at our volume). Override with `OPENAI_MODEL`.
+const DEFAULT_MODEL: &str = "gpt-5-mini";
+
+fn model() -> String {
+    std::env::var("OPENAI_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string())
+}
+
+/// Core chat call. With `json_mode`, asks the API for a single valid JSON object
+/// (no prose, no fenced block) — the OPENAI requires the word "json" in the
+/// prompt, which the JSON callers include.
+async fn chat(system: &str, user: &str, json_mode: bool) -> anyhow::Result<String> {
     // Relies on OPENAI_KEY and optionally OPENAI_BASE_URL.
     let credentials = Credentials::from_env();
     let messages = vec![
         ChatCompletionMessage {role:ChatCompletionMessageRole::System,content:Some(system.to_string()),name:None,function_call:None, tool_call_id: None, tool_calls: None },
         ChatCompletionMessage {role:ChatCompletionMessageRole::User,content:Some(user.to_string()),name:None,function_call:None, tool_call_id: None, tool_calls: None },
     ];
-    let chat_completion = ChatCompletion::builder("gpt-4o", messages.clone())
-        .credentials(credentials.clone())
-        .create()
-        .await?;
+    let mut builder = ChatCompletion::builder(&model(), messages.clone())
+        .credentials(credentials.clone());
+    if json_mode {
+        builder = builder.response_format(ChatCompletionResponseFormat::json_object());
+    }
+    let chat_completion = builder.create().await?;
     let returned_message = chat_completion.choices.first()
         .ok_or_else(|| anyhow::anyhow!("No choices returned from AI"))?.message.clone();
 
@@ -21,6 +35,10 @@ pub async fn get_ai_message(system :&str, user:&str) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow::anyhow!("AI returned empty content"))?;
     let string_content = content.trim();
     Ok(string_content.to_string())
+}
+
+pub async fn get_ai_message(system :&str, user:&str) -> anyhow::Result<String> {
+    chat(system, user, false).await
 }
 
 pub fn extract_json(response : &str) -> Option<String> {
@@ -40,7 +58,9 @@ pub fn extract_json(response : &str) -> Option<String> {
 pub async fn try_ai_json<T>(query : &str) -> Option<T>
 where T: for<'de> Deserialize<'de> + schemars::JsonSchema {
     let schema = serde_json::to_string_pretty(&schema_for!(T)).unwrap();
-    let response = match get_ai_message(&format!("You are a helpful assistant. Format your response in JSON according to the following schema: {}. Do NOT include the schema in the response.", schema), query).await {
+    // JSON mode makes the API return a single valid JSON object directly (no
+    // prose, no fenced block), so we can parse the response as-is.
+    let response = match chat(&format!("You are a helpful assistant. Format your response as a JSON object matching this schema: {}. Do NOT include the schema in the response.", schema), query, true).await {
         Ok(r) => r,
         Err(e) => {
             log::error!("AI request failed: {e}");
@@ -50,7 +70,9 @@ where T: for<'de> Deserialize<'de> + schemars::JsonSchema {
 
     info!("AI Response: {}", response);
 
-    let json_response = extract_json(&response).unwrap_or(response.to_string());
+    // The response should already be raw JSON; fall back to stripping a fenced
+    // block just in case a model wraps it anyway.
+    let json_response = extract_json(&response).unwrap_or_else(|| response.to_string());
 
     serde_json::from_str(&json_response).unwrap_or(None)
 }

--- a/src/ai/test.rs
+++ b/src/ai/test.rs
@@ -72,30 +72,27 @@ mod tests {
         }
 
         let user = r#"Generate a minecraft book with a title, author, and 10 pages of content, about redstone.
-            Only use color formatting or bold for keywords or titles. Leave most of the body text in plain format.
+
+            Formatting rules — follow exactly:
+            - Body text is PLAIN by default: no color, no bold, no italics. This is true for the vast majority of the text.
+            - A page may open with a short heading that is bold (bold only, never colored).
+            - Color at most ONE word or short phrase per page, and only for a genuinely important name or concept. Most pages should have NO colored text at all. Treat color like rare rubrication in an old manuscript, not a highlighter.
+            - Never write "Keyword:" labels, glossaries, or lists of highlighted terms.
+            - When in doubt, leave text plain.
+
             DO NOT USE § codes with section symbols
             DO NOT USE UNICODE ESCAPE CODES
             Instead do formatting using json elements."#;
         let book: Book = try_ai_json::<Book>(user).await.expect("Failed to parse AI response");
 
         let pages: Vec<String> = book.pages.iter().map(|page| {
-            let mut components = page.iter();
-            if let Some(first) = components.next() {
-                let mut first_obj = serde_json::to_value(first).unwrap();
-                if let Some(first_map) = first_obj.as_object_mut() {
-                    let extra: Vec<serde_json::Value> = components
-                        .map(|t| serde_json::to_value(t).unwrap())
-                        .collect();
-                    if !extra.is_empty() {
-                        first_map.insert("extra".to_string(), serde_json::Value::Array(extra));
-                    }
-                }
-
-                // Serialize and escape as a JSON string
-                format!("'{}'", (&first_obj.to_string().replace("\'", "\\\'"))).replace("\n", "\\\\n").replace("\\n", "\\\\n")
-            } else {
-                "\"\"".to_string() // Empty string for blank pages
-            }
+            // Neutral empty root + all components as `extra`, so a bold heading
+            // doesn't inherit down into the body. Bare SNBT compound renders as
+            // formatted text (a quoted string would print the JSON literally).
+            let extra: Vec<serde_json::Value> = page.iter()
+                .map(|t| serde_json::to_value(t).unwrap())
+                .collect();
+            serde_json::json!({ "text": "", "extra": extra }).to_string()
         }).collect();
         let page_refs = pages.iter().map(|s| s.as_str()).collect::<Vec<_>>();
         let book = provider.give_player_book(&page_refs, &book.title, &book.author)

--- a/src/generator/chronicle.rs
+++ b/src/generator/chronicle.rs
@@ -118,35 +118,30 @@ struct Book {
 
 pub async fn give_player_book(editor : &Editor, instruction : &str) -> anyhow::Result<()> {
     let user = &format!(r#"{}.
-            Use Color and Bold ONLY for KEYWORDS. Most of the body should not be colored or bolded. Leave most of the body text in plain format.
-            Please limit the title and author to less than 32 characters each.
-            DO NOT USE § codes with section symbols
-            DO NOT USE UNICODE ESCAPE CODES
-            Instead do formatting using json elements."#, instruction);
+
+            Formatting rules — follow exactly:
+            - Body text is PLAIN by default: no color, no bold, no italics. This is true for the vast majority of the text.
+            - A page may open with a short heading that is bold (bold only, never colored).
+            - Color at most ONE word or short phrase per page, and only for a genuinely important name or concept. Most pages should have NO colored text at all. Treat color like rare rubrication in an old manuscript, not a highlighter.
+            - Never write "Keyword:" labels, glossaries, or lists of highlighted terms.
+            - When in doubt, leave text plain.
+
+            Keep the title and author under 32 characters each.
+            Do NOT use § section codes or unicode escape codes — format only using the JSON elements."#, instruction);
     let book: Book = try_ai_json::<Book>(user).await
         .ok_or_else(|| anyhow::anyhow!("Failed to get or parse AI response for book"))?;
 
     let pages: Vec<String> = book.pages.iter().map(|page| {
-            let mut components = page.iter();
-            if let Some(first) = components.next() {
-                let mut first_obj = serde_json::to_value(first).unwrap();
-                if let Some(first_map) = first_obj.as_object_mut() {
-                    let extra: Vec<serde_json::Value> = components
-                        .map(|t| serde_json::to_value(t).unwrap())
-                        .collect();
-                    if !extra.is_empty() {
-                        first_map.insert("extra".to_string(), serde_json::Value::Array(extra));
-                    }
-                }
-
-                // Serialize and escape as a JSON string
-                format!("'{}'", (&first_obj.to_string().replace("\'", "\\\'")))
-                    .replace("\n", "\\\\n")
-                    .replace("\\n", "\\\\n") // Only double escaped newlines allowed
-                    .replace("\\\"", "\"") // We don't want to escape quotes
-            } else {
-                "\"\"".to_string() // Empty string for blank pages
-            }
+            // Wrap every component under a NEUTRAL empty root, so each keeps its
+            // own formatting. (If we promoted the first component to the root, its
+            // bold/color would inherit down into every `extra` child — turning a
+            // bold heading into a wholly-bold page.) The result is a bare SNBT
+            // compound; a text component is valid SNBT, so the component-format
+            // book parses it as formatted text rather than printing raw JSON.
+            let extra: Vec<serde_json::Value> = page.iter()
+                .map(|t| serde_json::to_value(t).unwrap())
+                .collect();
+            serde_json::json!({ "text": "", "extra": extra }).to_string()
         }).collect();
     let page_refs = pages.iter().map(|s| s.as_str()).collect::<Vec<_>>();
     if let Err(e) = editor.give_player_book(&page_refs, &book.title, &book.author).await {
@@ -175,11 +170,6 @@ pub async fn generate_chronicle(editor: &Editor, settlement_info : &mut Settleme
                 return anyhow::Ok(());
             },
             Err(e) => {
-                if format!("{:?}", e).contains("sequence, expected a string") {
-                    info!("Chronicle generated successfully.");
-                    return Ok(());
-                }
-                
                 error!("Error generating chronicle: {:?}, retrying", e);
             }
         }

--- a/src/http_mod/command_response.rs
+++ b/src/http_mod/command_response.rs
@@ -1,10 +1,15 @@
-use std::collections::HashMap;
-
 use serde_derive::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct CommandResponse {
+    #[serde(default)]
     pub status: i32,
+    #[serde(default)]
     pub message: String,
-    pub data: Option<HashMap<String, String>>,
+    // The GDMC /command endpoint returns arbitrary JSON here (often nested or
+    // arrays, not just string→string), so keep it untyped rather than failing
+    // the whole parse — which used to make `give_player_book` return Err even on
+    // a successful placement.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
 }


### PR DESCRIPTION
Improves the AI-generated settlement chronicle (names + lore books). Independent of #26.

## Model & reliability
- Chronicle model `gpt-4o` → **`gpt-5-mini`** (a `DEFAULT_MODEL` const with an `OPENAI_MODEL` env override). ~5× cheaper and ample for this light creative/structured work — pennies per settlement.
- `try_ai_json` now uses **JSON mode** (`response_format: json_object`), so the API returns a valid JSON object directly instead of a fenced block we scrape — far fewer parse failures falling back to defaults.

## Formatted books (the real bug)
Written-book pages rendered as **raw JSON text** in-game. Two fixes:
- Emit each page as a **bare SNBT text component** (a quoted JSON string is shown literally by the 1.20.5+ component format).
- Wrap components under a **neutral empty root** so a bold heading no longer inherits down into the whole page body.

Result: bold section headings, plain body, the occasional colored key term.

## Tasteful formatting + cleanup
- Tightened the lore prompt: plain by default, a hard budget ("at most one colored term per page, most pages none"), bold-only headings, no "Keyword:" lists.
- `CommandResponse.data` is now an untyped `serde_json::Value` (the GDMC `/command` endpoint returns nested/array values), so `give_player_book` returns `Ok` on success — removing the error-swallowing hack in `generate_chronicle`.

Verified live against `gpt-5-mini`: name + book generation parse and place correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)