### PR TITLE
Settlement decorations: street lights, rooftop terraces, exterior props + terraform fixes

### DIFF
--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -10,6 +10,7 @@
 # ---------------------------------------------------------------------------
 roof_canopy:
   unique: true
+  tags: [roof_shade]
   min_room_area: 16
   weight: 3.0
   blocks:
@@ -57,5 +58,72 @@ roof_lamp:
     - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
     - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
     - { block: "minecraft:lantern",   offset: [0, 2, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Parasol — a single-post umbrella for decks too small for the 3×3 canopy.
+# Shares the `roof_shade` tag (so a roof gets one shade), but with weight 1 it
+# loses to the canopy wherever the canopy fits; on small decks it's the only
+# shade left. Plus-shaped wool canopy at the top, deck walkable beneath.
+# ---------------------------------------------------------------------------
+roof_parasol:
+  unique: true
+  tags: [roof_shade]
+  min_room_area: 9
+  weight: 1.0
+  blocks:
+    - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 2, 0], layer: ground, swap: wood }
+    - { block: "minecraft:white_wool", offset: [0, 3, 0],  layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 3, 0],  layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [-1, 3, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [0, 3, 1],  layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [0, 3, -1], layer: ceiling, swap: color }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Brazier — a fire pit on a low pedestal. Light, warmth and a smoke plume on
+# the skyline. Sandstone base + lit campfire.
+# ---------------------------------------------------------------------------
+roof_brazier:
+  blocks:
+    - { block: "minecraft:cut_sandstone", offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:campfire",      offset: [0, 1, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Pottery cluster — a pair of decorated pots, distinct from the single `vase`.
+# ---------------------------------------------------------------------------
+roof_jars:
+  blocks:
+    - { block: "minecraft:decorated_pot",      offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:decorated_pot",      offset: [0, 0, 1], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [0, 1], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Planter — a raised bed with a flowering azalea shrub (a leaf bush, so it
+# stays put on the deck unlike loose plants). 2 blocks tall.
+# ---------------------------------------------------------------------------
+roof_planter:
+  blocks:
+    - { block: "minecraft:oak_planks",        offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:flowering_azalea",  offset: [0, 1, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Water trough — a cut-sandstone basin holding a cauldron of water against the
+# parapet. Reads as a rooftop water store.
+# ---------------------------------------------------------------------------
+roof_water_trough:
+  unique: true
+  blocks:
+    - { block: "minecraft:water_cauldron[level=3]", offset: [0, 0, 0], layer: ground }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -127,3 +127,131 @@ roof_water_trough:
     - { block: "minecraft:water_cauldron[level=3]", offset: [0, 0, 0], layer: ground }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
+
+# ===========================================================================
+# More variety — extra shade silhouettes, skyline pieces, greenery, storage.
+# ===========================================================================
+
+# Awning — a freestanding lean-to: tall back posts, short front posts, a wool
+# fabric stepping down from back (y2) to front (y1). A different shade
+# silhouette from the flat canopy; shares the `roof_shade` tag. 3×2.
+roof_awning:
+  unique: true
+  tags: [roof_shade]
+  min_room_area: 12
+  weight: 1.5
+  blocks:
+    # Back posts (2 tall) and front posts (1 tall).
+    - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 0, 1], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 1], layer: ground, swap: wood }
+    # Fabric: high row at the back (y2), stepping down at the front (y1).
+    - { block: "minecraft:white_wool", offset: [0, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [2, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [0, 1, 1], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 1, 1], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [2, 1, 1], layer: ceiling, swap: color }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [2, 0], constraint: blocked_reachable }
+    - { offset: [0, 1], constraint: blocked_reachable }
+    - { offset: [2, 1], constraint: blocked_reachable }
+
+# Pergola — like the canopy but roofed with open trapdoor slats for dappled
+# shade instead of solid wool. Another `roof_shade` option. 3×3.
+roof_pergola:
+  unique: true
+  tags: [roof_shade]
+  min_room_area: 16
+  weight: 1.5
+  blocks:
+    - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 0, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 1, 2], layer: ground, swap: wood }
+    # Slatted roof (trapdoors laid flat at the top).
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 2], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 2], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 2], layer: ceiling, swap: wood }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [2, 0], constraint: blocked_reachable }
+    - { offset: [0, 2], constraint: blocked_reachable }
+    - { offset: [2, 2], constraint: blocked_reachable }
+
+# Chimney — a sandstone stack with a campfire on top: a real smoke plume and a
+# tall silhouette on the skyline.
+roof_chimney:
+  unique: true
+  blocks:
+    - { block: "minecraft:chiseled_sandstone", offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:chiseled_sandstone", offset: [0, 1, 0], layer: ground }
+    - { block: "minecraft:chiseled_sandstone", offset: [0, 2, 0], layer: ground }
+    - { block: "minecraft:campfire",           offset: [0, 3, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# Amphora — a tall storage jar raised on a short pedestal.
+roof_amphora:
+  blocks:
+    - { block: "minecraft:oak_fence",     offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:decorated_pot", offset: [0, 1, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# Potted palm — a small tree centrepiece: a short trunk with a leafy crown that
+# spreads overhead (ceiling layer, so you walk beneath it). Leaves are
+# `persistent` so they don't decay.
+roof_palm:
+  unique: true
+  min_room_area: 9
+  weight: 1.5
+  blocks:
+    - { block: "minecraft:jungle_log",                 offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:jungle_log",                 offset: [0, 1, 0], layer: ground }
+    - { block: "minecraft:jungle_leaves[persistent=true]", offset: [0, 2, 0],  layer: ceiling }
+    - { block: "minecraft:jungle_leaves[persistent=true]", offset: [1, 2, 0],  layer: ceiling }
+    - { block: "minecraft:jungle_leaves[persistent=true]", offset: [-1, 2, 0], layer: ceiling }
+    - { block: "minecraft:jungle_leaves[persistent=true]", offset: [0, 2, 1],  layer: ceiling }
+    - { block: "minecraft:jungle_leaves[persistent=true]", offset: [0, 2, -1], layer: ceiling }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# Laundry line — sheets hung between two posts to dry in the sun. 3×1.
+roof_laundry:
+  blocks:
+    - { block: "minecraft:oak_fence",  offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [0, 2, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [2, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [2, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [2, 2, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [1, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:white_wool", offset: [1, 1, 0], layer: ceiling, swap: color }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [2, 0], constraint: blocked_reachable }
+
+# Woodpile — a small stack of logs for the brazier.
+roof_woodpile:
+  blocks:
+    - { block: "minecraft:oak_log[axis=x]", offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:oak_log[axis=x]", offset: [0, 0, 1], layer: ground }
+    - { block: "minecraft:oak_log[axis=x]", offset: [0, 1, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [0, 1], constraint: blocked_reachable }

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -178,15 +178,15 @@ roof_pergola:
     - { block: "minecraft:oak_fence", offset: [2, 0, 2], layer: ground, swap: wood }
     - { block: "minecraft:oak_fence", offset: [2, 1, 2], layer: ground, swap: wood }
     # Slatted roof (trapdoors laid flat at the top).
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 0], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 0], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 0], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 1], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 1], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 1], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [0, 2, 2], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [1, 2, 2], layer: ceiling, swap: wood }
-    - { block: "minecraft:oak_trapdoor[half=top,open=false,facing=north]", offset: [2, 2, 2], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [0, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [1, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [2, 2, 0], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [0, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [1, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [2, 2, 1], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [0, 2, 2], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [1, 2, 2], layer: ceiling, swap: wood }
+    - { block: "minecraft:oak_trapdoor[half=bottom,open=false,facing=north]", offset: [2, 2, 2], layer: ceiling, swap: wood }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
     - { offset: [2, 0], constraint: blocked_reachable }

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -1,0 +1,61 @@
+# Rooftop terrace furniture for flat (desert) roofs. Placed by decorate_rooftops
+# onto the open deck, with the parapet acting as the wall. Offsets follow the
+# usual convention: blocks are [along, up(y), away], constraints are [along, away].
+# Low-profile pieces read best against the 1-block parapet.
+
+# ---------------------------------------------------------------------------
+# Shade — the terrace centrepiece. Four fence posts carry a wool canopy two
+# blocks up, so the deck stays walkable underneath (canopy blocks sit in the
+# `ceiling` layer and don't claim the floor). 3×3 footprint; large decks only.
+# ---------------------------------------------------------------------------
+roof_canopy:
+  unique: true
+  min_room_area: 16
+  weight: 3.0
+  blocks:
+    # Corner posts (2 tall).
+    - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 0, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 0, 2], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [2, 1, 2], layer: ground, swap: wood }
+    # Canopy roof (wool, 3×3 at y=2). Ceiling layer so the deck stays walkable.
+    - { block: "minecraft:white_wool", offset: [0, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [2, 2, 0], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [0, 2, 1], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 2, 1], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [2, 2, 1], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [0, 2, 2], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [1, 2, 2], layer: ceiling, swap: color }
+    - { block: "minecraft:white_wool", offset: [2, 2, 2], layer: ceiling, swap: color }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [2, 0], constraint: blocked_reachable }
+    - { offset: [0, 2], constraint: blocked_reachable }
+    - { offset: [2, 2], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Sleeping mat — a carpet bedroll with a hay bolster for a headrest. Sleeping
+# in the cool night air is the whole point of a desert terrace. 1×2.
+# ---------------------------------------------------------------------------
+roof_bedroll:
+  blocks:
+    - { block: "minecraft:hay_block",    offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:white_carpet", offset: [0, 0, 1], layer: ground, swap: color, walkable: true }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# ---------------------------------------------------------------------------
+# Terrace lamp — a short fence post topped with a lantern, for night light.
+# ---------------------------------------------------------------------------
+roof_lamp:
+  blocks:
+    - { block: "minecraft:oak_fence", offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence", offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:lantern",   offset: [0, 2, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -255,3 +255,57 @@ roof_woodpile:
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
     - { offset: [0, 1], constraint: blocked_reachable }
+
+# ===========================================================================
+# Batch 3 — cooking, crafting, garden ledge, lounging.
+# ===========================================================================
+
+# Tandoor — a clay oven: a sandstone base with a lit smoker on top. Cooking,
+# light, and a thin smoke wisp.
+roof_tandoor:
+  unique: true
+  blocks:
+    - { block: "minecraft:cut_sandstone",            offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:smoker[lit=true,facing=north]", offset: [0, 1, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# Cactus ledge — a row of three potted cacti, a little desert garden. 1×3.
+roof_cactus_row:
+  min_room_area: 12
+  blocks:
+    - { block: "minecraft:potted_cactus", offset: [0, 0, 0], layer: ground }
+    - { block: "minecraft:potted_cactus", offset: [0, 0, 1], layer: ground }
+    - { block: "minecraft:potted_cactus", offset: [0, 0, 2], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [0, 1], constraint: blocked_reachable }
+    - { offset: [0, 2], constraint: blocked_reachable }
+
+# Hammock — a fabric sling strung between two posts to laze in the shade. The
+# sling hangs overhead (ceiling layer) so the deck stays walkable beneath. 3×1.
+roof_hammock:
+  blocks:
+    - { block: "minecraft:oak_fence",  offset: [0, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [0, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [2, 0, 0], layer: ground, swap: wood }
+    - { block: "minecraft:oak_fence",  offset: [2, 1, 0], layer: ground, swap: wood }
+    - { block: "minecraft:white_wool", offset: [1, 1, 0], layer: ceiling, swap: color }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+    - { offset: [2, 0], constraint: blocked_reachable }
+
+# Millstone — a floor grindstone for grinding grain or spice. 1×1.
+roof_grindstone:
+  blocks:
+    - { block: "minecraft:grindstone[face=floor,facing=north]", offset: [0, 0, 0], layer: ground }
+  constraints:
+    - { offset: [0, 0], constraint: blocked_reachable }
+
+# Rug runner — a long walkable carpet with alternating colours. 1×3. Like the
+# stock carpets, walkable blocks carry no constraints (they stay walkable).
+roof_rug_runner:
+  blocks:
+    - { block: "minecraft:white_carpet", offset: [0, 0, 0], layer: ground, swap: color, walkable: true }
+    - { block: "minecraft:white_carpet", offset: [0, 0, 1], layer: ground, swap: secondary_color, walkable: true }
+    - { block: "minecraft:white_carpet", offset: [0, 0, 2], layer: ground, swap: color, walkable: true }

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -86,37 +86,108 @@ study:
   required: [bookshelf]
   optional: [lantern, desk, chair, bookshelf, shelf, carpet, carpet, lectern, potted_plant]
 
-# Flat-roof terrace (desert). Decorated by decorate_rooftops, not a real room.
-# A low fill threshold keeps the deck airy — a shaded spot to sit and sleep,
-# not a packed storeroom. The canopy is the centrepiece; the rest is optional.
-roof_terrace:
+# Flat-roof themes (desert). decorate_rooftops picks ONE of these per building
+# so neighbouring roofs read as different spaces. These aren't real rooms — the
+# parapet acts as the wall and there's no ceiling. Keep fill thresholds modest
+# (working roofs a touch denser) so decks stay legible from the air.
+
+# Living terrace — a shaded spot to relax.
+roof_lounge:
   fill_threshold: 0.45
   required: [roof_shade]
   optional:
     - roof_bedroll
-    - roof_planter
-    - roof_palm
+    - roof_hammock
     - carpet
     - carpet
+    - roof_rug_runner
     - bench
     - chair
     - table
     - roof_lamp
+    - roof_palm
+    - vase
+    - potted_plant
+    - roof_laundry
+
+# Roof garden — greenery and water.
+roof_garden:
+  fill_threshold: 0.5
+  required: [roof_shade]
+  optional:
+    - roof_planter
+    - roof_palm
+    - roof_cactus_row
+    - potted_plant
+    - potted_plant
+    - roof_water_trough
+    - vase
+    - carpet
+    - roof_lamp
+    - bench
+    - roof_jars
+
+# Open-air kitchen — cooking and food stores.
+roof_kitchen:
+  fill_threshold: 0.5
+  required: [roof_tandoor]
+  optional:
     - roof_brazier
     - roof_chimney
-    - roof_tandoor
-    - roof_jars
-    - roof_amphora
-    - roof_water_trough
-    - roof_laundry
     - roof_woodpile
-    - roof_cactus_row
-    - roof_hammock
-    - roof_grindstone
-    - roof_rug_runner
-    - potted_plant
-    - vase
+    - roof_water_trough
     - barrel
     - crate
+    - roof_jars
+    - roof_amphora
+    - roof_lamp
+    - table
+    - roof_shade
     - sack_pile
-    - loom
+
+# Workshop — crafting on the roof.
+roof_workshop:
+  fill_threshold: 0.55
+  required: [loom]
+  optional:
+    - roof_grindstone
+    - crate
+    - sack_pile
+    - barrel
+    - roof_woodpile
+    - roof_lamp
+    - table
+    - vase
+    - roof_shade
+    - roof_amphora
+
+# Storage roof — packed with goods.
+roof_storage:
+  fill_threshold: 0.6
+  required: [barrel]
+  optional:
+    - crate
+    - sack_pile
+    - barrel
+    - crate
+    - roof_amphora
+    - roof_jars
+    - roof_woodpile
+    - roof_water_trough
+    - roof_lamp
+
+# Sleeping deck — bedouin-style, sleep in the cool night air.
+roof_sleeping:
+  fill_threshold: 0.45
+  required: [roof_shade]
+  optional:
+    - roof_bedroll
+    - roof_bedroll
+    - roof_hammock
+    - carpet
+    - roof_rug_runner
+    - roof_lamp
+    - roof_brazier
+    - roof_jars
+    - potted_plant
+    - roof_laundry

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -90,6 +90,20 @@ study:
 # A low fill threshold keeps the deck airy — a shaded spot to sit and sleep,
 # not a packed storeroom. The canopy is the centrepiece; the rest is optional.
 roof_terrace:
-  fill_threshold: 0.4
-  required: [roof_canopy]
-  optional: [roof_bedroll, carpet, carpet, bench, chair, table, roof_lamp, potted_plant, vase]
+  fill_threshold: 0.45
+  required: [roof_shade]
+  optional:
+    - roof_bedroll
+    - roof_planter
+    - carpet
+    - carpet
+    - bench
+    - chair
+    - table
+    - roof_lamp
+    - roof_brazier
+    - roof_jars
+    - roof_water_trough
+    - potted_plant
+    - vase
+    - barrel

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -95,6 +95,7 @@ roof_terrace:
   optional:
     - roof_bedroll
     - roof_planter
+    - roof_palm
     - carpet
     - carpet
     - bench
@@ -102,8 +103,12 @@ roof_terrace:
     - table
     - roof_lamp
     - roof_brazier
+    - roof_chimney
     - roof_jars
+    - roof_amphora
     - roof_water_trough
+    - roof_laundry
+    - roof_woodpile
     - potted_plant
     - vase
     - barrel

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -104,11 +104,19 @@ roof_terrace:
     - roof_lamp
     - roof_brazier
     - roof_chimney
+    - roof_tandoor
     - roof_jars
     - roof_amphora
     - roof_water_trough
     - roof_laundry
     - roof_woodpile
+    - roof_cactus_row
+    - roof_hammock
+    - roof_grindstone
+    - roof_rug_runner
     - potted_plant
     - vase
     - barrel
+    - crate
+    - sack_pile
+    - loom

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -85,3 +85,11 @@ studio:
 study:
   required: [bookshelf]
   optional: [lantern, desk, chair, bookshelf, shelf, carpet, carpet, lectern, potted_plant]
+
+# Flat-roof terrace (desert). Decorated by decorate_rooftops, not a real room.
+# A low fill threshold keeps the deck airy — a shaded spot to sit and sleep,
+# not a packed storeroom. The canopy is the centrepiece; the rest is optional.
+roof_terrace:
+  fill_threshold: 0.4
+  required: [roof_canopy]
+  optional: [roof_bedroll, carpet, carpet, bench, chair, table, roof_lamp, potted_plant, vase]

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -161,9 +161,9 @@ roof_workshop:
     - roof_shade
     - roof_amphora
 
-# Storage roof — packed with goods.
+# Storage roof — a few goods stacked up, not a packed warehouse.
 roof_storage:
-  fill_threshold: 0.6
+  fill_threshold: 0.4
   required: [barrel]
   optional:
     - crate

--- a/src/generator/buildings_v2/door_ramp.rs
+++ b/src/generator/buildings_v2/door_ramp.rs
@@ -266,6 +266,40 @@ pub fn plan_door_ramps(
     ramps
 }
 
+/// The exterior entrance cell for every ground-floor door — the cell a player
+/// stands on when they step out and reach natural grade. For a door with a ramp
+/// this is one cell past the bottom of the ramp; for a flat door it's the
+/// landing directly outside. Used to start door→road connector paths from the
+/// real entrance instead of guessing.
+pub fn door_entrances(wall_segs: &WallSegments, ramps: &[DoorRamp]) -> Vec<Point2D> {
+    use std::collections::HashMap;
+    let ramp_by_door: HashMap<Point2D, &DoorRamp> =
+        ramps.iter().map(|r| (r.door_cell, r)).collect();
+
+    let mut entrances = Vec::new();
+    for (seg, opening) in wall_segs.doors() {
+        if seg.floor != 0 {
+            continue;
+        }
+        let cells = segment_cells(seg);
+        let door_idx = opening.offset as usize;
+        let Some(&door_cell) = cells.get(door_idx) else { continue };
+        let outward: Point2D = (-seg.facing).into();
+        let landing = door_cell + outward;
+
+        let entrance = match ramp_by_door.get(&door_cell) {
+            // One cell past the last step, where the ramp meets grade.
+            Some(ramp) => match ramp.steps.last() {
+                Some(last) => last.cell + Point2D::from(ramp.side_dir),
+                None => ramp.landing_cell,
+            },
+            None => landing,
+        };
+        entrances.push(entrance);
+    }
+    entrances
+}
+
 /// Plan ramps from a World's heightmap (convenience wrapper).
 pub fn plan_door_ramps_from_world(
     wall_segs: &WallSegments,

--- a/src/generator/buildings_v2/exterior.rs
+++ b/src/generator/buildings_v2/exterior.rs
@@ -1,0 +1,145 @@
+//! Sparse exterior wall decoration.
+//!
+//! Occasionally sets a household prop (barrel, pot, planter, firewood, …) on
+//! the ground against the *outside* of a building's walls, so houses read as
+//! lived-in rather than dropped models. Runs per building once the shell is
+//! built. Tasteful by design: most houses get one or two props, never blocking
+//! a door, a road, or another building.
+
+use std::collections::HashSet;
+
+use crate::editor::Editor;
+use crate::generator::BuildClaim;
+use crate::generator::buildings::BuildingID;
+use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
+use crate::minecraft::{string_to_block, Block};
+use crate::noise::RNG;
+
+use super::footprint::Footprint;
+use super::pipeline::BuildCtx;
+use super::walls::{segment_cells, WallSegments};
+
+/// Prop blocks placed against exterior walls — a varied, mostly single-block
+/// set of everyday household clutter. Keep this list 10+ deep so a street shows
+/// real variety.
+const PROPS: [&str; 12] = [
+    "minecraft:barrel[facing=up]",
+    "minecraft:decorated_pot",
+    "minecraft:hay_block",
+    "minecraft:composter",
+    "minecraft:cauldron",
+    "minecraft:water_cauldron[level=3]",
+    "minecraft:potted_cactus",
+    "minecraft:potted_azalea_bush",
+    "minecraft:potted_dead_bush",
+    "minecraft:oak_log[axis=x]",
+    "minecraft:lantern",
+    "minecraft:flower_pot",
+];
+
+/// Weighted target count of props per building — average ~1.3, capped at 3,
+/// often zero, so decoration stays occasional.
+const TARGET_COUNTS: [u32; 6] = [0, 0, 1, 1, 2, 3];
+
+/// Decorate the outside of a building's walls with a few sparse props.
+pub async fn decorate_exterior_walls(
+    ctx: &mut BuildCtx<'_>,
+    footprint: &Footprint,
+    wall_segs: &WallSegments,
+) {
+    let mut rng = ctx.rng.derive();
+
+    let target = *rng.choose(&TARGET_COUNTS);
+    if target == 0 {
+        return;
+    }
+
+    // Cells just outside each door (plus the approach cell) — keep entrances clear.
+    let mut avoid: HashSet<Point2D> = HashSet::new();
+    for (seg, opening) in wall_segs.doors() {
+        let cells = segment_cells(seg);
+        let out: Point2D = seg.facing.into();
+        for dx in 0..opening.width {
+            if let Some(&cell) = cells.get((opening.offset + dx) as usize) {
+                avoid.insert(cell + out);
+                avoid.insert(cell + out * 2);
+            }
+        }
+    }
+
+    // The exterior ring: cells one step out from the footprint.
+    let filled: HashSet<Point2D> = footprint.filled_points().into_iter().collect();
+    let mut ring: HashSet<Point2D> = HashSet::new();
+    for &c in &filled {
+        for d in CARDINALS_2D {
+            let ext = c + d;
+            if !filled.contains(&ext) {
+                ring.insert(ext);
+            }
+        }
+    }
+    // Sort to a deterministic order (Point2D isn't Ord), then shuffle via RNG.
+    let mut candidates: Vec<Point2D> = ring.into_iter().collect();
+    candidates.sort_by_key(|p| (p.x, p.y));
+    shuffle(&mut candidates, &mut rng);
+
+    // Claim placed props as part of this building so a later building or road
+    // never overwrites them (same id the footprint claim uses).
+    let building_idx = ctx.editor.world().buildings.len();
+
+    let mut placed: Vec<Point2D> = Vec::new();
+    for cell in candidates {
+        if placed.len() >= target as usize {
+            break;
+        }
+        if avoid.contains(&cell) || !is_open_ground(ctx.editor, cell) {
+            continue;
+        }
+        // Spread props out so two never sit side by side.
+        if placed.iter().any(|p| p.distance_manhattan(&cell) < 3) {
+            continue;
+        }
+
+        let prop = pick_prop(&mut rng);
+        let y = ctx.editor.world().get_height_at(cell);
+        ctx.editor.place_block(&prop, Point3D::new(cell.x, y, cell.y)).await;
+        ctx.editor
+            .world_mut()
+            .claim(cell, BuildClaim::Building(BuildingID(building_idx)));
+        placed.push(cell);
+    }
+}
+
+/// A cell is a good prop spot if it's in bounds, unclaimed open ground (not a
+/// road, wall, structure, or another building), and sits on solid, non-water
+/// ground.
+fn is_open_ground(editor: &Editor, cell: Point2D) -> bool {
+    let world = editor.world();
+    if !world.is_in_bounds_2d(cell) {
+        return false;
+    }
+    if !matches!(world.get_claim(cell), Some(BuildClaim::None | BuildClaim::Nature)) {
+        return false;
+    }
+    // The block the prop will stand on (one below the placement Y).
+    let y = world.get_height_at(cell);
+    match world.get_block(Point3D::new(cell.x, y - 1, cell.y)) {
+        Some(b) => {
+            let id = b.id.as_str();
+            !b.id.is_water() && id != "minecraft:air" && id != "air"
+        }
+        None => false,
+    }
+}
+
+fn pick_prop(rng: &mut RNG) -> Block {
+    let s = *rng.choose(&PROPS);
+    string_to_block(s).unwrap_or_else(|| Block::from_id(s.into()))
+}
+
+fn shuffle<T>(items: &mut [T], rng: &mut RNG) {
+    for i in (1..items.len()).rev() {
+        let j = rng.rand_i32_range(0, (i + 1) as i32) as usize;
+        items.swap(i, j);
+    }
+}

--- a/src/generator/buildings_v2/foundation/terraform.rs
+++ b/src/generator/buildings_v2/foundation/terraform.rs
@@ -5,7 +5,6 @@ use crate::generator::BuildClaim;
 use crate::generator::buildings_v2::footprint::Footprint;
 use crate::generator::buildings_v2::pipeline::BuildCtx;
 use crate::geometry::{Point2D, Point3D};
-use crate::minecraft::Block;
 
 /// How many blocks outward from the footprint edge to blend terrain.
 const BLEND_RADIUS: i32 = 5;
@@ -77,27 +76,12 @@ pub async fn blend_terrain(ctx: &mut BuildCtx<'_>, footprint: &Footprint, base_y
                 continue;
             }
 
-            // Keep the blended cap in the natural surface material: grass stays
-            // grass, sand stays sand, stone stays stone. Only grassy ground gets
-            // a dirt body + grass cap; every other surface is filled and capped
-            // with itself, so the blend never paints foreign grass over rock or
-            // sand. Snow is re-laid on top.
+            // Keep the blended cap in the natural surface material; gravity
+            // surfaces (sand/gravel) get a solid sandstone/stone body so the cap
+            // rests on a base and can't fall. (See `terraform_layers`.)
             let surface = ctx.editor.world().get_ground_block(point).clone();
-            let s = surface.id.as_str();
-            let is_snow = s.contains("snow");
-            let is_grassy = s.contains("grass_block")
-                || s.contains("dirt")
-                || s.contains("podzol")
-                || s.contains("mycelium");
-
-            let (fill, top) = if is_grassy || is_snow {
-                (
-                    Block::from_id("minecraft:dirt".into()),
-                    Block::from_id("minecraft:grass_block".into()),
-                )
-            } else {
-                (surface.clone(), surface.clone())
-            };
+            let is_snow = surface.id.as_str().contains("snow");
+            let (fill, top) = crate::generator::terrain::terraform_layers(&surface);
 
             // Convert the old surface to fill material since it's being buried.
             ctx.editor.place_block(&fill, point.add_y(terrain_y - 1)).await;

--- a/src/generator/buildings_v2/foundation/terraform.rs
+++ b/src/generator/buildings_v2/foundation/terraform.rs
@@ -77,23 +77,26 @@ pub async fn blend_terrain(ctx: &mut BuildCtx<'_>, footprint: &Footprint, base_y
                 continue;
             }
 
+            // Keep the blended cap in the natural surface material: grass stays
+            // grass, sand stays sand, stone stays stone. Only grassy ground gets
+            // a dirt body + grass cap; every other surface is filled and capped
+            // with itself, so the blend never paints foreign grass over rock or
+            // sand. Snow is re-laid on top.
             let surface = ctx.editor.world().get_ground_block(point).clone();
-            let is_snow = surface.id.as_str().contains("snow");
-            let is_sandy = {
-                let s = surface.id.as_str();
-                s.contains("sand") || s.contains("sandstone")
-            };
+            let s = surface.id.as_str();
+            let is_snow = s.contains("snow");
+            let is_grassy = s.contains("grass_block")
+                || s.contains("dirt")
+                || s.contains("podzol")
+                || s.contains("mycelium");
 
-            let (fill, top) = if is_sandy {
-                (
-                    Block::from_id("minecraft:sand".into()),
-                    Block::from_id("minecraft:sand".into()),
-                )
-            } else {
+            let (fill, top) = if is_grassy || is_snow {
                 (
                     Block::from_id("minecraft:dirt".into()),
                     Block::from_id("minecraft:grass_block".into()),
                 )
+            } else {
+                (surface.clone(), surface.clone())
             };
 
             // Convert the old surface to fill material since it's being buried.

--- a/src/generator/buildings_v2/foundation/terraform.rs
+++ b/src/generator/buildings_v2/foundation/terraform.rs
@@ -79,7 +79,15 @@ pub async fn blend_terrain(ctx: &mut BuildCtx<'_>, footprint: &Footprint, base_y
             // Keep the blended cap in the natural surface material; gravity
             // surfaces (sand/gravel) get a solid sandstone/stone body so the cap
             // rests on a base and can't fall. (See `terraform_layers`.)
-            let surface = ctx.editor.world().get_ground_block(point).clone();
+            //
+            // Sample the real surface block at `terrain_y - 1` (top solid), not
+            // `get_ground_block` — that reads the first-air block above the
+            // surface (air), which would mis-detect the surface and hole it.
+            let surface = ctx
+                .editor
+                .world()
+                .get_block(point.add_y(terrain_y - 1))
+                .unwrap_or_else(|| crate::minecraft::Block::from_id("minecraft:dirt".into()));
             let is_snow = surface.id.as_str().contains("snow");
             let (fill, top) = crate::generator::terrain::terraform_layers(&surface);
 

--- a/src/generator/buildings_v2/furnish/mod.rs
+++ b/src/generator/buildings_v2/furnish/mod.rs
@@ -16,7 +16,9 @@ mod block;
 mod loot;
 mod placement;
 mod room;
+mod roof;
 mod types;
 
+pub use roof::decorate_rooftops;
 pub use room::furnish_rooms;
 pub use types::{BlockLayer, CellConstraint, FacingMode};

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -41,9 +41,16 @@ pub async fn decorate_rooftops(
     frame: &Frame,
     roof_ladder_wall: Option<(i32, i32)>,
 ) {
+    let mut pick_rng = ctx.rng.derive();
+
+    // Leave roughly a third of roofs bare — an empty deck is part of the
+    // variety, and a street where every roof is dressed reads as busy.
+    if pick_rng.rand_i32_range(0, 3) == 0 {
+        return;
+    }
+
     // Pick one rooftop theme for the whole building so its deck(s) read as a
     // single, coherent space.
-    let mut pick_rng = ctx.rng.derive();
     let key = ROOF_ROOM_KEYS[pick_rng.rand_i32_range(0, ROOF_ROOM_KEYS.len() as i32) as usize];
     let room_list = match ctx.data.furniture.rooms.get(key) {
         Some(list) => list,

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -1,0 +1,103 @@
+//! Flat-roof terrace decoration.
+//!
+//! Points the interior furnish machinery at each flat-roof *deck*, treating the
+//! parapet as the surrounding wall. The deck is a flat open rectangle, so we
+//! build a fresh constraint map over it (inset one cell from the parapet),
+//! reserve the roof-ladder exit, and run the `roof_terrace` furniture list
+//! through the same placement/connectivity engine the rooms use.
+//!
+//! Runs after interior furnishing and only for `RoofStyle::Flat`. Dome rects
+//! (square, ≥ `MIN_DOME_SIDE`) have no walkable deck and are skipped.
+
+use crate::editor::Editor;
+use crate::geometry::{Point2D, Rect2D};
+
+use super::room::furnish_interior;
+use super::super::frame::Frame;
+use super::super::pipeline::BuildCtx;
+use super::super::roof::dome::is_dome_eligible;
+use super::super::roof::top_floor_rects;
+use super::super::rooms::{CellState, ConstraintMap};
+
+/// The rooms.yaml entry that lists rooftop terrace furniture.
+const ROOF_ROOM_KEY: &str = "roof_terrace";
+
+/// Decorate every flat-roof deck in a building with terrace furniture.
+///
+/// `roof_ladder_wall` is the parapet cell the access ladder climbs against
+/// (from `place_roof_ladder`); its inward deck neighbours are kept clear so the
+/// player can step off the ladder.
+pub async fn decorate_rooftops(
+    ctx: &mut BuildCtx<'_>,
+    frame: &Frame,
+    roof_ladder_wall: Option<(i32, i32)>,
+) {
+    let room_list = match ctx.data.furniture.rooms.get(ROOF_ROOM_KEY) {
+        Some(list) => list,
+        None => return,
+    };
+
+    let editor: &Editor = &*ctx.editor;
+    let items = &ctx.data.furniture.items;
+    let materials = &ctx.data.materials;
+    let loot = &ctx.data.furniture.loot;
+    let palette = ctx.palette;
+
+    let rects = top_floor_rects(frame);
+    for (i, rect) in rects.iter().enumerate() {
+        // Domes have no deck; flat rects do.
+        if is_dome_eligible(rect) {
+            continue;
+        }
+
+        // Deck interior = the rect inset one cell, so the parapet ring acts as
+        // the wall that wall-anchored items lean against.
+        let interior = Rect2D {
+            origin: Point2D::new(rect.min().x + 1, rect.min().y + 1),
+            size: Point2D::new(rect.size.x - 2, rect.size.y - 2),
+        };
+        if interior.size.x <= 0 || interior.size.y <= 0 {
+            continue;
+        }
+
+        // Furniture stands on the deck: the deck block sits at `roof_y - 2`, so
+        // its top surface (where furniture goes) is `roof_y - 1`.
+        let roof_y = frame.roof_y(i);
+        let floor_y = roof_y - 1;
+        // No ceiling above an open terrace; canopies place their own overhead
+        // blocks. Keep a nominal value so ceiling items (none in the list) would
+        // land clear rather than inside the deck.
+        let ceiling_y = floor_y + 4;
+
+        let mut constraints = ConstraintMap::new(&interior);
+
+        // Keep the ladder exit walkable: reserve the deck cells next to the
+        // parapet cell the ladder climbs against.
+        if let Some((wx, wz)) = roof_ladder_wall {
+            for (dx, dz) in [(0, -1), (1, 0), (0, 1), (-1, 0)] {
+                let cell = (wx + dx, wz + dz);
+                if constraints.get(cell).is_some() {
+                    constraints.set(cell, CellState::UnblockedReachable);
+                }
+            }
+        }
+
+        let mut roof_rng = ctx.rng.derive();
+        furnish_interior(
+            editor,
+            &interior,
+            &mut constraints,
+            room_list,
+            items,
+            floor_y,
+            ceiling_y,
+            None, // open sky — no roof-clearance clamp
+            false,
+            palette,
+            materials,
+            loot,
+            &mut roof_rng,
+        )
+        .await;
+    }
+}

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -19,8 +19,17 @@ use super::super::roof::dome::is_dome_eligible;
 use super::super::roof::top_floor_rects;
 use super::super::rooms::{CellState, ConstraintMap};
 
-/// The rooms.yaml entry that lists rooftop terrace furniture.
-const ROOF_ROOM_KEY: &str = "roof_terrace";
+/// The rooms.yaml entries a flat roof can be furnished as. One is chosen at
+/// random per building, so neighbouring roofs read as different spaces — a
+/// garden, a lounge, an open-air kitchen, etc.
+const ROOF_ROOM_KEYS: [&str; 6] = [
+    "roof_lounge",
+    "roof_garden",
+    "roof_kitchen",
+    "roof_workshop",
+    "roof_storage",
+    "roof_sleeping",
+];
 
 /// Decorate every flat-roof deck in a building with terrace furniture.
 ///
@@ -32,7 +41,11 @@ pub async fn decorate_rooftops(
     frame: &Frame,
     roof_ladder_wall: Option<(i32, i32)>,
 ) {
-    let room_list = match ctx.data.furniture.rooms.get(ROOF_ROOM_KEY) {
+    // Pick one rooftop theme for the whole building so its deck(s) read as a
+    // single, coherent space.
+    let mut pick_rng = ctx.rng.derive();
+    let key = ROOF_ROOM_KEYS[pick_rng.rand_i32_range(0, ROOF_ROOM_KEYS.len() as i32) as usize];
+    let room_list = match ctx.data.furniture.rooms.get(key) {
         Some(list) => list,
         None => return,
     };

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -11,6 +11,7 @@
 
 use crate::editor::Editor;
 use crate::geometry::{Point2D, Rect2D};
+use crate::minecraft::Color;
 
 use super::room::furnish_interior;
 use super::super::frame::Frame;
@@ -29,6 +30,21 @@ const ROOF_ROOM_KEYS: [&str; 6] = [
     "roof_workshop",
     "roof_storage",
     "roof_sleeping",
+];
+
+/// Fabric colours a roof's textiles (awnings, canopies, carpets, bedrolls) can
+/// take. One is chosen per building and swapped in for `swap: color` blocks, so
+/// roofs aren't all the palette's default red — warm canvas tones with a few
+/// dyed accents, all plausible for sun-bleached desert cloth.
+const ROOF_FABRIC_COLORS: [Color; 8] = [
+    Color::White,
+    Color::Orange,
+    Color::Yellow,
+    Color::Red,
+    Color::Brown,
+    Color::LightBlue,
+    Color::Cyan,
+    Color::Magenta,
 ];
 
 /// Decorate every flat-roof deck in a building with terrace furniture.
@@ -61,7 +77,13 @@ pub async fn decorate_rooftops(
     let items = &ctx.data.furniture.items;
     let materials = &ctx.data.materials;
     let loot = &ctx.data.furniture.loot;
-    let palette = ctx.palette;
+
+    // Give this building's roof textiles their own fabric colour instead of the
+    // palette's default, so a street of roofs isn't all one shade.
+    let fabric = ROOF_FABRIC_COLORS[pick_rng.rand_i32_range(0, ROOF_FABRIC_COLORS.len() as i32) as usize];
+    let mut roof_palette = ctx.palette.clone();
+    roof_palette.primary_color = Some(fabric);
+    let palette = &roof_palette;
 
     let rects = top_floor_rects(frame);
     for (i, rect) in rects.iter().enumerate() {

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -157,13 +157,6 @@ pub(super) async fn furnish_room(
     } else {
         frame.ceiling_y(room.floor)
     };
-    let mut slots = wall_slots(&interior);
-    shuffle(&mut slots, rng);
-
-    let mut open_cells: Vec<(i32, i32)> = interior.iter().map(|p| (p.x, p.y)).collect();
-    shuffle(&mut open_cells, rng);
-
-    let room_area = interior.area();
     let is_attic = room.role == RoomRole::Attic;
     // Only attics have a sloped roof above the room — flat-ceiling rooms get
     // None and skip the per-cell clearance check entirely.
@@ -172,15 +165,52 @@ pub(super) async fn furnish_room(
     } else {
         None
     };
+
+    let placed = furnish_interior(
+        editor, &interior, &mut room.constraints, room_list, items,
+        floor_y, ceiling_y, roof_clearance.as_ref(), is_attic,
+        palette, materials, loot_tables, rng,
+    ).await;
+    room.furniture.extend(placed);
+}
+
+/// Furnish an arbitrary interior rect against a (pre-seeded) constraint map
+/// from a room furniture list. Shared by [`furnish_room`] (interior rooms) and
+/// rooftop terrace decoration: the caller supplies the geometry (interior,
+/// floor/ceiling Y, optional roof clearance) and gets back the placed items.
+pub(super) async fn furnish_interior(
+    editor: &Editor,
+    interior: &Rect2D,
+    constraints: &mut ConstraintMap,
+    room_list: &RoomFurnitureList,
+    items: &HashMap<String, Furniture>,
+    floor_y: i32,
+    ceiling_y: i32,
+    roof_clearance: Option<&RoofClearance<'_>>,
+    is_attic: bool,
+    palette: &Palette,
+    materials: &HashMap<MaterialId, Material>,
+    loot_tables: &HashMap<String, LootTable>,
+    rng: &mut RNG,
+) -> Vec<PlacedFurniture> {
+    let mut placed: Vec<PlacedFurniture> = Vec::new();
+
+    let mut slots = wall_slots(interior);
+    shuffle(&mut slots, rng);
+
+    let mut open_cells: Vec<(i32, i32)> = interior.iter().map(|p| (p.x, p.y)).collect();
+    shuffle(&mut open_cells, rng);
+
+    let room_area = interior.area();
     let mut placed_tags: HashSet<String> = HashSet::new();
 
     for entry in &room_list.required {
         let candidates = resolve_candidates(entry, items, room_area, is_attic, &placed_tags, rng);
         for (name, item) in candidates {
             if let Some(cells) = try_place_item(
-                editor, item, &interior, &mut room.constraints,
+                editor, item, interior, constraints,
                 &slots, &open_cells, floor_y, ceiling_y,
-                roof_clearance.as_ref(),
+                roof_clearance,
                 palette, materials, loot_tables, rng,
             ).await {
                 if item.unique {
@@ -188,31 +218,31 @@ pub(super) async fn furnish_room(
                         placed_tags.insert(tag.to_string());
                     }
                 }
-                room.furniture.push(PlacedFurniture { name: name.clone(), cells });
+                placed.push(PlacedFurniture { name: name.clone(), cells });
                 break;
             }
         }
     }
 
     let fill_threshold = room_list.fill_threshold.unwrap_or(DEFAULT_FILL_THRESHOLD);
-    // Rooms that explicitly set a threshold (storage, pantry) run the
-    // optional list in repeated passes until nothing more fits — packing
+    // Rooms that explicitly set a threshold (storage, pantry, roof terrace) run
+    // the optional list in repeated passes until nothing more fits — packing
     // them until the threshold is hit or a full pass places nothing.
     let aggressive = room_list.fill_threshold.is_some();
 
     loop {
-        if room.constraints.fill_ratio() >= fill_threshold {
+        if constraints.fill_ratio() >= fill_threshold {
             break;
         }
         let mut placed_this_pass = false;
         for entry in &room_list.optional {
-            if room.constraints.fill_ratio() >= fill_threshold { break; }
+            if constraints.fill_ratio() >= fill_threshold { break; }
             let candidates = resolve_candidates(entry, items, room_area, is_attic, &placed_tags, rng);
             for (name, item) in candidates {
                 if let Some(cells) = try_place_item(
-                    editor, item, &interior, &mut room.constraints,
+                    editor, item, interior, constraints,
                     &slots, &open_cells, floor_y, ceiling_y,
-                    roof_clearance.as_ref(),
+                    roof_clearance,
                     palette, materials, loot_tables, rng,
                 ).await {
                     if item.unique {
@@ -220,7 +250,7 @@ pub(super) async fn furnish_room(
                             placed_tags.insert(tag.to_string());
                         }
                     }
-                    room.furniture.push(PlacedFurniture { name: name.clone(), cells });
+                    placed.push(PlacedFurniture { name: name.clone(), cells });
                     placed_this_pass = true;
                     break;
                 }
@@ -230,6 +260,8 @@ pub(super) async fn furnish_room(
             break;
         }
     }
+
+    placed
 }
 
 /// Furnish all rooms in a building using loaded furniture data.

--- a/src/generator/buildings_v2/mod.rs
+++ b/src/generator/buildings_v2/mod.rs
@@ -1,6 +1,7 @@
 pub mod blueprint;
 pub mod cellar;
 pub mod door_ramp;
+pub mod exterior;
 pub mod floors;
 pub mod footprint;
 pub mod foundation;

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -22,7 +22,7 @@ use super::foundation::place_foundation;
 use crate::generator::BuildClaim;
 use crate::generator::buildings::BuildingID;
 use super::frame::{Frame, apply_jetty, generate_frame};
-use super::furnish::furnish_rooms;
+use super::furnish::{decorate_rooftops, furnish_rooms};
 use super::{BuildingContext, Culture};
 use super::roof::RoofStyle;
 use super::roof::gable::GablePitch;
@@ -182,6 +182,12 @@ pub async fn build_house(
 
 
     furnish_rooms(ctx, &mut room_plan, &frame, &roof_heightmaps).await;
+
+    // Flat roofs are open terraces — decorate the deck (shade, seating, plants)
+    // once the interior is furnished. Keeps the ladder exit clear.
+    if matches!(roof_style, RoofStyle::Flat) {
+        decorate_rooftops(ctx, &frame, roof_ladder_wall).await;
+    }
 
     check_building_invariants(&frame, &room_plan, &floor_plan)?;
 

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -23,6 +23,7 @@ use crate::generator::BuildClaim;
 use crate::generator::buildings::BuildingID;
 use super::frame::{Frame, apply_jetty, generate_frame};
 use super::furnish::{decorate_rooftops, furnish_rooms};
+use super::exterior::decorate_exterior_walls;
 use super::{BuildingContext, Culture};
 use super::roof::RoofStyle;
 use super::roof::gable::GablePitch;
@@ -188,6 +189,10 @@ pub async fn build_house(
     if matches!(roof_style, RoofStyle::Flat) {
         decorate_rooftops(ctx, &frame, roof_ladder_wall).await;
     }
+
+    // A few sparse props against the outside walls (barrels, pots, …) so the
+    // house reads as lived-in. Skips doors, roads, and claimed cells.
+    decorate_exterior_walls(ctx, &footprint, &wall_segs).await;
 
     check_building_invariants(&frame, &room_plan, &floor_plan)?;
 

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -70,6 +70,9 @@ pub struct HouseOutput {
     pub floor_plan: FloorPlan,
     pub room_plan: RoomPlan,
     pub door_ramps: Vec<DoorRamp>,
+    /// Exterior entrance cell per ground-floor door (bottom of the ramp if any,
+    /// else the cell outside the door). Used to start door→road connectors.
+    pub door_entrances: Vec<Point2D>,
     pub has_attic: bool,
     pub has_cellar: bool,
     /// Cellar descending-stair cells (position 0 is the cellar landing), if a
@@ -176,6 +179,9 @@ pub async fn build_house(
     // Reconcile doors with terrain: run parallel stair ramps along the wall
     // for doors where `base_y` doesn't match outside-terrain.
     let door_ramps = plan_door_ramps_from_world(&wall_segs, &footprint, ctx.editor.world());
+    // Save the real exterior entrance per door (bottom of the ramp, if any) for
+    // the settlement's door→road connectors.
+    let door_entrances = super::door_ramp::door_entrances(&wall_segs, &door_ramps);
     place_door_ramps(ctx, &door_ramps).await;
 
     assign_room_floors(&mut room_plan);
@@ -217,6 +223,7 @@ pub async fn build_house(
         floor_plan,
         room_plan,
         door_ramps,
+        door_entrances,
         has_attic,
         has_cellar,
         cellar_stair,

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -1684,6 +1684,24 @@ mod tests {
         }
         println!("Paved {} verge cells (arterial {} + collector {})", verge_total, tier_verge[0].len(), tier_verge[1].len());
 
+        // Street lighting: run last, after houses have claimed their cells, so
+        // lamps line every road's verge without landing on a building. The city
+        // generator picks the lantern type city-wide.
+        let city_rect = editor.world().world_rect_2d();
+        let city_centre = (city_rect.origin + city_rect.max()) / 2;
+        let cold = {
+            let n = editor.world().get_surface_biome_at(city_centre);
+            let n = n.name();
+            n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
+        };
+        let street_lantern: crate::minecraft::Block = if cold {
+            "minecraft:soul_lantern".into()
+        } else {
+            "minecraft:lantern".into()
+        };
+        let lamps = crate::generator::paths::place_street_lights(&editor, &all_paths, &street_lantern).await;
+        println!("Placed {} street lamps", lamps.len());
+
         editor.flush_buffer().await;
     }
 }

--- a/src/generator/paths/building.rs
+++ b/src/generator/paths/building.rs
@@ -13,7 +13,7 @@ use crate::{editor::Editor, generator::{BuildClaim, data::LoadedData, materials:
 /// magenta = a cell the paver skipped because a claim (building/wall) blocks
 /// it. Markers sit `DEBUG_MARKER_HEIGHT` above the road surface so the network
 /// is readable from the air even where roofs cover the streets.
-pub const DEBUG_ROAD_MARKERS: bool = true;
+pub const DEBUG_ROAD_MARKERS: bool = false;
 const DEBUG_MARKER_HEIGHT: i32 = 20;
 
 /// How a paved cell must treat the claim already on it.

--- a/src/generator/paths/connect.rs
+++ b/src/generator/paths/connect.rs
@@ -1,0 +1,95 @@
+//! Door-to-road connectors.
+//!
+//! For each building door that isn't already on or beside a road, A* a narrow
+//! footpath from the door out to the nearest road cell and pave it with the road
+//! material. Run *after* all roads and buildings are placed, so the goal network
+//! is complete and the route can steer around every footprint.
+
+use std::collections::HashSet;
+
+use crate::editor::Editor;
+use crate::generator::data::LoadedData;
+use crate::generator::materials::MaterialId;
+use crate::geometry::Point2D;
+use crate::noise::RNG;
+
+use super::building::build_path;
+use super::path::PathPriority;
+use super::routing::{get_path_with, RouteContext, RouteParams};
+
+/// Don't bother routing a connector longer than this (Manhattan) — a door that
+/// far from any road is almost certainly an interior/odd case.
+const MAX_CONNECTOR: i32 = 40;
+
+/// Pave a 1-wide path from every disconnected door to the nearest road.
+///
+/// `doors` are the ground cells just outside each door. A door is skipped when
+/// it (or a cardinal neighbour) already sits on a road. `region` confines the
+/// route to the urban area, `blocked` are cells the route must avoid (building /
+/// wall footprints), and `road_cells` are both the goal and the stop condition.
+pub async fn connect_doors_to_roads(
+    editor: &Editor,
+    data: &LoadedData,
+    doors: &[Point2D],
+    region: &HashSet<Point2D>,
+    road_cells: &HashSet<Point2D>,
+    blocked: &HashSet<Point2D>,
+    material: MaterialId,
+    rng: &mut RNG,
+) -> usize {
+    if road_cells.is_empty() {
+        return 0;
+    }
+
+    let mut paved = 0usize;
+    for &door in doors {
+        // Already connected? On a road, or one cell from one.
+        if road_cells.contains(&door)
+            || door.neighbours().iter().any(|n| road_cells.contains(n))
+        {
+            continue;
+        }
+
+        // Nearest road cell.
+        let Some(&goal) = road_cells.iter().min_by_key(|r| r.distance_squared(&door)) else {
+            continue;
+        };
+        if door.distance_manhattan(&goal) > MAX_CONNECTOR {
+            continue;
+        }
+
+        let start = editor.world().add_height(door);
+        let end = editor.world().add_height(goal);
+
+        // Route a Low-priority (width-1) path that stays in the urban area,
+        // dodges building/wall footprints, and ends the moment it touches a road.
+        let routed = {
+            let ctx = RouteContext {
+                region: Some(region),
+                road_cells: None,
+                road_height: None,
+                goal_cells: Some(road_cells),
+                wall_dist: None,
+                blocked: Some(blocked),
+            };
+            get_path_with(
+                editor,
+                start,
+                end,
+                PathPriority::Low,
+                material.clone(),
+                RouteParams::default(),
+                ctx,
+                async |_| {},
+            )
+            .await
+        };
+
+        if let Some(path) = routed {
+            build_path(editor, data, &path, rng).await;
+            paved += 1;
+        }
+    }
+
+    paved
+}

--- a/src/generator/paths/lights.rs
+++ b/src/generator/paths/lights.rs
@@ -1,0 +1,170 @@
+//! Street lighting for the road network.
+//!
+//! Posts a fence-and-lantern lamp on the verge beside every road — arterials,
+//! collectors, and alleys — spaced evenly by arc length and staggered side to
+//! side. Run *after* [`build_paths_merged`](super::build_paths_merged) so the
+//! pavement is already down and we only have to step just off its edge.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::editor::Editor;
+use crate::generator::BuildClaim;
+use crate::geometry::{get_surrounding_set, Point2D, Point3D, DOWN, UP};
+use crate::minecraft::Block;
+
+use super::path::Path;
+
+/// Arc-length distance between consecutive lamps along a road. Lamps alternate
+/// sides each interval, so a single side sees a lamp roughly every `2 * SPACING`.
+const SPACING: f64 = 7.0;
+
+/// Two lamps closer than this (squared XZ distance) are treated as the same
+/// spot — kills clustering where paths overlap or merge at junctions.
+const MIN_GAP_SQ: i32 = 16; // 4 blocks
+
+/// Fence blocks in the vertical post (heights `ground..ground + POST_FENCES`).
+/// An arm fence sits on top reaching toward the road, with the lantern hung
+/// beneath it.
+const POST_FENCES: i32 = 5;
+
+/// Place street lights beside every road in `paths`.
+///
+/// Walks each centreline by arc length, drops an anchor every [`SPACING`]
+/// blocks, steps perpendicular off the pavement onto the verge (alternating
+/// side each anchor), and stands a fence-post lamp there. Candidates that
+/// land on pavement, water, out of bounds, on a claimed cell, or too close to
+/// an existing lamp are skipped (the opposite side is tried first).
+///
+/// `lantern` is the lamp block chosen city-wide by the caller (e.g.
+/// `minecraft:lantern`, or `minecraft:soul_lantern` for a cold settlement); it
+/// is hung beneath the arm, so any state on it is replaced with `hanging=true`.
+///
+/// Returns the verge cells where lamps were stood (their base, at ground). The
+/// caller can claim them; placement here mirrors [`build_paths_merged`](super::build_paths_merged),
+/// which also leaves claiming to the caller.
+pub async fn place_street_lights(editor: &Editor, paths: &[Path], lantern: &Block) -> Vec<Point2D> {
+    // Light every road tier — arterials, collectors, and alleys.
+    let lit: Vec<&Path> = paths.iter().collect();
+    if lit.is_empty() {
+        return Vec::new();
+    }
+
+    // The full paved set across the lit roads, so a candidate can be tested for
+    // "is this still road?" — built exactly like the paving widen pass.
+    let paved = paved_cells(&lit);
+
+    let mut placed: Vec<Point2D> = Vec::new();
+    let mut anchor_index: u32 = 0;
+
+    for path in &lit {
+        let pts = path.points();
+        if pts.len() < 2 {
+            continue;
+        }
+        // Offset that clears the pavement: the widen pass reaches `width - 1`
+        // cells out from the centreline (4-connected), so `width` is one past.
+        let offset = path.width().max(1) as i32;
+
+        let mut dist_acc = 0.0_f64;
+        for i in 1..pts.len() {
+            let prev = pts[i - 1].drop_y();
+            let curr = pts[i].drop_y();
+            dist_acc += prev.distance(&curr);
+
+            while dist_acc >= SPACING {
+                dist_acc -= SPACING;
+
+                // Perpendicular to travel, reduced to a clean cardinal so the
+                // lamp offsets squarely off the road rather than diagonally.
+                let delta = curr - prev;
+                let perp = if delta.x.abs() >= delta.y.abs() {
+                    Point2D::new(0, 1)
+                } else {
+                    Point2D::new(1, 0)
+                };
+
+                // Alternate which side we try first; fall back to the other.
+                let primary = if anchor_index % 2 == 0 { 1 } else { -1 };
+                anchor_index += 1;
+
+                for side in [primary, -primary] {
+                    let cell = curr + perp * (offset * side);
+                    if is_valid_spot(editor, cell, &paved, &placed) {
+                        // Step from the verge back toward the road; the arm and
+                        // lantern lean out over the street along this direction.
+                        let toward_road = perp * (-side);
+                        place_lamp(editor, cell, toward_road, lantern).await;
+                        placed.push(cell);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    placed
+}
+
+/// The widened paved footprint of `paths`, mirroring the shoulder pass in
+/// [`build_paths_merged`](super::build_paths_merged).
+fn paved_cells(paths: &[&Path]) -> HashSet<Point2D> {
+    let mut paved: HashSet<Point2D> = HashSet::new();
+    for path in paths {
+        let centre: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
+        paved.extend(get_surrounding_set(&centre, path.width().saturating_sub(1)));
+        paved.extend(centre);
+    }
+    paved
+}
+
+/// A verge cell is a good lamp spot if it is in bounds, off the pavement, on
+/// unclaimed natural ground (not water), and not crowding another lamp.
+fn is_valid_spot(
+    editor: &Editor,
+    cell: Point2D,
+    paved: &HashSet<Point2D>,
+    placed: &[Point2D],
+) -> bool {
+    let world = editor.world();
+    if !world.is_in_bounds_2d(cell) || paved.contains(&cell) {
+        return false;
+    }
+    // Only stand a lamp on open ground — never on a building, structure, wall,
+    // gate, or another path's claim.
+    if !matches!(
+        world.get_claim(cell),
+        Some(BuildClaim::None | BuildClaim::Nature)
+    ) {
+        return false;
+    }
+    if world.is_water(cell) {
+        return false;
+    }
+    placed.iter().all(|p| p.distance_squared(&cell) >= MIN_GAP_SQ)
+}
+
+/// Stand a lamp on the verge: a fence post, an arm fence reaching one block
+/// toward the road at the post's top, and `lantern` hung beneath that arm so the
+/// light leans out over the street. `toward_road` is a unit step from the verge
+/// cell back toward the centreline.
+async fn place_lamp(editor: &Editor, cell: Point2D, toward_road: Point2D, lantern: &Block) {
+    let ground = editor.world().add_height(cell);
+    let fence: Block = "minecraft:oak_fence".into();
+
+    // Vertical post.
+    for h in 0..POST_FENCES {
+        editor.place_block_forced(&fence, ground + UP * h).await;
+    }
+
+    // Arm fence one block toward the road, level with the post's top.
+    let top = ground.y + POST_FENCES - 1;
+    let arm = Point3D::new(cell.x + toward_road.x, top, cell.y + toward_road.y);
+    editor.place_block_forced(&fence, arm).await;
+
+    // Lantern hung beneath the arm — force `hanging=true` regardless of the
+    // caller's block state.
+    let mut state = HashMap::new();
+    state.insert("hanging".to_string(), "true".to_string());
+    let hung = Block::new(lantern.id.clone(), Some(state), None);
+    editor.place_block_forced(&hung, arm + DOWN).await;
+}

--- a/src/generator/paths/lights.rs
+++ b/src/generator/paths/lights.rs
@@ -16,7 +16,7 @@ use super::path::Path;
 
 /// Arc-length distance between consecutive lamps along a road. Lamps alternate
 /// sides each interval, so a single side sees a lamp roughly every `2 * SPACING`.
-const SPACING: f64 = 7.0;
+const SPACING: f64 = 10.0;
 
 /// Two lamps closer than this (squared XZ distance) are treated as the same
 /// spot — kills clustering where paths overlap or merge at junctions.

--- a/src/generator/paths/mod.rs
+++ b/src/generator/paths/mod.rs
@@ -3,11 +3,13 @@ mod test;
 mod routing;
 mod path;
 mod building;
+mod connect;
 mod lights;
 pub mod network;
 
 pub use a_star::a_star;
 pub use building::{build_path, build_paths_merged};
+pub use connect::connect_doors_to_roads;
 pub use lights::place_street_lights;
 pub use network::{build_road_network, find_blocks};
 pub use path::{Path, PathPriority, PathType};

--- a/src/generator/paths/mod.rs
+++ b/src/generator/paths/mod.rs
@@ -3,10 +3,12 @@ mod test;
 mod routing;
 mod path;
 mod building;
+mod lights;
 pub mod network;
 
 pub use a_star::a_star;
 pub use building::{build_path, build_paths_merged};
+pub use lights::place_street_lights;
 pub use network::{build_road_network, find_blocks};
 pub use path::{Path, PathPriority, PathType};
 pub use routing::{get_path, get_path_with, route_path, route_path_with, RouteContext, RouteParams};

--- a/src/generator/paths/test.rs
+++ b/src/generator/paths/test.rs
@@ -93,4 +93,83 @@ mod tests {
 
         editor.flush_buffer().await;
     }
+
+    /// Offline: lamps land just off the pavement, evenly spaced and staggered to
+    /// both sides of a straight arterial.
+    #[tokio::test]
+    async fn street_lights_line_the_verge_offline() {
+        use crate::editor::World;
+        use crate::generator::materials::MaterialId;
+        use crate::generator::paths::{place_street_lights, Path, PathPriority};
+        use crate::geometry::Rect3D;
+
+        let build_area = Rect3D::from_points(Point3D::new(0, 0, 0), Point3D::new(255, 127, 255));
+        let world = World::synthetic(build_area, 64);
+        let editor = world.get_offline_editor();
+
+        // Straight east-west arterial, width 3, along z = 32 from x=10..=60.
+        let width = 3u32;
+        let z = 32;
+        let pts: Vec<Point3D> = (10..=60).map(|x| Point3D::new(x, 64, z)).collect();
+        let road = Path::new(pts, width, MaterialId::new("cobblestone".to_string()), PathPriority::High);
+
+        let lantern: crate::minecraft::Block = "minecraft:lantern".into();
+        let lamps = place_street_lights(&editor, &[road], &lantern).await;
+
+        // A 50-long road at spacing 7 should give a handful of lamps.
+        assert!(lamps.len() >= 5, "expected several lamps, got {}", lamps.len());
+
+        let paved_half = (width - 1) as i32; // widen reach from the centreline
+        let mut saw_north = false;
+        let mut saw_south = false;
+        for lamp in &lamps {
+            // Off the pavement: perpendicular offset clears the widened shoulder.
+            let perp = (lamp.y - z).abs();
+            assert!(
+                perp > paved_half,
+                "lamp at {:?} sits on the pavement (perp {} <= {})",
+                lamp, perp, paved_half
+            );
+            // Beside the road, not wandered off down its length.
+            assert!(lamp.x >= 10 && lamp.x <= 60, "lamp at {:?} off the road span", lamp);
+            if lamp.y < z { saw_north = true; }
+            if lamp.y > z { saw_south = true; }
+        }
+        assert!(saw_north && saw_south, "lamps should stagger to both sides");
+
+        // No two lamps crowd each other.
+        for (i, a) in lamps.iter().enumerate() {
+            for b in &lamps[i + 1..] {
+                assert!(
+                    a.distance_squared(b) >= 16,
+                    "lamps {:?} and {:?} are too close", a, b
+                );
+            }
+        }
+    }
+
+    /// Offline: alley-tier (Low priority, width 1) roads are lit too.
+    #[tokio::test]
+    async fn street_lights_light_alleys_offline() {
+        use crate::editor::World;
+        use crate::generator::materials::MaterialId;
+        use crate::generator::paths::{place_street_lights, Path, PathPriority};
+        use crate::geometry::Rect3D;
+
+        let build_area = Rect3D::from_points(Point3D::new(0, 0, 0), Point3D::new(255, 127, 255));
+        let world = World::synthetic(build_area, 64);
+        let editor = world.get_offline_editor();
+
+        let pts: Vec<Point3D> = (10..=60).map(|x| Point3D::new(x, 64, 32)).collect();
+        let alley = Path::new(pts, 1, MaterialId::new("cobblestone".to_string()), PathPriority::Low);
+
+        let lantern: crate::minecraft::Block = "minecraft:lantern".into();
+        let lamps = place_street_lights(&editor, &[alley], &lantern).await;
+        assert!(!lamps.is_empty(), "alleys should be lit");
+        // A width-1 alley pavement is just the centreline (z=32); lamps sit one
+        // cell off it.
+        for lamp in &lamps {
+            assert!((lamp.y - 32).abs() >= 1, "lamp at {:?} on the alley centreline", lamp);
+        }
+    }
 }

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -687,14 +687,9 @@ mod tests {
         // Road-label viz: each named road (stroke) gets a wool colour, floated
         // two blocks above the debug tier markers. Segments grouped into one road
         // share a colour, so a long avenue reads as one ribbon even where side
-        // streets branch. Alleys (no road_id) are unlabelled.
-        const WOOL_COLORS: [&str; 16] = [
-            "white_wool", "orange_wool", "magenta_wool", "light_blue_wool",
-            "yellow_wool", "lime_wool", "pink_wool", "gray_wool",
-            "light_gray_wool", "cyan_wool", "purple_wool", "blue_wool",
-            "brown_wool", "green_wool", "red_wool", "black_wool",
-        ];
-        const LABEL_HEIGHT: i32 = 22; // debug tier markers sit at +20.
+        // streets branch. Alleys (no road_id) are unlabelled. The `label` map is
+        // computed unconditionally because the SVG town map below reuses it; only
+        // the in-world wool placement is gated.
         // One label per cell so roads sharing pavement (a collector merged onto an
         // arterial) don't braid two colors over one street: the higher tier wins
         // the shared cells, and a road only shows its own colour where it diverges.
@@ -731,13 +726,25 @@ mod tests {
                 }
             }
         }
-        let mut named_roads: HashSet<u32> = HashSet::new();
-        for (c, (_, _, rid, y)) in &label {
-            named_roads.insert(*rid);
-            let wool: Block = WOOL_COLORS[*rid as usize % WOOL_COLORS.len()].into();
-            editor.place_block_forced(&wool, Point3D::new(c.x, y + LABEL_HEIGHT, c.y)).await;
+        // In-world wool ribbons — disabled for now. Flip `DEBUG_ROAD_WOOL` to
+        // restore them; the SVG town map is unaffected either way.
+        const DEBUG_ROAD_WOOL: bool = false;
+        if DEBUG_ROAD_WOOL {
+            const WOOL_COLORS: [&str; 16] = [
+                "white_wool", "orange_wool", "magenta_wool", "light_blue_wool",
+                "yellow_wool", "lime_wool", "pink_wool", "gray_wool",
+                "light_gray_wool", "cyan_wool", "purple_wool", "blue_wool",
+                "brown_wool", "green_wool", "red_wool", "black_wool",
+            ];
+            const LABEL_HEIGHT: i32 = 22; // debug tier markers sit at +20.
+            let mut named_roads: HashSet<u32> = HashSet::new();
+            for (c, (_, _, rid, y)) in &label {
+                named_roads.insert(*rid);
+                let wool: Block = WOOL_COLORS[*rid as usize % WOOL_COLORS.len()].into();
+                editor.place_block_forced(&wool, Point3D::new(c.x, y + LABEL_HEIGHT, c.y)).await;
+            }
+            println!("Labelled {} named roads", named_roads.len());
         }
-        println!("Labelled {} named roads", named_roads.len());
 
         // ---- Phase 4: hierarchical house placement ----
         // Per lot, walk frontage densest-tier first: arterial → collector →
@@ -1147,6 +1154,24 @@ mod tests {
                 Err(e) => println!("Failed to write town.svg: {}", e),
             }
         }
+
+        // Street lighting: run last, after houses have claimed their cells, so
+        // lamps line every road's verge without landing on a building. The city
+        // generator picks the lantern type city-wide.
+        let city_rect = editor.world().world_rect_2d();
+        let city_centre = (city_rect.origin + city_rect.max()) / 2;
+        let cold = {
+            let n = editor.world().get_surface_biome_at(city_centre);
+            let n = n.name();
+            n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
+        };
+        let street_lantern: crate::minecraft::Block = if cold {
+            "minecraft:soul_lantern".into()
+        } else {
+            "minecraft:lantern".into()
+        };
+        let lamps = crate::generator::paths::place_street_lights(&editor, &all_paths, &street_lantern).await;
+        println!("Placed {} street lamps", lamps.len());
 
         editor.flush_buffer().await;
 

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -194,7 +194,9 @@ mod tests {
 
         // Flatten, then route the tiered network over the gentled terrain.
         let urban = editor.world().get_urban_points();
-        flatten_urban_area(&mut editor, &urban, 16, 12, true).await;
+        // skip_water = false: terraform through any water in the urban area and
+        // clear leftover puddles, so the settlement isn't dotted with water.
+        flatten_urban_area(&mut editor, &urban, 16, 12, false).await;
 
         // --- Place the industrial buildings FIRST, on good flattened ground. With
         // no roads yet, `road_bonus` is 0 — these big buildings are sited by
@@ -344,7 +346,9 @@ mod tests {
         let urban = editor.world().get_urban_points();
 
         log_trees(&mut editor, urban.clone()).await;
-        flatten_urban_area(&mut editor, &urban, 16, 12, true).await;
+        // skip_water = false: terraform through any water in the urban area and
+        // clear leftover puddles, so the settlement isn't dotted with water.
+        flatten_urban_area(&mut editor, &urban, 16, 12, false).await;
 
         let data = LoadedData::load().expect("Failed to load generator data");
         // Wall + gates — gates seed the collector tier of the network.

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -485,7 +485,8 @@ mod tests {
         // Phase 2 — tiered A* road network, connecting the industrial buildings
         // (anchor nodes) and routed around them (the `blocked` barrier). One
         // material for every tier — tiers differ by width, not surface block.
-        let road_material = MaterialId::new("cobblestone".to_string());
+        // Desert settlement: sandstone-paved roads.
+        let road_material = MaterialId::new("sandstone".to_string());
         let road_network = build_road_network(
             &editor, road_material.clone(), road_material, true, &ind_nodes, &blocked, 1,
         ).await;
@@ -991,8 +992,8 @@ mod tests {
         // shoulder. Painted at the live ground top (h-1), matching the
         // post-flatten/foundation surface. One material for every tier.
         let verge_blocks = [
-            Block { id: "cobblestone".into(), data: None, state: None },
-            Block { id: "cobblestone".into(), data: None, state: None },
+            Block { id: "sandstone".into(), data: None, state: None },
+            Block { id: "sandstone".into(), data: None, state: None },
         ];
         let mut verge_total = 0usize;
         for (ti, cells) in tier_verge.iter().enumerate() {
@@ -1029,7 +1030,7 @@ mod tests {
             alley_band.len(), connectors.len(), full_alleys.len(),
         );
         let alley_pts: Vec<Point3D> = full_alleys.iter().map(|c| editor.world().add_height(*c)).collect();
-        let alley_path = Path::new(alley_pts, 1, MaterialId::new("cobblestone".to_string()), PathPriority::Low);
+        let alley_path = Path::new(alley_pts, 1, MaterialId::new("sandstone".to_string()), PathPriority::Low);
         build_paths_merged(&editor, &data, &[alley_path], &mut rng).await;
         for c in &full_alleys {
             editor.world_mut().claim(*c, crate::generator::BuildClaim::Path(crate::generator::paths::PathType::Pavement));

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -813,6 +813,8 @@ mod tests {
         // placement and checked for a road-slab lip afterward (we can't touch
         // `editor` inside the loop; it's borrowed by the build context).
         let mut door_thresholds: Vec<Point3D> = Vec::new();
+        // Ground-floor door exterior cells, for door->road connector paths.
+        let mut door_cells: Vec<P2> = Vec::new();
         for lot in &sub_blocks {
             if lot.is_empty() { continue; }
             let Some(mut plot) = plot_from_block(lot) else { continue; };
@@ -902,10 +904,22 @@ mod tests {
                         bctx.base_y_override = base_lvl;
                         let mut bctx_editor = BuildCtx::new(&mut editor, &data, &palette, &mut rng);
                         match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
-                            Ok(_) => {
+                            Ok(out) => {
                                 plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
                                 total_buildings += 1;
                                 tier_placed[ti] += 1;
+                                // Collect ground-floor door exterior cells (one
+                                // out from the door) for door->road connectors.
+                                for (seg, opening) in out.wall_segs.doors() {
+                                    if seg.floor != 0 { continue; }
+                                    let cells = crate::generator::buildings_v2::walls::segment_cells(seg);
+                                    let out_dir: P2 = seg.facing.into();
+                                    for dx in 0..opening.width {
+                                        if let Some(&c) = cells.get((opening.offset + dx) as usize) {
+                                            door_cells.push(c + out_dir);
+                                        }
+                                    }
+                                }
                                 // Collect door-threshold cells: the strip just outside
                                 // the house's road-facing wall at floor level, where a
                                 // road slab leaves a half-block lip in the doorway. We
@@ -1051,6 +1065,21 @@ mod tests {
             .filter(|c| urban.contains(c))
             .collect();
         let road_pct = 100.0 * road_cells.len() as f32 / urban.len().max(1) as f32;
+
+        // Door->road connectors: any door not already on/beside a road gets a
+        // 1-wide sandstone path A*'d to the nearest road, routed around buildings.
+        let blocked_for_paths: HashSet<P2> = urban.iter().copied().filter(|&c| matches!(
+            editor.world().get_claim(c),
+            Some(crate::generator::BuildClaim::Building(_)
+                | crate::generator::BuildClaim::Wall
+                | crate::generator::BuildClaim::Structure(_)
+                | crate::generator::BuildClaim::Gate)
+        )).collect();
+        let connected = crate::generator::paths::connect_doors_to_roads(
+            &editor, &data, &door_cells, &urban, &road_cells, &blocked_for_paths,
+            MaterialId::new("sandstone".to_string()), &mut rng,
+        ).await;
+        println!("Connected {} doors to roads", connected);
         println!(
             "SUMMARY: {} industrial + {} rural resource buildings, {} houses | \
              road surface {} / {} urban cells ({:.1}%)",

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -908,18 +908,9 @@ mod tests {
                                 plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
                                 total_buildings += 1;
                                 tier_placed[ti] += 1;
-                                // Collect ground-floor door exterior cells (one
-                                // out from the door) for door->road connectors.
-                                for (seg, opening) in out.wall_segs.doors() {
-                                    if seg.floor != 0 { continue; }
-                                    let cells = crate::generator::buildings_v2::walls::segment_cells(seg);
-                                    let out_dir: P2 = seg.facing.into();
-                                    for dx in 0..opening.width {
-                                        if let Some(&c) = cells.get((opening.offset + dx) as usize) {
-                                            door_cells.push(c + out_dir);
-                                        }
-                                    }
-                                }
+                                // Real door entrances (bottom of ramp, if any),
+                                // saved by the pipeline, for door->road connectors.
+                                door_cells.extend(out.door_entrances.iter().copied());
                                 // Collect door-threshold cells: the strip just outside
                                 // the house's road-facing wall at floor level, where a
                                 // road slab leaves a half-block lip in the doorway. We

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -1066,6 +1066,10 @@ mod tests {
                 | crate::generator::BuildClaim::Structure(_)
                 | crate::generator::BuildClaim::Gate)
         )).collect();
+        let already: usize = door_cells.iter().filter(|&&d| {
+            road_cells.contains(&d) || d.neighbours().iter().any(|n| road_cells.contains(n))
+        }).count();
+        println!("Door entrances: {} ({} already on/beside a road)", door_cells.len(), already);
         let connected = crate::generator::paths::connect_doors_to_roads(
             &editor, &data, &door_cells, &urban, &road_cells, &blocked_for_paths,
             MaterialId::new("sandstone".to_string()), &mut rng,

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -138,12 +138,18 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
         }
 
         // Keep the terraformed cap in the natural surface material: grass stays
-        // grass, sand stays sand, stone stays stone. Only genuinely grassy
-        // ground gets a dirt body under a grass cap; every other surface is
-        // capped with itself, so we never paint foreign grass over rock or sand.
-        // Gravity surfaces (sand/gravel) get a SOLID subsurface (sandstone/
-        // stone) so the cap has a base and can't fall. Snow is re-laid on top.
-        let surface = editor.world().get_ground_block(xz).clone();
+        // grass, sand stays sand, stone stays stone. Gravity surfaces (sand/
+        // gravel) get a SOLID subsurface (sandstone/stone) so the cap has a base
+        // and can't fall. Snow is re-laid on top.
+        //
+        // Sample the real surface block at `terrain_y - 1` (the top solid),
+        // NOT `get_ground_block` — that reads `ground_block_map` at the
+        // first-air heightmap value, i.e. the block ABOVE the surface (air),
+        // which would mis-detect every surface and cap with air (a 1-deep hole).
+        let surface = editor
+            .world()
+            .get_block(point.with_y(terrain_y - 1))
+            .unwrap_or_else(|| Block::from_id("minecraft:dirt".into()));
         let (fill, top) = terraform_layers(&surface);
         let is_snow = surface.id.as_str().contains("snow");
 

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -81,6 +81,34 @@ fn boundary_distance(cells: &HashSet<Point2D>) -> HashMap<Point2D, i32> {
     dist
 }
 
+/// Choose the (subsurface fill, surface cap) blocks for terraforming a column,
+/// given the natural surface block. Grassy ground gets a dirt body + grass cap.
+/// Gravity surfaces (sand, red sand, gravel) get a SOLID rock body (sandstone /
+/// red sandstone / stone) under the loose cap, so the single top layer rests on
+/// a base and can't fall — and it matches real desert geology (sand on
+/// sandstone). Everything else (stone, terracotta, …) is stable and is filled
+/// and capped with itself. Snow folds into the grassy case; callers re-lay the
+/// snow layer on top.
+pub fn terraform_layers(surface: &Block) -> (Block, Block) {
+    let s = surface.id.as_str();
+    if s.contains("snow")
+        || s.contains("grass_block")
+        || s.contains("dirt")
+        || s.contains("podzol")
+        || s.contains("mycelium")
+    {
+        (Block::from_id("minecraft:dirt".into()), Block::from_id("minecraft:grass_block".into()))
+    } else if s.contains("red_sand") && !s.contains("sandstone") {
+        (Block::from_id("minecraft:red_sandstone".into()), surface.clone())
+    } else if s.contains("sand") && !s.contains("sandstone") {
+        (Block::from_id("minecraft:sandstone".into()), surface.clone())
+    } else if s.contains("gravel") {
+        (Block::from_id("minecraft:stone".into()), surface.clone())
+    } else {
+        (surface.clone(), surface.clone())
+    }
+}
+
 pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_water : bool) {
     // Only the points we actually terraform may be written back to the
     // heightmap. Asserting heights for skipped water cells would make the map
@@ -111,21 +139,13 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
 
         // Keep the terraformed cap in the natural surface material: grass stays
         // grass, sand stays sand, stone stays stone. Only genuinely grassy
-        // ground gets a dirt body under a grass cap; every other surface (sand,
-        // stone, gravel, terracotta, …) is filled and capped with itself, so we
-        // never paint foreign grass over rock or sand. Snow is re-laid on top.
+        // ground gets a dirt body under a grass cap; every other surface is
+        // capped with itself, so we never paint foreign grass over rock or sand.
+        // Gravity surfaces (sand/gravel) get a SOLID subsurface (sandstone/
+        // stone) so the cap has a base and can't fall. Snow is re-laid on top.
         let surface = editor.world().get_ground_block(xz).clone();
-        let s = surface.id.as_str();
-        let is_snow = s.contains("snow");
-        let is_grassy = s.contains("grass_block")
-            || s.contains("dirt")
-            || s.contains("podzol")
-            || s.contains("mycelium");
-        let (fill, top) = if is_grassy || is_snow {
-            (Block::from_id("minecraft:dirt".into()), Block::from_id("minecraft:grass_block".into()))
-        } else {
-            (surface.clone(), surface.clone())
-        };
+        let (fill, top) = terraform_layers(&surface);
+        let is_snow = surface.id.as_str().contains("snow");
 
         if target_y > terrain_y {
             // Raise: subsurface fill from the old surface up to the new top.

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -171,6 +171,22 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
         if is_snow {
             editor.place_block_forced(&surface, point.with_y(target_y)).await;
         }
+
+        // When we're terraforming through water (skip_water = false, e.g. the
+        // city flatten), clear any water still standing above the new surface so
+        // the settlement has no awkward leftover puddles. Scan up from the
+        // surface until the water stops.
+        if !skip_water {
+            let mut y = target_y;
+            while editor
+                .world()
+                .get_block(point.with_y(y))
+                .is_some_and(|b| b.id.is_water())
+            {
+                editor.place_block_forced(&"air".into(), point.with_y(y)).await;
+                y += 1;
+            }
+        }
     }
 
     editor.world_mut().set_heights(&updated);

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -109,20 +109,22 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
             continue;
         }
 
-        // Material choice mirrors foundation `blend_terrain`: dirt+grass for
-        // normal ground, sand for sandy ground, snow re-capped on top. We sample
-        // the ground block only to *detect* the surface type — the placed top is
-        // a literal block, since the sampled cell isn't reliably solid.
+        // Keep the terraformed cap in the natural surface material: grass stays
+        // grass, sand stays sand, stone stays stone. Only genuinely grassy
+        // ground gets a dirt body under a grass cap; every other surface (sand,
+        // stone, gravel, terracotta, …) is filled and capped with itself, so we
+        // never paint foreign grass over rock or sand. Snow is re-laid on top.
         let surface = editor.world().get_ground_block(xz).clone();
-        let is_snow = surface.id.as_str().contains("snow");
-        let is_sandy = {
-            let s = surface.id.as_str();
-            s.contains("sand") || s.contains("sandstone")
-        };
-        let (fill, top) = if is_sandy {
-            (Block::from_id("minecraft:sand".into()), Block::from_id("minecraft:sand".into()))
-        } else {
+        let s = surface.id.as_str();
+        let is_snow = s.contains("snow");
+        let is_grassy = s.contains("grass_block")
+            || s.contains("dirt")
+            || s.contains("podzol")
+            || s.contains("mycelium");
+        let (fill, top) = if is_grassy || is_snow {
             (Block::from_id("minecraft:dirt".into()), Block::from_id("minecraft:grass_block".into()))
+        } else {
+            (surface.clone(), surface.clone())
         };
 
         if target_y > terrain_y {


### PR DESCRIPTION
Adds a layer of decoration to generated settlements (focused on the Desert culture) and fixes several terraform bugs surfaced along the way.

## Features

**Street lights** (`paths/lights.rs`)
- `place_street_lights` posts a fence-pole lamp with an arm + hanging lantern on the verge beside every road, arc-length spaced (~10 blocks) and staggered side to side. City generator passes the lantern type.

**Rooftop terraces** (`furnish/roof.rs`)
- Flat (desert) roof decks are furnished as living spaces, reusing the interior furnish engine via an extracted `furnish_interior` (parapet acts as the wall, ladder exit kept clear).
- One of **six random themes per building** — lounge, garden, kitchen, workshop, storage, sleeping — each with its own item pool. ~1/3 of roofs left bare for variety; per-building random fabric colour.
- Rich prop set: canopy/parasol/awning/pergola shades, bedrolls, hammock, brazier, chimney, tandoor, water trough, jars/amphora, planters, palm, cactus, loom, grindstone, and more.

**Exterior wall props** (`buildings_v2/exterior.rs`)
- A few sparse household props (barrels, pots, planters, firewood, cauldrons — 12-item set) against the outside walls. ~1–2 per house, skips doors/roads/claimed cells, claims placed cells so nothing overwrites them.

**Door → road connectors** (`paths/connect.rs`)
- A\* a 1-wide path from each door's real entrance to the nearest road, routed around buildings, only when not already connected.
- Door entrances are saved authoritatively (`door_ramp::door_entrances`) — bottom of the ramp if the door has one, else the landing — surfaced on `HouseOutput`.

**Desert roads** — sandstone-paved roads, verges, and alleys.

## Terraform fixes
- **Preserve the natural surface** instead of always capping grass: sand→sand, stone→stone, grass→grass.
- **Off-by-one fix** (`terraforming.rs`): terraform sampled `ground_block_map` at the first-air heightmap value (the block *above* the surface = air), capping holes / mis-detecting material. Now samples the real top-solid block at `terrain_y - 1`.
- **Sand-on-sandstone**: gravity surfaces (sand/gravel) get a solid subsurface so the cap can't fall.
- **Clear leftover water** from the city when terraforming through it.

## Notes
- Compiles; offline tests pass (`pipeline_invariants_property_test`, `build_furnished_houses_offline`, street-light tests). Server-dependent visuals (props, connectors, water clearing) verified via the desert `full_settlement_pipeline` run where possible.
- The `get_ground_block` off-by-one is worked around in terraform only (shared map left as-is to avoid disturbing `is_water`/classification) — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)