### PR TITLE
Medieval town generation via buildings_v2 + decorations

### DIFF
--- a/data/furniture/items/shelves.yaml
+++ b/data/furniture/items/shelves.yaml
@@ -1,0 +1,89 @@
+# Display shelves — wall-mounted minecraft:*_shelf blocks (1.21.9+) that show
+# up to 3 thematic items to telegraph a room's purpose. Modelled like the wall
+# banner: a single block one above the floor (offset [along, y, away] = [0,1,0]),
+# no floor block, so the cell stays walkable underneath. `swap: wood` retargets
+# the species to the building's secondary wood (oak_shelf -> spruce_shelf, …);
+# `loot:` fills the 3 display slots from the matching table in loot.yaml.
+#
+# Authored facing=south = the north-wall case (shelf faces south, into the
+# room); rotate_block spins it to the correct outward facing on the other walls.
+# All carry the `display_shelf` tag plus their own name; rooms reference the
+# specific item so each room gets shelving that fits it.
+
+wine_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_wine
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+
+pantry_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_pantry
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+
+kitchen_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_kitchen
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+
+library_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_books
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+
+tool_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_tools
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+
+display_shelf:
+  tags: [display_shelf]
+  blocks:
+    - block: "minecraft:oak_shelf[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: wood
+      walkable: true
+      loot: shelf_general
+  constraints:
+    - offset: [0, 0]
+      constraint: wall

--- a/data/furniture/items/thematic.yaml
+++ b/data/furniture/items/thematic.yaml
@@ -1,0 +1,115 @@
+# Thematic / signature furniture — pieces meant to give a single room type its
+# own visual identity so rooms don't all read as the same generic mix of
+# chests, barrels, carpets and banners. Same schema as common.yaml. The engine
+# places blocks / block-entities only (not entities like armor stands or item
+# frames), so "martial" or "culinary" flavour comes from distinctive blocks —
+# grindstones, campfires, cauldrons, dyed wool — rather than decorative props.
+
+# ---------------------------------------------------------------------------
+# Martial — armoury / workshop
+# ---------------------------------------------------------------------------
+
+# Sharpening wheel. Floor grindstone, freestanding. Reads as a workstation for
+# maintaining tools and arms. (roof_grindstone is the rooftop-deck variant.)
+grindstone:
+  blocks:
+    - block: "minecraft:grindstone[face=floor,facing=north]"
+      offset: [0, 0, 0]
+      layer: ground
+  constraints:
+    - offset: [0, 0]
+      constraint: blocked_reachable
+
+# Twin wall banners side by side — a heraldic display for halls and armouries.
+# Both hang on the wall a block up, facing the room; the pair takes the
+# palette's primary + secondary colours so they read as matched standards.
+banner_pair:
+  min_room_area: 12
+  blocks:
+    - block: "minecraft:white_wall_banner[facing=south]"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: color
+    - block: "minecraft:white_wall_banner[facing=south]"
+      offset: [1, 1, 0]
+      layer: ground
+      swap: secondary_color
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+      facing: away_from_wall
+    - offset: [1, 0]
+      constraint: wall
+      facing: away_from_wall
+
+# Weapons chest — a plain chest stocked from the armoury loot table. Reads as a
+# footlocker of arms; distinct from the generic `chest` only by its contents.
+weapon_chest:
+  blocks:
+    - block: "minecraft:chest"
+      offset: [0, 0, 0]
+      layer: ground
+      loot: armory
+  constraints:
+    - offset: [0, 0]
+      constraint: blocked_reachable
+      facing: away_from_wall
+
+# ---------------------------------------------------------------------------
+# Culinary — kitchen / hearth
+# ---------------------------------------------------------------------------
+
+# Open cook-fire: a lit campfire. Campfires don't spread fire, so they're safe
+# on wooden floors. The kitchen's signature heat source alongside smoker/furnace.
+kitchen_hearth:
+  blocks:
+    - block: "minecraft:campfire[lit=true,facing=south]"
+      offset: [0, 0, 0]
+      layer: ground
+  constraints:
+    - offset: [0, 0]
+      constraint: blocked_reachable
+      facing: away_from_wall
+
+# Fireplace: a lit campfire set against the wall, the cosy centre of a hearth
+# room. Faces into the room. Unique so a room gets at most one.
+hearth_fire:
+  unique: true
+  blocks:
+    - block: "minecraft:campfire[lit=true,facing=south]"
+      offset: [0, 0, 0]
+      layer: ground
+  constraints:
+    - offset: [0, 0]
+      constraint: wall
+      facing: away_from_wall
+
+# ---------------------------------------------------------------------------
+# Craft — weaver's studio
+# ---------------------------------------------------------------------------
+
+# Bales of dyed wool stacked two high — raw stock for a weaver. Picks up the
+# palette's primary then secondary colour so studios' bales differ by building.
+wool_bales:
+  blocks:
+    - block: "minecraft:white_wool"
+      offset: [0, 0, 0]
+      layer: ground
+      swap: color
+    - block: "minecraft:white_wool"
+      offset: [0, 1, 0]
+      layer: ground
+      swap: secondary_color
+  constraints:
+    - offset: [0, 0]
+      constraint: blocked_reachable
+
+# Dye vat: a water-filled cauldron for setting colour into cloth. Freestanding.
+dye_vat:
+  blocks:
+    - block: "minecraft:water_cauldron[level=3]"
+      offset: [0, 0, 0]
+      layer: ground
+  constraints:
+    - offset: [0, 0]
+      constraint: blocked_reachable

--- a/data/furniture/loot.yaml
+++ b/data/furniture/loot.yaml
@@ -105,6 +105,88 @@ armory:
     - { id: "minecraft:leather_helmet", count: [1, 1], weight: 2 }
     - { id: "minecraft:leather_chestplate", count: [1, 1], weight: 2 }
 
+# ---------------------------------------------------------------------------
+# Display-shelf contents. Shown on wall shelves (minecraft:*_shelf, 3 slots) to
+# telegraph a room's purpose at a glance. Some items are renamed for flavour
+# (a recoloured potion shown as "Wine"). capacity:3 + count:[2,3] = tidy shelves.
+# ---------------------------------------------------------------------------
+
+# Wine cellar — bottles of "wine" (renamed, recoloured potions).
+shelf_wine:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:potion", count: [1, 1], weight: 3, name: "Red Wine",    components: '"minecraft:potion_contents":{custom_color:7483191}' }
+    - { id: "minecraft:potion", count: [1, 1], weight: 2, name: "White Wine",  components: '"minecraft:potion_contents":{custom_color:15129760}' }
+    - { id: "minecraft:potion", count: [1, 1], weight: 1, name: "Spiced Wine", components: '"minecraft:potion_contents":{custom_color:9849600}' }
+    - { id: "minecraft:glass_bottle", count: [1, 1], weight: 1 }
+
+# Larder / pantry — preserved foods and bulk staples.
+shelf_pantry:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:bread",        count: [1, 2], weight: 4 }
+    - { id: "minecraft:cooked_beef",  count: [1, 2], weight: 2 }
+    - { id: "minecraft:dried_kelp",   count: [1, 3], weight: 2 }
+    - { id: "minecraft:apple",        count: [1, 3], weight: 3 }
+    - { id: "minecraft:carrot",       count: [1, 3], weight: 2 }
+    - { id: "minecraft:potato",       count: [1, 3], weight: 2 }
+    - { id: "minecraft:pumpkin_pie",  count: [1, 1], weight: 1 }
+    - { id: "minecraft:honey_bottle", count: [1, 1], weight: 1, name: "Preserves" }
+
+# Kitchen — fresh ingredients and cookware on display.
+shelf_kitchen:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:bread",  count: [1, 2], weight: 4 }
+    - { id: "minecraft:egg",    count: [1, 3], weight: 2 }
+    - { id: "minecraft:apple",  count: [1, 3], weight: 3 }
+    - { id: "minecraft:bowl",   count: [1, 2], weight: 2 }
+    - { id: "minecraft:cookie", count: [1, 3], weight: 2 }
+    - { id: "minecraft:cake",   count: [1, 1], weight: 1 }
+    - { id: "minecraft:carrot", count: [1, 3], weight: 2 }
+
+# Study / library — books, writings, and maps.
+shelf_books:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:book",           count: [1, 3], weight: 4 }
+    - { id: "minecraft:enchanted_book", count: [1, 1], weight: 1 }
+    - { id: "minecraft:writable_book",  count: [1, 1], weight: 2, name: "Journal" }
+    - { id: "minecraft:paper",          count: [1, 3], weight: 2 }
+    - { id: "minecraft:map",            count: [1, 1], weight: 1 }
+    - { id: "minecraft:book",           count: [1, 1], weight: 1, name: "Tome" }
+
+# Workshop — tools and raw stock.
+shelf_tools:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:iron_pickaxe",    count: [1, 1], weight: 3 }
+    - { id: "minecraft:iron_axe",        count: [1, 1], weight: 3 }
+    - { id: "minecraft:iron_shovel",     count: [1, 1], weight: 2 }
+    - { id: "minecraft:iron_hoe",        count: [1, 1], weight: 2 }
+    - { id: "minecraft:shears",          count: [1, 1], weight: 2 }
+    - { id: "minecraft:flint_and_steel", count: [1, 1], weight: 1 }
+    - { id: "minecraft:iron_ingot",      count: [1, 3], weight: 2 }
+
+# General household — a lived-in mix for living rooms.
+shelf_general:
+  capacity: 3
+  count: [2, 3]
+  items:
+    - { id: "minecraft:book",         count: [1, 2], weight: 2 }
+    - { id: "minecraft:apple",        count: [1, 2], weight: 2 }
+    - { id: "minecraft:bowl",         count: [1, 2], weight: 2 }
+    - { id: "minecraft:flower_pot",   count: [1, 1], weight: 2 }
+    - { id: "minecraft:clock",        count: [1, 1], weight: 1 }
+    - { id: "minecraft:compass",      count: [1, 1], weight: 1 }
+    - { id: "minecraft:candle",       count: [1, 2], weight: 2 }
+    - { id: "minecraft:honey_bottle", count: [1, 1], weight: 1, name: "Cordial" }
+
 # Furnace contents — slot 0 is input (raw), slot 1 is fuel, slot 2 is output.
 # Each slot rolls independently. A finished smelt would have only slot 2;
 # an idle furnace typically has fuel loaded and maybe a raw item queued.

--- a/data/materials/wood/brown/birch_planks.json
+++ b/data/materials/wood/brown/birch_planks.json
@@ -5,6 +5,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:birch_planks",
+        "shelf"              : "minecraft:birch_shelf",
         "stairs"             : "minecraft:birch_stairs",
         "slab"               : "minecraft:birch_slab",
         "fence"              : "minecraft:birch_fence",

--- a/data/materials/wood/brown/dark_oak_planks.json
+++ b/data/materials/wood/brown/dark_oak_planks.json
@@ -5,6 +5,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:dark_oak_planks",
+        "shelf"              : "minecraft:dark_oak_shelf",
         "stairs"             : "minecraft:dark_oak_stairs",
         "slab"               : "minecraft:dark_oak_slab",
         "fence"              : "minecraft:dark_oak_fence",

--- a/data/materials/wood/brown/oak_planks.json
+++ b/data/materials/wood/brown/oak_planks.json
@@ -6,6 +6,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:oak_planks",
+        "shelf"              : "minecraft:oak_shelf",
         "stairs"             : "minecraft:oak_stairs",
         "slab"               : "minecraft:oak_slab",
         "fence"              : "minecraft:oak_fence",

--- a/data/materials/wood/brown/spruce_planks.json
+++ b/data/materials/wood/brown/spruce_planks.json
@@ -6,6 +6,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:spruce_planks",
+        "shelf"              : "minecraft:spruce_shelf",
         "stairs"             : "minecraft:spruce_stairs",
         "slab"               : "minecraft:spruce_slab",
         "fence"              : "minecraft:spruce_fence",

--- a/data/materials/wood/log/cherry_log.json
+++ b/data/materials/wood/log/cherry_log.json
@@ -2,6 +2,7 @@
     "id" : "cherry_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:cherry_log"
+        "block" : "minecraft:cherry_log",
+        "shelf" : "minecraft:cherry_shelf"
     }
 }

--- a/data/materials/wood/log/dark_oak_log.json
+++ b/data/materials/wood/log/dark_oak_log.json
@@ -2,6 +2,7 @@
     "id" : "dark_oak_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:dark_oak_log"
+        "block" : "minecraft:dark_oak_log",
+        "shelf" : "minecraft:dark_oak_shelf"
     }
 }

--- a/data/materials/wood/log/jungle_log.json
+++ b/data/materials/wood/log/jungle_log.json
@@ -2,6 +2,7 @@
     "id" : "jungle_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:jungle_log"
+        "block" : "minecraft:jungle_log",
+        "shelf" : "minecraft:jungle_shelf"
     }
 }

--- a/data/materials/wood/log/oak_log.json
+++ b/data/materials/wood/log/oak_log.json
@@ -2,6 +2,7 @@
     "id" : "oak_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:oak_log"
+        "block" : "minecraft:oak_log",
+        "shelf" : "minecraft:oak_shelf"
     }
 }

--- a/data/materials/wood/log/spruce_log.json
+++ b/data/materials/wood/log/spruce_log.json
@@ -2,6 +2,7 @@
     "id" : "spruce_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:spruce_log"
+        "block" : "minecraft:spruce_log",
+        "shelf" : "minecraft:spruce_shelf"
     }
 }

--- a/data/materials/wood/log/stripped_acacia_log.json
+++ b/data/materials/wood/log/stripped_acacia_log.json
@@ -2,6 +2,7 @@
     "id" : "stripped_acacia_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:stripped_acacia_log"
+        "block" : "minecraft:stripped_acacia_log",
+        "shelf" : "minecraft:acacia_shelf"
     }
 }

--- a/data/materials/wood/log/stripped_birch_log.json
+++ b/data/materials/wood/log/stripped_birch_log.json
@@ -2,6 +2,7 @@
     "id" : "stripped_birch_log",
     "connections" : {},
     "blocks" : {
-        "block" : "minecraft:stripped_birch_log"
+        "block" : "minecraft:stripped_birch_log",
+        "shelf" : "minecraft:birch_shelf"
     }
 }

--- a/data/materials/wood/other/warped_planks.json
+++ b/data/materials/wood/other/warped_planks.json
@@ -4,6 +4,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:warped_planks",
+        "shelf"              : "minecraft:warped_shelf",
         "stairs"             : "minecraft:warped_stairs",
         "slab"               : "minecraft:warped_slab",
         "fence"              : "minecraft:warped_fence",

--- a/data/materials/wood/red/acacia_planks.json
+++ b/data/materials/wood/red/acacia_planks.json
@@ -6,6 +6,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:acacia_planks",
+        "shelf"              : "minecraft:acacia_shelf",
         "stairs"             : "minecraft:acacia_stairs",
         "slab"               : "minecraft:acacia_slab",
         "fence"              : "minecraft:acacia_fence",

--- a/data/materials/wood/red/cherry_planks.json
+++ b/data/materials/wood/red/cherry_planks.json
@@ -5,6 +5,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:cherry_planks",
+        "shelf"              : "minecraft:cherry_shelf",
         "stairs"             : "minecraft:cherry_stairs",
         "slab"               : "minecraft:cherry_slab",
         "fence"              : "minecraft:cherry_fence",

--- a/data/materials/wood/red/crimson_planks.json
+++ b/data/materials/wood/red/crimson_planks.json
@@ -5,6 +5,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:crimson_planks",
+        "shelf"              : "minecraft:crimson_shelf",
         "stairs"             : "minecraft:crimson_stairs",
         "slab"               : "minecraft:crimson_slab",
         "fence"              : "minecraft:crimson_fence",

--- a/data/materials/wood/red/jungle_planks.json
+++ b/data/materials/wood/red/jungle_planks.json
@@ -6,6 +6,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:jungle_planks",
+        "shelf"              : "minecraft:jungle_shelf",
         "stairs"             : "minecraft:jungle_stairs",
         "slab"               : "minecraft:jungle_slab",
         "fence"              : "minecraft:jungle_fence",

--- a/data/materials/wood/red/mangrove_planks.json
+++ b/data/materials/wood/red/mangrove_planks.json
@@ -6,6 +6,7 @@
     },
     "blocks" : {
         "block"              : "minecraft:mangrove_planks",
+        "shelf"              : "minecraft:mangrove_shelf",
         "stairs"             : "minecraft:mangrove_stairs",
         "slab"               : "minecraft:mangrove_slab",
         "fence"              : "minecraft:mangrove_fence",

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -4,43 +4,43 @@ armory:
 
 bedroom:
   required: [bed, lantern]
-  optional: [chest, bookshelf, desk, chair, shelf, wall_banner, barrel, crafting_table, table, bookshelf, shelf, vase, carpet, carpet, reading_nook, dressing_screen, potted_plant]
+  optional: [chest, bookshelf, desk, chair, shelf, display_shelf, wall_banner, barrel, crafting_table, table, bookshelf, shelf, vase, carpet, carpet, reading_nook, dressing_screen, potted_plant]
 
 common:
   required: [bed, crafting_table, furnace, chest]
-  optional: [lantern, table, chair, bench]
+  optional: [lantern, display_shelf, table, chair, bench]
 
 dining:
   required: [lantern, table]
-  optional: [chair, chair, chair, chair, wall_banner, vase, chest, carpet, carpet, bench, chandelier, potted_plant]
+  optional: [chair, chair, chair, chair, wall_banner, display_shelf, vase, chest, carpet, carpet, bench, chandelier, potted_plant]
 
 great_room:
   required: [lantern]
-  optional: [chest, bookshelf, table, chair, chair, wall_banner, vase, shelf, carpet, carpet, lectern, bench, chandelier, potted_plant]
+  optional: [chest, bookshelf, display_shelf, table, chair, chair, wall_banner, vase, shelf, carpet, carpet, lectern, bench, chandelier, potted_plant]
 
 hearth:
   required: [furnace, crafting_table]
-  optional: [chest, barrel, lantern]
+  optional: [chest, barrel, lantern, display_shelf]
 
 kitchen:
-  required: [furnace, smoker]
-  optional: [cauldron, barrel, lantern, potted_plant]
+  required: [furnace, smoker, kitchen_shelf]
+  optional: [cauldron, barrel, lantern, kitchen_shelf, potted_plant]
 
 library:
-  required: [bookshelf]
-  optional: [bookshelf, lantern, lectern]
+  required: [bookshelf, library_shelf]
+  optional: [bookshelf, library_shelf, lantern, lectern]
 
 master_bedroom:
   required: [bed, lantern]
-  optional: [chest, desk, chair, bookshelf, bookshelf, shelf, wall_banner, vase, table, carpet, carpet, reading_nook, dressing_screen, chandelier, potted_plant]
+  optional: [chest, desk, chair, bookshelf, bookshelf, shelf, library_shelf, wall_banner, vase, table, carpet, carpet, reading_nook, dressing_screen, chandelier, potted_plant]
 
 multi_bedroom:
   required: [bed, lantern]
-  optional: [chest, bookshelf, desk, chair, shelf, vase, wall_banner, table, carpet, carpet, reading_nook, dressing_screen, potted_plant]
+  optional: [chest, bookshelf, desk, chair, shelf, library_shelf, vase, wall_banner, table, carpet, carpet, reading_nook, dressing_screen, potted_plant]
 
 pantry:
   fill_threshold: 0.78
-  required: [lantern]
+  required: [lantern, pantry_shelf]
   optional:
     - barrel
     - barrel_stack
@@ -80,11 +80,11 @@ storage:
 
 studio:
   required: [loom]
-  optional: [crafting_table, lantern]
+  optional: [crafting_table, lantern, tool_shelf]
 
 study:
-  required: [bookshelf]
-  optional: [lantern, desk, chair, bookshelf, shelf, carpet, carpet, lectern, potted_plant]
+  required: [bookshelf, library_shelf]
+  optional: [lantern, desk, chair, bookshelf, library_shelf, shelf, carpet, carpet, lectern, potted_plant]
 
 # Flat-roof themes (desert). decorate_rooftops picks ONE of these per building
 # so neighbouring roofs read as different spaces. These aren't real rooms — the
@@ -93,7 +93,7 @@ study:
 
 # Living terrace — a shaded spot to relax.
 roof_lounge:
-  fill_threshold: 0.45
+  fill_threshold: 0.3
   required: [roof_shade]
   optional:
     - roof_bedroll
@@ -112,7 +112,7 @@ roof_lounge:
 
 # Roof garden — greenery and water.
 roof_garden:
-  fill_threshold: 0.5
+  fill_threshold: 0.33
   required: [roof_shade]
   optional:
     - roof_planter
@@ -129,7 +129,7 @@ roof_garden:
 
 # Open-air kitchen — cooking and food stores.
 roof_kitchen:
-  fill_threshold: 0.5
+  fill_threshold: 0.33
   required: [roof_tandoor]
   optional:
     - roof_brazier
@@ -147,7 +147,7 @@ roof_kitchen:
 
 # Workshop — crafting on the roof.
 roof_workshop:
-  fill_threshold: 0.55
+  fill_threshold: 0.35
   required: [loom]
   optional:
     - roof_grindstone
@@ -163,7 +163,7 @@ roof_workshop:
 
 # Storage roof — a few goods stacked up, not a packed warehouse.
 roof_storage:
-  fill_threshold: 0.4
+  fill_threshold: 0.28
   required: [barrel]
   optional:
     - crate
@@ -178,7 +178,7 @@ roof_storage:
 
 # Sleeping deck — bedouin-style, sleep in the cool night air.
 roof_sleeping:
-  fill_threshold: 0.45
+  fill_threshold: 0.3
   required: [roof_shade]
   optional:
     - roof_bedroll
@@ -191,3 +191,61 @@ roof_sleeping:
     - roof_jars
     - potted_plant
     - roof_laundry
+
+# ---------------------------------------------------------------------------
+# Cellar themes — one chosen at random per building's cellar, in an even mix
+# with the plain `storage` root cellar (see cellar.rs CELLAR_THEMES). All are
+# windowless, so each requires a lantern.
+# ---------------------------------------------------------------------------
+
+# Wine cellar — casks and racked bottles with a small tasting nook. Kept airy.
+cellar_wine:
+  fill_threshold: 0.55
+  required: [lantern, barrel_stack, wine_shelf]
+  optional:
+    - barrel
+    - barrel_stack
+    - roof_amphora
+    - roof_jars
+    - shelf
+    - loaded_shelves
+    - table
+    - chair
+    - chair
+    - bench
+    - vase
+    - crate
+
+# Larder / cold store — food stores and preservation. A well-stocked pantry.
+cellar_larder:
+  fill_threshold: 0.7
+  required: [lantern, barrel, pantry_shelf]
+  optional:
+    - sack_pile
+    - hay_pile
+    - barrel
+    - crate
+    - cauldron
+    - smoker
+    - shelf
+    - loaded_shelves
+    - roof_jars
+    - roof_amphora
+    - barrel_stack
+
+# Undercroft workshop — crafting below ground. Tools and raw stock.
+cellar_workshop:
+  fill_threshold: 0.6
+  required: [lantern, crafting_table, tool_shelf]
+  optional:
+    - anvil
+    - loom
+    - roof_grindstone
+    - crate
+    - barrel
+    - sack_pile
+    - shelf
+    - stacked_bookshelves
+    - table
+    - cauldron
+    - furnace

--- a/data/rooms.yaml
+++ b/data/rooms.yaml
@@ -1,6 +1,7 @@
 armory:
+  fill_threshold: 0.5
   required: [anvil]
-  optional: [chest, lantern]
+  optional: [grindstone, banner_pair, weapon_chest, wall_banner, barrel, lantern, carpet, weapon_chest]
 
 bedroom:
   required: [bed, lantern]
@@ -16,18 +17,18 @@ dining:
 
 great_room:
   required: [lantern]
-  optional: [chest, bookshelf, display_shelf, table, chair, chair, wall_banner, vase, shelf, carpet, carpet, lectern, bench, chandelier, potted_plant]
+  optional: [chest, bookshelf, display_shelf, table, chair, chair, banner_pair, vase, shelf, carpet, carpet, lectern, bench, chandelier, potted_plant]
 
 hearth:
-  required: [furnace, crafting_table]
-  optional: [chest, barrel, lantern, display_shelf]
+  required: [hearth_fire, crafting_table]
+  optional: [chair, chair, bench, table, chest, barrel, lantern, carpet, cauldron, potted_plant]
 
 kitchen:
-  required: [furnace, smoker, kitchen_shelf]
-  optional: [cauldron, barrel, lantern, kitchen_shelf, potted_plant]
+  required: [furnace, smoker]
+  optional: [kitchen_hearth, cauldron, barrel, lantern, kitchen_shelf, potted_plant]
 
 library:
-  required: [bookshelf, library_shelf]
+  required: [bookshelf]
   optional: [bookshelf, library_shelf, lantern, lectern]
 
 master_bedroom:
@@ -80,10 +81,10 @@ storage:
 
 studio:
   required: [loom]
-  optional: [crafting_table, lantern, tool_shelf]
+  optional: [wool_bales, dye_vat, tool_shelf, wool_bales, crafting_table, lantern, chest, carpet, table]
 
 study:
-  required: [bookshelf, library_shelf]
+  required: [bookshelf]
   optional: [lantern, desk, chair, bookshelf, library_shelf, shelf, carpet, carpet, lectern, potted_plant]
 
 # Flat-roof themes (desert). decorate_rooftops picks ONE of these per building
@@ -236,11 +237,12 @@ cellar_larder:
 # Undercroft workshop — crafting below ground. Tools and raw stock.
 cellar_workshop:
   fill_threshold: 0.6
-  required: [lantern, crafting_table, tool_shelf]
+  required: [lantern, crafting_table]
   optional:
+    - tool_shelf
     - anvil
     - loom
-    - roof_grindstone
+    - grindstone
     - crate
     - barrel
     - sack_pile

--- a/src/generator/buildings_v2/cellar.rs
+++ b/src/generator/buildings_v2/cellar.rs
@@ -25,12 +25,9 @@ use super::floors::{FloorPlan, StairKind};
 use super::footprint::{Footprint, SizeClass};
 use super::frame::{Frame, CELLAR_FLOOR};
 use super::pipeline::BuildCtx;
-use super::rooms::{
-    compute_room_interior, CellState, ConstraintMap, Room, RoomPlan, RoomRole,
-};
-use super::furnish::furnish_rooms;
+use super::rooms::{compute_room_interior, CellState, ConstraintMap, RoomPlan};
+use super::furnish::furnish_interior;
 use super::walls::{segment_cells, WallSegments};
-use super::RoomType;
 
 /// Roll cellar eligibility by size class. Larger, grander buildings are far
 /// more likely to have a cellar; a cottage only rarely gets a root cellar.
@@ -175,7 +172,9 @@ fn ground_floor_door_cells(wall_segs: &WallSegments) -> Vec<Point2D> {
             continue;
         }
         let seg_cells = segment_cells(seg);
-        let inward: Point2D = (-seg.facing).into();
+        // `seg.facing` is the wall's INWARD normal, so the cell a person stands
+        // on entering is `door_cell + facing` (negating it lands outside).
+        let inward: Point2D = seg.facing.into();
         for w in 0..opening.width as usize {
             let idx = opening.offset as usize + w;
             if let Some(&door_cell) = seg_cells.get(idx) {
@@ -300,7 +299,7 @@ pub async fn maybe_build_cellar(
     let (positions, dir) = stair;
     place_descending_stair(ctx, &positions, dir, floor_y, &main_stair_cells, &mut rng).await;
 
-    furnish_cellar(ctx, frame, core, interior, &positions).await;
+    furnish_cellar(ctx, frame, interior, &positions).await;
     Some(positions)
 }
 
@@ -417,13 +416,18 @@ async fn place_descending_stair(
     }
 }
 
-/// Build a one-room plan for the cellar and run the shared furnishing pass over
-/// it using the `storage` furniture list. Stair cells are constrained out so no
-/// furniture lands on the steps or hangs over the shaft.
+/// Cellar themes — one chosen uniformly at random per building. `storage` is the
+/// plain root cellar; the rest are flavoured rooms defined in `data/rooms.yaml`.
+/// All are windowless, so each list requires a lantern for light.
+const CELLAR_THEMES: [&str; 4] = ["storage", "cellar_wine", "cellar_larder", "cellar_workshop"];
+
+/// Furnish the cellar from a randomly chosen theme list. Reuses the shared
+/// `furnish_interior` engine (same as rooms and rooftop terraces): we seed the
+/// constraint map so no furniture lands on the stair steps or hangs over the
+/// shaft, then pack the chosen list against the cellar's interior rect.
 async fn furnish_cellar(
     ctx: &mut BuildCtx<'_>,
     frame: &Frame,
-    core: Rect2D,
     interior: Rect2D,
     positions: &[Point2D],
 ) {
@@ -439,20 +443,49 @@ async fn furnish_cellar(
         constraints.set_ceiling(cell);
     }
 
-    let room = Room {
-        rect: core,
-        rect_index: 0,
-        floor: CELLAR_FLOOR,
-        role: RoomRole::Cellar,
-        room_type: RoomType::Storage,
-        interior,
-        constraints,
-        furniture: Vec::new(),
-        floor_type: None,
+    // Pick this cellar's theme; fall back to the plain storage list if a themed
+    // entry is missing from the data.
+    let mut pick_rng = ctx.rng.derive();
+    let key = CELLAR_THEMES[pick_rng.rand_i32_range(0, CELLAR_THEMES.len() as i32) as usize];
+    let room_list = match ctx
+        .data
+        .furniture
+        .rooms
+        .get(key)
+        .or_else(|| ctx.data.furniture.rooms.get("storage"))
+    {
+        Some(list) => list,
+        None => return,
     };
 
-    let mut plan = RoomPlan { rooms: vec![room], interior_doors: Vec::new() };
-    furnish_rooms(ctx, &mut plan, frame, &[]).await;
+    // The cellar's deck sits at the CELLAR_FLOOR surface; its ceiling is the
+    // ground-floor slab (flat, so no roof clearance).
+    let floor_y = frame.floor_y(CELLAR_FLOOR);
+    let ceiling_y = frame.ceiling_y(CELLAR_FLOOR);
+
+    let editor: &Editor = &*ctx.editor;
+    let items = &ctx.data.furniture.items;
+    let materials = &ctx.data.materials;
+    let loot = &ctx.data.furniture.loot;
+    let palette = ctx.palette;
+    let mut furn_rng = ctx.rng.derive();
+
+    furnish_interior(
+        editor,
+        &interior,
+        &mut constraints,
+        room_list,
+        items,
+        floor_y,
+        ceiling_y,
+        None,  // flat ground-floor slab above — no roof-clearance clamp
+        false, // not an attic
+        palette,
+        materials,
+        loot,
+        &mut furn_rng,
+    )
+    .await;
 }
 
 #[cfg(test)]

--- a/src/generator/buildings_v2/exterior.rs
+++ b/src/generator/buildings_v2/exterior.rs
@@ -58,7 +58,9 @@ pub async fn decorate_exterior_walls(
     let mut avoid: HashSet<Point2D> = HashSet::new();
     for (seg, opening) in wall_segs.doors() {
         let cells = segment_cells(seg);
-        let out: Point2D = seg.facing.into();
+        // `seg.facing` is the wall's INWARD normal, so the *outside* of the door
+        // (where exterior props would block the entrance) is its negation.
+        let out: Point2D = (-seg.facing).into();
         for dx in 0..opening.width {
             if let Some(&cell) = cells.get((opening.offset + dx) as usize) {
                 avoid.insert(cell + out);

--- a/src/generator/buildings_v2/floors/stairs.rs
+++ b/src/generator/buildings_v2/floors/stairs.rs
@@ -240,7 +240,9 @@ pub(super) fn select_stairwells(
 fn door_cells_on_floor(wall_segs: &WallSegments, floor: u32) -> HashSet<(i32, i32)> {
     let mut cells = HashSet::new();
     for seg in wall_segs.segments_on_floor(floor) {
-        let inward: Point2D = (-seg.facing).into();
+        // `seg.facing` is the wall's INWARD normal (points toward the interior),
+        // so the cell a player stands on to use the door is `door_cell + facing`.
+        let inward: Point2D = seg.facing.into();
         let seg_cells = segment_cells(seg);
         for o in &seg.openings {
             if !matches!(o.kind, OpeningKind::Door(_)) {
@@ -471,7 +473,11 @@ fn pick_stair_for_floor(
     let mut door_facings: HashSet<Cardinal> = HashSet::new();
     for seg in wall_segs.segments_on_floor(floor) {
         if seg.openings.iter().any(|o| matches!(o.kind, OpeningKind::Door(_))) {
-            door_facings.insert(seg.facing);
+            // `wall_facing` (below) names the geometric *outward* side a stair
+            // backs against; `seg.facing` is the wall's INWARD normal, so the
+            // matching outward side is its negation. Comparing them in the same
+            // frame is what actually keeps a stair off a door-bearing wall.
+            door_facings.insert(-seg.facing);
         }
     }
 

--- a/src/generator/buildings_v2/furnish/data.rs
+++ b/src/generator/buildings_v2/furnish/data.rs
@@ -231,6 +231,18 @@ pub struct LootItem {
     pub count: [i32; 2],
     #[serde(default = "default_weight")]
     pub weight: f32,
+    /// Optional custom display name — sets the item's `minecraft:custom_name`
+    /// component. Used for flavour on display shelves (e.g. a healing potion
+    /// shown as "Wine"). Plain text only.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Optional extra component entries inserted verbatim inside the item's
+    /// `components:{…}` SNBT — e.g.
+    /// `"minecraft:potion_contents":{potion:"minecraft:healing"}` to colour a
+    /// potion. Author the inner entries only (no outer braces); combine several
+    /// with commas.
+    #[serde(default)]
+    pub components: Option<String>,
 }
 
 /// A fixed slot assignment (furnace-style).

--- a/src/generator/buildings_v2/furnish/loot.rs
+++ b/src/generator/buildings_v2/furnish/loot.rs
@@ -28,9 +28,29 @@ fn roll_range_inclusive(range: [i32; 2], rng: &mut RNG) -> i32 {
     if lo == hi { lo } else { rng.rand_i32_range(lo, hi + 1) }
 }
 
+/// Render one item stack as SNBT, including a `components:{…}` block when the
+/// loot item carries a custom name and/or extra component entries.
+fn render_item(slot: i32, item: &data::LootItem, count: i32) -> String {
+    let mut comp: Vec<String> = Vec::new();
+    if let Some(name) = &item.name {
+        // custom_name is a text component; an SNBT-quoted JSON string works
+        // (the server normalises it). Verified on 1.21.11.
+        comp.push(format!("\"minecraft:custom_name\":'\"{}\"'", name));
+    }
+    if let Some(extra) = &item.components {
+        comp.push(extra.clone());
+    }
+    let comp_str = if comp.is_empty() {
+        String::new()
+    } else {
+        format!(",components:{{{}}}", comp.join(","))
+    };
+    format!("{{Slot:{}b,id:\"{}\",Count:{}b{}}}", slot, item.id, count, comp_str)
+}
+
 /// Roll an SNBT `{Items:[...]}` payload for a container from a loot table.
 pub(super) fn roll_loot_snbt(table: &LootTable, rng: &mut RNG) -> String {
-    let mut entries: Vec<(i32, String, i32)> = Vec::new();
+    let mut parts: Vec<String> = Vec::new();
 
     if !table.fixed.is_empty() {
         // Fixed strategy: furnace/smoker style, each slot rolled independently.
@@ -42,7 +62,7 @@ pub(super) fn roll_loot_snbt(table: &LootTable, rng: &mut RNG) -> String {
             }
             if let Some(item) = pick_weighted_item(&fs.items, rng) {
                 let count = roll_range_inclusive(item.count, rng).max(1);
-                entries.push((fs.slot, item.id.clone(), count));
+                parts.push(render_item(fs.slot, item, count));
             }
         }
     } else if !table.items.is_empty() {
@@ -57,14 +77,10 @@ pub(super) fn roll_loot_snbt(table: &LootTable, rng: &mut RNG) -> String {
             let slot = slot_pool.swap_remove(idx);
             if let Some(item) = pick_weighted_item(&table.items, rng) {
                 let count = roll_range_inclusive(item.count, rng).max(1);
-                entries.push((slot, item.id.clone(), count));
+                parts.push(render_item(slot, item, count));
             }
         }
     }
 
-    let parts: Vec<String> = entries
-        .iter()
-        .map(|(slot, id, count)| format!("{{Slot:{}b,id:\"{}\",Count:{}b}}", slot, id, count))
-        .collect();
     format!("{{Items:[{}]}}", parts.join(","))
 }

--- a/src/generator/buildings_v2/furnish/mod.rs
+++ b/src/generator/buildings_v2/furnish/mod.rs
@@ -21,4 +21,5 @@ mod types;
 
 pub use roof::decorate_rooftops;
 pub use room::furnish_rooms;
+pub(crate) use room::furnish_interior;
 pub use types::{BlockLayer, CellConstraint, FacingMode};

--- a/src/generator/buildings_v2/furnish/placement.rs
+++ b/src/generator/buildings_v2/furnish/placement.rs
@@ -163,7 +163,7 @@ fn ground_block_cells(
 
 /// Per-cell roof-block y for an attic room. Used to reject furniture cells
 /// that would poke into (or against) the sloped roof.
-pub(super) struct RoofClearance<'a> {
+pub(crate) struct RoofClearance<'a> {
     pub(super) hm: &'a RoofHeightmap,
     /// Wall-top y for this rect (= roof_y from Frame). The lowest roof block
     /// at (x, z) sits at `roof_y + heightmap.get(x, z).floor()`.

--- a/src/generator/buildings_v2/furnish/placement.rs
+++ b/src/generator/buildings_v2/furnish/placement.rs
@@ -185,6 +185,38 @@ impl RoofClearance<'_> {
             None => false,
         }
     }
+
+    /// True if a player can stand on the attic floor at this cell — i.e. there
+    /// are two air blocks (feet at `floor_y`, head at `floor_y + 1`) below the
+    /// lowest roof block. Eave cells under the slope fail this and must be
+    /// pruned from the walkable graph so connectivity routing can't path
+    /// through them. Cells with no roof data are assumed clear (not pruned).
+    pub(super) fn floor_walkable(&self, cell: (i32, i32), floor_y: i32) -> bool {
+        match self.roof_block_y(cell) {
+            Some(rb_y) => rb_y >= floor_y + 2,
+            None => true,
+        }
+    }
+}
+
+/// Mark attic floor cells with sub-2-block headroom as `Blocked` so the
+/// connectivity flood-fill and fill-ratio treat them as the impassable eave
+/// cells they physically are. Only `Empty` cells are pruned — reserved access
+/// cells (stair tops, doorways, ladder) keep their state.
+pub(super) fn prune_low_headroom(
+    constraints: &mut ConstraintMap,
+    interior: &Rect2D,
+    clearance: &RoofClearance,
+    floor_y: i32,
+) {
+    for cell in interior.iter() {
+        let xz = (cell.x, cell.y);
+        if matches!(constraints.get(xz), Some(CellState::Empty))
+            && !clearance.floor_walkable(xz, floor_y)
+        {
+            constraints.set(xz, CellState::Blocked);
+        }
+    }
 }
 
 /// Reject a placement if any of its blocks fails the attic roof-clearance test.

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -59,12 +59,9 @@ pub async fn decorate_rooftops(
 ) {
     let mut pick_rng = ctx.rng.derive();
 
-    // Leave roughly a third of roofs bare — an empty deck is part of the
-    // variety, and a street where every roof is dressed reads as busy.
-    if pick_rng.rand_i32_range(0, 3) == 0 {
-        return;
-    }
-
+    // Every flat roof gets dressed — the variety comes from the theme, the
+    // fabric colour, and the deliberately low per-theme `fill_threshold`
+    // (rooms.yaml) that keeps each deck sparse rather than packed.
     // Pick one rooftop theme for the whole building so its deck(s) read as a
     // single, coherent space.
     let key = ROOF_ROOM_KEYS[pick_rng.rand_i32_range(0, ROOF_ROOM_KEYS.len() as i32) as usize];

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -178,7 +178,7 @@ pub(super) async fn furnish_room(
 /// from a room furniture list. Shared by [`furnish_room`] (interior rooms) and
 /// rooftop terrace decoration: the caller supplies the geometry (interior,
 /// floor/ceiling Y, optional roof clearance) and gets back the placed items.
-pub(super) async fn furnish_interior(
+pub(crate) async fn furnish_interior(
     editor: &Editor,
     interior: &Rect2D,
     constraints: &mut ConstraintMap,

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -13,8 +13,8 @@ use super::block::swap_block_for_palette;
 use super::data::{Furniture, LootTable, RoomFurnitureList};
 use super::loot::roll_loot_snbt;
 use super::placement::{
-    RoofClearance, WallSlot, interior_rect, is_ceiling_item, needs_wall, try_place_at_wall_slot,
-    try_place_ceiling, try_place_freestanding, wall_slots,
+    RoofClearance, WallSlot, interior_rect, is_ceiling_item, needs_wall, prune_low_headroom,
+    try_place_at_wall_slot, try_place_ceiling, try_place_freestanding, wall_slots,
 };
 use super::super::frame::Frame;
 use super::super::pipeline::BuildCtx;
@@ -165,6 +165,15 @@ pub(super) async fn furnish_room(
     } else {
         None
     };
+
+    // Eave cells under the low part of the roof aren't physically standable.
+    // Prune them out of the walkable graph before furnishing so the
+    // connectivity guard can't route a "path" through cells the player's head
+    // won't fit through (otherwise furniture can seal the real route while the
+    // check stays satisfied via the eaves).
+    if let Some(rc) = roof_clearance.as_ref() {
+        prune_low_headroom(&mut room.constraints, &interior, rc, floor_y);
+    }
 
     let placed = furnish_interior(
         editor, &interior, &mut room.constraints, room_list, items,

--- a/src/generator/buildings_v2/furnish/test.rs
+++ b/src/generator/buildings_v2/furnish/test.rs
@@ -2006,9 +2006,9 @@ fn random_table() -> LootTable {
         count: Some([2, 4]),
         capacity: Some(27),
         items: vec![
-            LootItem { id: "minecraft:bread".into(), count: [1, 3], weight: 3.0 },
-            LootItem { id: "minecraft:wheat".into(), count: [2, 5], weight: 2.0 },
-            LootItem { id: "minecraft:apple".into(), count: [1, 1], weight: 1.0 },
+            LootItem { id: "minecraft:bread".into(), count: [1, 3], weight: 3.0, name: None, components: None },
+            LootItem { id: "minecraft:wheat".into(), count: [2, 5], weight: 2.0, name: None, components: None },
+            LootItem { id: "minecraft:apple".into(), count: [1, 1], weight: 1.0, name: None, components: None },
         ],
         fixed: vec![],
     }
@@ -2059,7 +2059,7 @@ fn loot_roll_slots_are_distinct() {
     let table = LootTable {
         count: Some([5, 5]),
         capacity: Some(27),
-        items: vec![LootItem { id: "minecraft:stick".into(), count: [1, 1], weight: 1.0 }],
+        items: vec![LootItem { id: "minecraft:stick".into(), count: [1, 1], weight: 1.0, name: None, components: None }],
         fixed: vec![],
     };
     let mut rng = RNG::new(7);
@@ -2080,7 +2080,7 @@ fn loot_roll_capacity_caps_stack_count() {
     let table = LootTable {
         count: Some([10, 10]),
         capacity: Some(3),
-        items: vec![LootItem { id: "minecraft:coal".into(), count: [1, 1], weight: 1.0 }],
+        items: vec![LootItem { id: "minecraft:coal".into(), count: [1, 1], weight: 1.0, name: None, components: None }],
         fixed: vec![],
     };
     let mut rng = RNG::new(5);
@@ -2100,12 +2100,12 @@ fn loot_roll_fixed_slots_assigned_directly() {
             FixedSlot {
                 slot: 0,
                 chance: 1.0,
-                items: vec![LootItem { id: "minecraft:raw_iron".into(), count: [2, 2], weight: 1.0 }],
+                items: vec![LootItem { id: "minecraft:raw_iron".into(), count: [2, 2], weight: 1.0, name: None, components: None }],
             },
             FixedSlot {
                 slot: 1,
                 chance: 1.0,
-                items: vec![LootItem { id: "minecraft:coal".into(), count: [3, 3], weight: 1.0 }],
+                items: vec![LootItem { id: "minecraft:coal".into(), count: [3, 3], weight: 1.0, name: None, components: None }],
             },
         ],
     };
@@ -2125,7 +2125,7 @@ fn loot_roll_fixed_slot_chance_zero_skips() {
             FixedSlot {
                 slot: 2,
                 chance: 0.0,
-                items: vec![LootItem { id: "minecraft:iron_ingot".into(), count: [1, 1], weight: 1.0 }],
+                items: vec![LootItem { id: "minecraft:iron_ingot".into(), count: [1, 1], weight: 1.0, name: None, components: None }],
             },
         ],
     };

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -200,7 +200,7 @@ pub async fn build_house(
     // house reads as lived-in. Skips doors, roads, and claimed cells.
     decorate_exterior_walls(ctx, &footprint, &wall_segs).await;
 
-    check_building_invariants(&frame, &room_plan, &floor_plan)?;
+    check_building_invariants(&frame, &room_plan, &floor_plan, &roof_heightmaps)?;
 
     // Cellar runs last: it carves below the finished building using a derived
     // RNG, so it neither perturbs the main stream nor disturbs the room_plan

--- a/src/generator/buildings_v2/rooms/build.rs
+++ b/src/generator/buildings_v2/rooms/build.rs
@@ -33,8 +33,9 @@ fn find_entry_rect(rects: &[Rect2D], wall_segs: &WallSegments) -> Option<usize> 
             continue;
         }
         let door_cell = cells[idx];
-        // The room is one cell inward from the door
-        let inward: Point2D = (-seg.facing).into();
+        // The room is one cell inward from the door. `seg.facing` is already the
+        // wall's INWARD normal, so add it directly (negating lands outside).
+        let inward: Point2D = seg.facing.into();
         let interior_cell = door_cell + inward;
 
         for (i, rect) in rects.iter().enumerate() {

--- a/src/generator/buildings_v2/rooms/invariants.rs
+++ b/src/generator/buildings_v2/rooms/invariants.rs
@@ -10,6 +10,7 @@ use super::super::footprint::merge::{concave_corner_cells, walk_edge_cells};
 use super::super::footprint::{find_boundaries, phantom_wall_cells};
 use super::super::floors::FloorPlan;
 use super::super::frame::Frame;
+use super::super::roof::heightmap::RoofHeightmap;
 use super::constraints::CellState;
 use super::plan::{RoomPlan, RoomRole};
 
@@ -69,6 +70,7 @@ pub fn check_building_invariants(
     frame: &Frame,
     room_plan: &RoomPlan,
     floor_plan: &FloorPlan,
+    roof_heightmaps: &[RoofHeightmap],
 ) -> Result<(), String> {
     const NEIGHBORS: [(i32, i32); 4] = [(0, -1), (1, 0), (0, 1), (-1, 0)];
 
@@ -130,6 +132,37 @@ pub fn check_building_invariants(
                         "invariant (c): room {:?} floor {} furniture '{}' overlaps stair cell ({},{})",
                         room.room_type, room.floor, furn.name, fx, fz,
                     ));
+                }
+            }
+        }
+
+        // Invariant 4: no Empty (furniture-placeable, connectivity-routable)
+        // attic cell has sub-2-block headroom. The furnish prune
+        // (`prune_low_headroom`) converts eave cells under the low roof to
+        // Blocked so the connectivity guard can't route a path through cells the
+        // player's head won't fit through, and so furniture can't land there. If
+        // an Empty cell still has the roof <2 blocks above the floor, the prune
+        // regressed and furniture could orphan part of the attic behind an
+        // impassable eave. (UnblockedReachable perimeter cells — gable doorways,
+        // stair-air-above — are deliberately left: they're dead-end spurs, not
+        // through-routes, so they can't create the orphaning the prune prevents.)
+        if room.role == RoomRole::Attic {
+            if let Some(hm) = roof_heightmaps.get(room.rect_index) {
+                let floor_y = frame.floor_y(room.floor);
+                let roof_y = frame.roof_y(room.rect_index);
+                for ((cx, cz), state) in room.constraints.iter_ground() {
+                    if state != CellState::Empty { continue; }
+                    let h = hm.get(cx, cz);
+                    if h == f32::NEG_INFINITY { continue; }
+                    let rb_y = roof_y + h.floor() as i32;
+                    if rb_y < floor_y + 2 {
+                        return Err(format!(
+                            "invariant (d): room {:?} floor {} Empty attic cell ({},{}) \
+                             has roof block at y={} but floor y={} — only {} block(s) of \
+                             headroom (need ≥2); eave prune regressed",
+                            room.room_type, room.floor, cx, cz, rb_y, floor_y, rb_y - floor_y,
+                        ));
+                    }
                 }
             }
         }

--- a/src/generator/buildings_v2/walls/segments.rs
+++ b/src/generator/buildings_v2/walls/segments.rs
@@ -19,7 +19,10 @@ pub struct WallSegment {
     pub extra_start: Option<Point2D>,
     /// Extra cell appended at a concave end corner
     pub extra_end: Option<Point2D>,
-    /// Which direction the wall faces outward
+    /// The wall's INWARD normal — points from the wall toward the building
+    /// interior. (Door blocks use this as their Minecraft `facing`, and the
+    /// exterior side is `-facing`.) Despite the name, this is *not* the outward
+    /// direction; treating it as outward silently picks the wrong side.
     pub facing: Cardinal,
     /// Floor index (0 = ground)
     pub floor: u32,

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+﻿#[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
     use crate::{data::Loadable, editor::World, generator::districts::{WallType, build_wall, HasParcelData, parcel::{self, generate_parcels}, parcel_painter::{replace_ground, replace_ground_smooth}}, geometry::{Point2D, Point3D}, http_mod::{GDMCHTTPProvider, HeightMapType}, minecraft::Block, noise::{RNG, Seed}, util::init_logger};
@@ -227,7 +227,7 @@ mod tests {
         let pole: Block = "oak_fence".into();
         for (id, parcel_type, centre, size) in sign_info {
             if centre.x < 0 || centre.y < 0 || centre.x >= build_area.size.x || centre.y >= build_area.size.z {
-                log::info!("Super-parcel {} final type={:?} size={} cells, centre={:?} out of bounds — no sign", id, parcel_type, size, centre);
+                log::info!("Super-parcel {} final type={:?} size={} cells, centre={:?} out of bounds â€” no sign", id, parcel_type, size, centre);
                 continue;
             }
 
@@ -235,7 +235,7 @@ mod tests {
             let surface_y = height_map[centre.x as usize][centre.y as usize];
             let (world_x, world_z) = (centre.x + build_area.origin.x, centre.y + build_area.origin.z);
             log::info!(
-                "Super-parcel {} final type={:?} size={} cells — sign at world ({}, {}, {})  /tp @s {} {} {}",
+                "Super-parcel {} final type={:?} size={} cells â€” sign at world ({}, {}, {})  /tp @s {} {} {}",
                 id, parcel_type, size, world_x, surface_y + 4, world_z, world_x, surface_y + 5, world_z
             );
 
@@ -247,7 +247,7 @@ mod tests {
             editor.place_block(&sign_block(&id.to_string()), Point3D::new(centre.x, h + 4, centre.y)).await;
         }
 
-        // Verify the size band: every Urban/Rural (interior) parcel should be within ±50% of the
+        // Verify the size band: every Urban/Rural (interior) parcel should be within Â±50% of the
         // interior average block count. Off-limits parcels are exempt. See
         // docs/plans/parcel_size_balancing.md.
         let interior_sizes: Vec<(usize, parcel::ParcelType, usize)> = editor.world()
@@ -417,7 +417,7 @@ mod tests {
             "oak_wood_roof".into(),
             "red_wood_roof".into(),
         ];
-        // Medieval-feeling woods and stones — skipping tropical (jungle, acacia)
+        // Medieval-feeling woods and stones â€” skipping tropical (jungle, acacia)
         // and nether (blackstone) variants. Each is a partial palette that only
         // overrides its respective roles, so stacking them gives ~36 combos.
         let wood_palette_ids: Vec<PaletteId> = vec![
@@ -462,7 +462,7 @@ mod tests {
 
         // All road cells: perimeter + alleys. Claim as PathPlanned so the
         // frontage walker treats them as roads, but foundation terrain
-        // blending will still raise the heightmap on them — meaning the
+        // blending will still raise the heightmap on them â€” meaning the
         // post-house pave step picks up the foundation-influenced heights.
         let road_cells: HashSet<Point2D> = perimeter_roads.iter().chain(all_alleys.iter()).copied().collect();
         for p in &road_cells {
@@ -541,7 +541,7 @@ mod tests {
                 None => continue,
             };
 
-            // Frontage pass — one house per slot along each frontage chain.
+            // Frontage pass â€” one house per slot along each frontage chain.
             let frontages = {
                 let detected = detect_frontages(sub_block, &editor);
                 if detected.is_empty() {
@@ -598,7 +598,7 @@ mod tests {
                 }
             }
 
-            // Interior pass disabled — frontage only for now.
+            // Interior pass disabled â€” frontage only for now.
             // let max_interior = 10usize;
             // let mut placed = 0usize;
             // while placed < max_interior {
@@ -640,7 +640,7 @@ mod tests {
 
         editor.flush_buffer().await;
         println!(
-            "Done — {} total buildings across {} sub-blocks",
+            "Done â€” {} total buildings across {} sub-blocks",
             total_buildings, all_sub_blocks.len(),
         );
     }
@@ -773,9 +773,9 @@ mod tests {
         let mut producing_ids: Vec<_> = result.parcel_assignments.keys().cloned().collect();
         producing_ids.sort_by_key(|id| id.0);
 
-        println!("\n╔══ Parcel Resource Production Report ════════════╗");
+        println!("\nâ•”â•â• Parcel Resource Production Report â•â•â•â•â•â•â•â•â•â•â•â•â•—");
 
-        println!("║ Producing Super-Parcels ({} rural of {} total):", producing_ids.len(), editor.world().district_analysis_data.len());
+        println!("â•‘ Producing Super-Parcels ({} rural of {} total):", producing_ids.len(), editor.world().district_analysis_data.len());
         for id in &producing_ids {
             let analysis = &editor.world().district_analysis_data[id];
             let biome_names = {
@@ -786,50 +786,50 @@ mod tests {
                 names.join("+")
             };
             let a = &result.parcel_assignments[id];
-            println!("║   Super-Parcel {:>3} ({:<25}) → {} x2 [{}]",
+            println!("â•‘   Super-Parcel {:>3} ({:<25}) â†’ {} x2 [{}]",
                 id.0, biome_names, a.primary_resource, a.building);
         }
 
-        println!("║");
-        println!("║ Resource Supply:");
+        println!("â•‘");
+        println!("â•‘ Resource Supply:");
         let mut supply_sorted: Vec<(&String, &u32)> = result.supply.iter().collect();
         supply_sorted.sort_by_key(|(r, _)| r.as_str());
         for (resource, qty) in supply_sorted {
-            println!("║   {:<20} x{}", resource, qty);
+            println!("â•‘   {:<20} x{}", resource, qty);
         }
 
-        println!("║");
-        println!("║ Goods Produced:");
+        println!("â•‘");
+        println!("â•‘ Goods Produced:");
         if result.finished_goods.is_empty() && result.leftover_goods.is_empty() {
-            println!("║   (none)");
+            println!("â•‘   (none)");
         }
         for (good, qty) in &result.finished_goods {
-            println!("║   {:<20} x{}", good, qty);
+            println!("â•‘   {:<20} x{}", good, qty);
         }
         for (good, qty) in &result.leftover_goods {
-            println!("║   {:<20} x{}  (unused)", good, qty);
+            println!("â•‘   {:<20} x{}  (unused)", good, qty);
         }
 
-        println!("║");
-        println!("║ Gathering Buildings:");
+        println!("â•‘");
+        println!("â•‘ Gathering Buildings:");
         let mut gb_sorted: Vec<(&String, &u32)> = result.gather_buildings.iter().collect();
         gb_sorted.sort_by_key(|(b, _)| b.as_str());
         for (building, count) in gb_sorted {
-            println!("║   {:<20} x{}", building, count);
+            println!("â•‘   {:<20} x{}", building, count);
         }
 
-        println!("║");
-        println!("║ Processing Buildings Required:");
+        println!("â•‘");
+        println!("â•‘ Processing Buildings Required:");
         if result.processing_buildings.is_empty() {
-            println!("║   (none)");
+            println!("â•‘   (none)");
         }
         let mut pb_sorted: Vec<(&String, &u32)> = result.processing_buildings.iter().collect();
         pb_sorted.sort_by(|(a, ac), (b, bc)| bc.cmp(ac).then(a.cmp(b)));
         for (building, count) in pb_sorted {
-            println!("║   {:<20} x{}", building, count);
+            println!("â•‘   {:<20} x{}", building, count);
         }
 
-        println!("╚═══════════════════════════════════════════════════╝\n");
+        println!("â•šâ•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•\n");
     }
 
     #[tokio::test]
@@ -1129,580 +1129,14 @@ mod tests {
     /// parcels -> wall+gates -> flatten -> arterials(MST)+collectors(gates) -> build_path.
     #[tokio::test]
     async fn hierarchical_roads() {
-        use crate::generator::data::LoadedData;
-        use crate::generator::paths::{build_paths_merged, build_road_network, find_blocks, Path, PathPriority};
-        use crate::generator::terrain::{flatten_urban_area, force_height, log_trees};
-
         init_logger();
-
-        let seed = Seed(12345);
-        let mut rng = RNG::new(seed);
-        let mut rng2 = RNG::new(seed);
-
         let provider = GDMCHTTPProvider::new();
         let world = World::new(&provider).await.expect("Failed to create world");
         let mut editor = world.get_editor();
-
-        generate_parcels(seed, &mut editor).await;
-
-        // EVAL AID (test-only): the live server hands out a different build area
-        // each run, and the urban classifier frequently collapses to a single
-        // parcel — too degenerate to evaluate the road network. Force a
-        // contiguous ~4-parcel urban core: keep the prime, then promote the
-        // nearest non-off-limits super-parcels to Urban.
-        {
-            use crate::generator::districts::ParcelType;
-            const TARGET_URBAN: usize = 4;
-            let mut info: Vec<(crate::generator::districts::DistrictID, Point2D, bool)> =
-                editor.world().districts.iter()
-                    .filter(|(id, sd)| {
-                        if sd.data.parcel_type == ParcelType::OffLimits {
-                            return false;
-                        }
-                        // Never force a water-heavy parcel urban — it would build the
-                        // town on a lake. (Matches URBAN_WATER_LIMIT in classification.)
-                        let water = editor.world().district_analysis_data
-                            .get(id)
-                            .map_or(0.0, |a| a.water_percentage());
-                        water <= 0.33
-                    })
-                    .map(|(id, sd)| {
-                        let pts = &sd.data.points_2d;
-                        let c = pts.iter().fold(Point2D::ZERO, |a, p| a + *p) / pts.len().max(1) as i32;
-                        (*id, c, sd.data.parcel_type == ParcelType::Urban)
-                    })
-                    .collect();
-            let anchor = info.iter().find(|(_, _, u)| *u).map(|(_, c, _)| *c)
-                .or_else(|| info.first().map(|(_, c, _)| *c));
-            if let Some(anchor) = anchor {
-                info.sort_by_key(|(_, c, _)| c.distance_squared(&anchor));
-                for (id, _, _) in info.iter().take(TARGET_URBAN) {
-                    editor.world_mut().districts.get_mut(id).unwrap().data.parcel_type = ParcelType::Urban;
-                }
-            }
-        }
-
-        // Wall + gates — gates populate world.gate_locations, used by the network.
-        let materials = Material::load().expect("Failed to load materials");
-        let wall_material = MaterialId::new("stone_bricks".to_string());
-        let mut placer: Placer = Placer::new(&materials, &mut rng);
-        let structures = Structure::load().expect("Failed to load structures");
-        build_wall(
-            &editor.world().get_urban_points(), &mut editor, &mut rng2,
-            &mut placer, &wall_material, &structures, WallType::Standard,
+        crate::generator::settlement::generate_town(
+            &mut editor,
+            Seed(12345),
+            crate::generator::buildings_v2::Culture::Medieval,
         ).await;
-        drop(placer);
-
-        // DEBUG: how many urban super-parcels and gates did we actually get?
-        {
-            let n_urban = editor.world().districts.values()
-                .filter(|sd| sd.data.parcel_type == crate::generator::districts::ParcelType::Urban)
-                .count();
-            let n_total = editor.world().districts.len();
-            println!("URBAN super-parcels: {}/{} total | gates: {}", n_urban, n_total, editor.world().gate_locations.len());
-        }
-
-        // Phase 1 — feathered urban flatten.
-        let urban = editor.world().get_urban_points();
-        // Log (clear) the urban area of trees so roads, buildings, and houses
-        // aren't dropped into standing forest.
-        log_trees(&editor, urban.clone()).await;
-        println!("Logged {} urban cells of trees", urban.len());
-        flatten_urban_area(&mut editor, &urban, 16, 12, true).await;
-
-        let data = LoadedData::load().expect("Failed to load data");
-
-        // ---- Industrial buildings FIRST ----
-        // Place a handful of big processing buildings on the flattened ground (no
-        // roads yet → sited by flatness). They become the destinations the arterial
-        // network connects, plus a `blocked` barrier so nothing — roads, the
-        // subdivision, alleys, or houses — ever runs through them. (Fixed set here;
-        // the resource chain's `resolve_for_parcels` can supply the real mix later.)
-        use crate::generator::BuildClaim;
-        use crate::generator::placement::place_urban_buildings;
-
-        let mut ind_counts: HashMap<String, u32> = HashMap::new();
-        for b in ["smithy", "mill", "bakery", "carpenter", "tannery", "weaver"] {
-            ind_counts.insert(b.to_string(), 1);
-        }
-        let urban_sds: Vec<_> = editor.world().districts.values()
-            .filter(|sd| sd.data.parcel_type == crate::generator::districts::ParcelType::Urban)
-            .cloned()
-            .collect();
-        let urban_sd_refs: Vec<_> = urban_sds.iter().collect();
-        let n_before = editor.world().structures.len();
-        // Re-skin the industrial NBTs into the settlement's culture palette
-        // (their baked `resource_base` blocks → medieval spruce/stone).
-        let ind_palette = data.palettes
-            .get(&crate::generator::buildings_v2::Culture::Medieval.palette_id())
-            .expect("industry palette not found").clone();
-        if let Err(e) = place_urban_buildings(&urban_sd_refs, &ind_counts, &mut rng, &mut editor, &data, Some(&ind_palette)).await {
-            log::warn!("industrial placement failed: {}", e);
-        }
-        println!(
-            "Placed {} / {} industrial buildings",
-            editor.world().structures.len() - n_before, ind_counts.values().sum::<u32>(),
-        );
-
-        // Footprints → a `blocked` barrier (footprint + margin) and one node per
-        // building for the network to connect.
-        const IND_MARGIN: i32 = 2;
-        let mut ind_footprints: HashMap<u32, Vec<Point2D>> = HashMap::new();
-        for &p in &urban {
-            if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
-                ind_footprints.entry(id.id).or_default().push(p);
-            }
-        }
-        let building_cells: HashSet<Point2D> = ind_footprints.values().flatten().copied().collect();
-        let blocked: HashSet<Point2D> = building_cells.iter()
-            .flat_map(|p| {
-                (-IND_MARGIN..=IND_MARGIN).flat_map(move |dx| {
-                    (-IND_MARGIN..=IND_MARGIN).map(move |dz| Point2D::new(p.x + dx, p.y + dz))
-                })
-            })
-            .collect();
-        let ind_nodes: Vec<Point3D> = ind_footprints.values()
-            .map(|cells| {
-                let c = cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
-                editor.world().add_height(c)
-            })
-            .collect();
-
-        // Phase 2 — tiered A* road network, connecting the industrial buildings
-        // (anchor nodes) and routed around them (the `blocked` barrier).
-        let arterial_material = MaterialId::new("stone_bricks".to_string());
-        let collector_material = MaterialId::new("cobblestone".to_string());
-        let paths = build_road_network(
-            &editor, arterial_material, collector_material, true, &ind_nodes, &blocked, 1,
-        ).await.paths;
-        println!("Routed {} road segments", paths.len());
-
-        // DEBUG: Phase A merge check — how many of each path's cells coincide
-        // with cells already laid by earlier paths? High overlap = routes are
-        // merging onto the network instead of crossing it blindly.
-        {
-            let mut seen: HashSet<Point2D> = HashSet::new();
-            for path in &paths {
-                let cells: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
-                let shared = cells.iter().filter(|c| seen.contains(c)).count();
-                println!("  MERGE prio={:?} pts={} shared_with_network={}", path.priority(), cells.len(), shared);
-                seen.extend(cells);
-            }
-        }
-
-        // DEBUG: does the routed path y match the post-flatten heightmap?
-        if let Some(path) = paths.first() {
-            println!("--- path[0] sample: road_y vs ground_h vs ocean_h ---");
-            for p in path.points().iter().take(25) {
-                let xz = p.drop_y();
-                println!(
-                    "  ({:>4},{:>4})  road_y={:>3}  ground_h={:>3}  ocean_h={:>3}",
-                    xz.x, xz.y, p.y,
-                    editor.world().get_height_at(xz),
-                    editor.world().get_ocean_floor_height_at(xz),
-                );
-            }
-        }
-
-        // A path's *paved* cells — exactly what `build_paths_merged` lays:
-        // centreline ∪ (width-1) ring. Used for block barriers and frontage
-        // bands so blocks abut the real road edge (no gap ring).
-        let paved = |path: &Path| -> HashSet<Point2D> {
-            let centre: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
-            let mut cells = crate::geometry::get_surrounding_set(&centre, path.width().saturating_sub(1));
-            cells.extend(centre);
-            cells
-        };
-
-        // Blocks = urban minus the paved main roads and the wall.
-        let wall: HashSet<Point2D> = urban.iter()
-            .filter(|&&c| crate::geometry::CARDINALS_2D.iter().any(|&d| !urban.contains(&(c + d))))
-            .copied()
-            .collect();
-        let mut barriers: HashSet<Point2D> = HashSet::new();
-        for path in &paths {
-            barriers.extend(paved(path));
-        }
-        barriers.extend(&wall);
-        // Industrial buildings (footprint + margin) are barriers too, so blocks —
-        // and the subdivision, alleys, and houses inside them — form *around* the
-        // buildings, never through them.
-        barriers.extend(&blocked);
-
-        // Don't let blocks (and the lots/alleys/houses inside them) span steep
-        // terrain. A per-cell cliff test misses a *sustained* slope — a long
-        // staircase of 1-block risers passes cell-by-cell yet climbs far. So bar
-        // any cell whose local WIN-radius neighbourhood spans more than
-        // MAX_LOCAL_RELIEF blocks of height; the flood fill then breaks blocks
-        // along slope lines, keeping lots and their lanes on a flat shelf.
-        const WIN: i32 = 1; // 3×3 window
-        const MAX_LOCAL_RELIEF: i32 = 2;
-        let steep: HashSet<Point2D> = urban.iter()
-            .filter(|&&c| {
-                let (mut lo, mut hi) = (i32::MAX, i32::MIN);
-                for dx in -WIN..=WIN {
-                    for dz in -WIN..=WIN {
-                        let n = Point2D::new(c.x + dx, c.y + dz);
-                        if !urban.contains(&n) { continue; }
-                        let h = editor.world().get_ocean_floor_height_at(n);
-                        lo = lo.min(h);
-                        hi = hi.max(h);
-                    }
-                }
-                hi - lo > MAX_LOCAL_RELIEF
-            })
-            .copied()
-            .collect();
-        println!("Marked {} steep cells as barriers", steep.len());
-        barriers.extend(&steep);
-
-        let blocks = find_blocks(&urban, &barriers, 12);
-        println!("Found {} blocks", blocks.len());
-
-        // All main-road (arterial + collector) paved cells, used to peel a
-        // frontage ribbon off each block before subdividing its interior.
-        let main_road_cells: HashSet<Point2D> = {
-            let mut s = HashSet::new();
-            for path in &paths {
-                s.extend(paved(path));
-            }
-            s
-        };
-
-        // Per block: first reserve a frontage ribbon — a band one house deep
-        // against each main road — so the long arterial/collector-facing edge
-        // stays a single continuous lot instead of being chopped into stubs
-        // by subdivision. Then subdivide only the interior with tier-3 alleys.
-        // BSP cuts span the interior edge-to-edge, so an alley reaches its edge —
-        // adjacent (barriers = paved) to either a main road or the ribbon.
-        // Deep enough to absorb both the deepest House (depth_range 7..=10) AND
-        // the staircase rise of a diagonal frontage (an axis-aligned rect anchored
-        // at the slice's interior extreme reaches `rise + depth` into the band).
-        const RIBBON_DEPTH: i32 = 14;
-        let mut sub_blocks: Vec<HashSet<Point2D>> = Vec::new();
-        let mut alley_band: HashSet<Point2D> = HashSet::new();
-        let mut ribbon_lot_count = 0usize;
-        let mut ribbon_cells: HashSet<Point2D> = HashSet::new(); // DEBUG: all reserved ribbon cells
-        for block in &blocks {
-            let (mut ribbon_lots, interior) =
-                crate::generator::districts::subdivide::reserve_road_ribbon(block, &main_road_cells, RIBBON_DEPTH);
-            let (subs, alleys) = crate::generator::districts::subdivide::subdivide_block(&interior, &mut rng, 24);
-
-            // Connect the interior alleys to the main roads by carving through the
-            // ribbon, then convert those cells from frontage ribbon to alley.
-            let ribbon_union: HashSet<Point2D> = ribbon_lots.iter().flatten().copied().collect();
-            let connectors = crate::generator::districts::subdivide::carve_ribbon_connectors(
-                &ribbon_union, &alleys, &main_road_cells,
-            );
-            if !connectors.is_empty() {
-                for rp in &mut ribbon_lots { rp.retain(|c| !connectors.contains(c)); }
-                ribbon_lots.retain(|rp| !rp.is_empty());
-            }
-
-            ribbon_lot_count += ribbon_lots.len();
-            for rp in &ribbon_lots { ribbon_cells.extend(rp); }
-            sub_blocks.extend(ribbon_lots);
-            alley_band.extend(&alleys);
-            alley_band.extend(&connectors);
-            sub_blocks.extend(subs);
-        }
-        println!(
-            "Subdivided into {} lots ({} road-frontage ribbons), {} subdivider-road cells",
-            sub_blocks.len(), ribbon_lot_count, alley_band.len(),
-        );
-
-        // Assemble every road into one path list (mains + a synthesised width-1
-        // alley path), but DON'T build them yet — we build after the houses so
-        // house-foundation earth can't bury the road. Houses are placed first and
-        // sit their floor at the level of the road they front (see `road_h`).
-        let alley_pts: Vec<Point3D> = alley_band.iter().map(|c| editor.world().add_height(*c)).collect();
-        let alley_path = Path::new(alley_pts, 1, MaterialId::new("cobblestone".to_string()), PathPriority::Low);
-        let mut all_paths = paths.clone();
-        all_paths.push(alley_path);
-
-        // Road-height lookup over the paved band of every road (centreline +
-        // width ring, min y on overlap), so a house can pin its floor to the
-        // road it fronts. Built from `all_paths` so alley-facing houses get the
-        // alley level too.
-        let mut road_h: HashMap<Point2D, i32> = HashMap::new();
-        for path in &all_paths {
-            let w = path.width() as i32;
-            for pt in path.points() {
-                let base = pt.drop_y();
-                for dx in -w..=w {
-                    for dz in -w..=w {
-                        let c = Point2D::new(base.x + dx, base.y + dz);
-                        road_h.entry(c).and_modify(|y| *y = (*y).min(pt.y)).or_insert(pt.y);
-                    }
-                }
-            }
-        }
-
-        // Frontage bands per tier (paved cells, matching the roads we'll build).
-        let band = |prio: PathPriority| -> HashSet<Point2D> {
-            let mut s = HashSet::new();
-            for path in paths.iter().filter(|p| p.priority() == prio) {
-                s.extend(paved(path));
-            }
-            s
-        };
-        let arterial_band = band(PathPriority::High);
-        let collector_band = band(PathPriority::Medium);
-
-        // Build the roads FIRST, then the houses. force_height grades the corridor
-        // to the routed road heights, then build_paths_merged lays + melds the
-        // surface. We then claim every paved cell as `Path` so the following
-        // house foundations' terrain blending skips them (blend_terrain ignores
-        // Path claims) — the road can't be buried by foundation earth. The graded
-        // corridor is exactly `road_h` (same band, same min-on-overlap height).
-        let corridor_pts: HashSet<Point3D> = road_h
-            .iter()
-            .map(|(c, &y)| Point3D::new(c.x, y, c.y))
-            .collect();
-        force_height(&mut editor, &corridor_pts, false).await;
-        // `build_paths_merged` returns the exact cells where it laid a half-step
-        // slab; we raise a house a block over a fronting slab off this set rather
-        // than reading the placed road back (the editor cache is keyed by local
-        // coords while get_block subtracts the build-area origin, so a read here
-        // returns world terrain, not the road).
-        let road_slabs: HashSet<Point3D> = build_paths_merged(&editor, &data, &all_paths, &mut rng).await;
-        let slab_y_by_cell: HashMap<Point2D, i32> =
-            road_slabs.iter().map(|p| (p.drop_y(), p.y)).collect();
-
-        // Claim every paved road cell so house-foundation terraforming can't
-        // touch it (blend_terrain skips `BuildClaim::Path`).
-        for path in &all_paths {
-            for c in paved(path) {
-                editor.world_mut().claim(c, crate::generator::BuildClaim::Path(crate::generator::paths::PathType::Pavement));
-            }
-        }
-
-        // ---- Phase 4: hierarchical house placement ----
-        // Per lot, walk frontage densest-tier first: arterial → collector →
-        // subdivider. The lot's single Plot is shared across tiers, so houses
-        // placed against the arterial claim the prime frontage and later tiers
-        // can't overlap them. Size gradient: houses on roads, cottages on lanes.
-        use crate::generator::buildings_v2::{BuildCtx, BuildingContext, Culture, build_house};
-        use crate::generator::buildings_v2::roof::RoofStyle;
-        use crate::generator::buildings_v2::roof::gable::GablePitch;
-        use crate::generator::buildings_v2::footprint::{Footprint, SizeClass};
-        use crate::generator::city_houses::{
-            frontage_from_roads, plot_from_block, rect_from_frontage,
-            synthetic_plot_bounds, SIDE_BUFFER_CELLS,
-        };
-        use crate::generator::materials::{Palette, PaletteId};
-        use crate::geometry::Point2D as P2;
-
-        // Culture for this settlement. Medieval → spruce/stone palette, gable
-        // roofs, glass windows, and timber-frame jetties (square_bias 0, so no
-        // domes; per-house wood/stone/roof variety via roll_palette below).
-        let culture = Culture::Medieval;
-        let base_palette: Palette = data.palettes.get(&culture.palette_id())
-            .expect("base palette not found").clone();
-        let wood_ids: Vec<PaletteId> = vec!["oak".into(), "spruce".into(), "dark_oak".into()];
-        let stone_ids: Vec<PaletteId> = vec!["stone_bricks".into(), "cobblestone".into(), "deepslate".into()];
-        let roof_ids: Vec<PaletteId> = vec![
-            "acacia_wood_roof".into(), "brick_roof".into(), "oak_wood_roof".into(), "red_wood_roof".into(),
-        ];
-        let roof_styles = culture.roof_styles();
-
-        fn roll_palette(rng: &mut RNG, base: &Palette, data: &LoadedData, woods: &[PaletteId], stones: &[PaletteId], roofs: &[PaletteId]) -> Palette {
-            let w = &woods[rng.rand_i32_range(0, woods.len() as i32) as usize];
-            let s = &stones[rng.rand_i32_range(0, stones.len() as i32) as usize];
-            let r = &roofs[rng.rand_i32_range(0, roofs.len() as i32) as usize];
-            base.clone()
-                .merged_with(data.palettes.get(w).expect("wood palette not found"))
-                .merged_with(data.palettes.get(s).expect("stone palette not found"))
-                .merged_with(data.palettes.get(r).expect("roof palette not found"))
-        }
-        // Densest tier first; size pool per tier (houses on the main roads,
-        // cottages on the back lanes).
-        // House + Hall on every tier for now (district wealth will refine this
-        // later). Slots that can't fit a Hall's wider frontage just skip.
-        let tiers: [(&HashSet<Point2D>, &[SizeClass]); 3] = [
-            (&arterial_band, &[SizeClass::House, SizeClass::Hall]),
-            (&collector_band, &[SizeClass::House, SizeClass::Hall]),
-            (&alley_band, &[SizeClass::House, SizeClass::Hall]),
-        ];
-
-        let mut total_buildings = 0usize;
-        let mut tier_cells = [0usize; 3];   // frontage cells found per tier
-        let mut tier_placed = [0usize; 3];  // houses placed per tier
-        let mut tier_fail = [0usize; 3];    // build_house failures per tier
-        let mut tier_short = [0usize; 3];   // chains dropped: shorter than min_front
-        let mut tier_unfit = [0usize; 3];   // slots skipped: rect didn't fit the lot
-        // DEBUG: every cell detected as frontage, per tier, so we can float a
-        // marker above it and see what the placement loop actually "sees".
-        let mut tier_frontage: [HashSet<Point2D>; 3] = Default::default();
-        // Verge cells per main-road tier (arterial, collector): the gap between
-        // the road and each house front, which we pave into a forecourt so the
-        // unavoidable set-back on a diagonal reads as a shoulder, not bare grass.
-        let mut tier_verge: [HashSet<Point2D>; 2] = Default::default();
-        for lot in &sub_blocks {
-            if lot.is_empty() { continue; }
-            let Some(mut plot) = plot_from_block(lot) else { continue; };
-
-            for (ti, (band, pool)) in tiers.iter().enumerate() {
-                let min_front = pool.iter().map(|s| *s.front_width_range().start()).min().unwrap_or(0);
-                for frontage in frontage_from_roads(lot, band) {
-                    tier_cells[ti] += frontage.cells.len();
-                    tier_frontage[ti].extend(&frontage.cells);
-                    let chain_len = frontage.cells.len() as i32;
-                    if chain_len < min_front { tier_short[ti] += 1; continue; }
-                    let mut cursor: i32 = if min_front > 1 { rng.rand_i32_range(0, min_front) } else { 0 };
-                    // Shallowest depth we'll accept on a slice that can't take the
-                    // rolled depth — lets diagonal frontage (where an axis-aligned
-                    // rect overruns the staircased ribbon) still seat a house.
-                    const MIN_FIT_DEPTH: i32 = 5;
-                    while cursor + min_front <= chain_len {
-                        let size_class = *rng.choose(pool);
-                        let fw = rng.rand_i32_range(*size_class.front_width_range().start(), *size_class.front_width_range().end() + 1);
-                        let max_depth = rng.rand_i32_range(*size_class.depth_range().start(), *size_class.depth_range().end() + 1);
-                        if cursor + fw > chain_len { cursor += 1; continue; }
-                        let chain_slice = &frontage.cells[cursor as usize..(cursor + fw) as usize];
-                        // Square-frontage bias: with the culture's square chance,
-                        // make the house a square (depth = front width) if it fits,
-                        // so it gets a dome. Guarded so a 0 bias never draws RNG.
-                        // Otherwise pick the deepest depth (down to MIN_FIT_DEPTH)
-                        // that fits, shrinking the house to hug a diagonal ribbon.
-                        let want_square = culture.square_bias() > 0
-                            && rng.percent(culture.square_bias())
-                            && plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, fw));
-                        let depth = if want_square {
-                            fw
-                        } else if let Some(d) = (MIN_FIT_DEPTH..=max_depth).rev()
-                            .find(|&d| plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, d)))
-                        {
-                            d
-                        } else {
-                            tier_unfit[ti] += 1; cursor += 1; continue;
-                        };
-                        let rect = rect_from_frontage(chain_slice, frontage.outward, depth);
-
-                        // Desert keeps a uniform sandstone palette; other cultures
-                        // roll wood/stone/roof variants per house for variety.
-                        let palette = match culture {
-                            Culture::Desert => base_palette.clone(),
-                            _ => roll_palette(&mut rng, &base_palette, &data, &wood_ids, &stone_ids, &roof_ids),
-                        };
-                        let roof_style = roof_styles[rng.rand_i32_range(0, roof_styles.len() as i32) as usize];
-                        let plot_bounds = synthetic_plot_bounds(&rect, frontage.outward);
-                        let footprint = Footprint::from_rect(rect);
-                        // Align the main door with the road it faces: pin the floor
-                        // (= door sill) to the height of the *nearest* road cell to
-                        // this frontage. Probe outward from every frontage cell and
-                        // keep the closest road-height hit.
-                        let road_dir = P2::from(frontage.outward);
-                        let base_lvl = {
-                            let mut best: Option<(i32, i32, P2)> = None; // (dist, height, road cell)
-                            for &c in chain_slice {
-                                for step in 1..=RIBBON_DEPTH {
-                                    let probe = c + P2::new(road_dir.x * step, road_dir.y * step);
-                                    if let Some(&y) = road_h.get(&probe) {
-                                        if best.map_or(true, |(bd, _, _)| step < bd) { best = Some((step, y, probe)); }
-                                        break;
-                                    }
-                                }
-                            }
-                            best.map(|(_, y, cell)| {
-                                // If the fronting road cell carries a half-step slab,
-                                // raise the floor one block above the slab so the door
-                                // steps down onto it instead of opening onto a lip.
-                                match slab_y_by_cell.get(&cell) {
-                                    Some(&slab_y) => slab_y + 1,
-                                    None => y,
-                                }
-                            })
-                        };
-                        let mut bctx = BuildingContext::new(culture, size_class, roof_style);
-                        bctx.base_y_override = base_lvl;
-                        let mut bctx_editor = BuildCtx::new(&mut editor, &data, &palette, &mut rng);
-                        match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
-                            Ok(_) => {
-                                plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
-                                total_buildings += 1;
-                                tier_placed[ti] += 1;
-                                // Record the verge: from each frontage cell, walk
-                                // into the block (−outward) until we reach the
-                                // house. On a straight slice this is just the
-                                // frontage row; on a diagonal it's the triangular
-                                // set-back we want to pave over.
-                                if ti < 2 {
-                                    let road_dir = P2::from(frontage.outward);
-                                    let into = P2::new(-road_dir.x, -road_dir.y);
-                                    for &c in chain_slice {
-                                        let mut p = c;
-                                        let mut guard = 0;
-                                        while !rect.contains(p) && guard < 32 {
-                                            tier_verge[ti].insert(p);
-                                            p = p + into;
-                                            guard += 1;
-                                        }
-                                    }
-                                }
-                                cursor += fw + SIDE_BUFFER_CELLS;
-                            }
-                            Err(msg) => {
-                                tier_fail[ti] += 1;
-                                log::warn!("placement build_house failed: {}", msg);
-                                cursor += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        println!("Placed {} buildings across {} lots", total_buildings, sub_blocks.len());
-        println!(
-            "Per-tier [frontage cells / placed / failed] — arterial: {}/{}/{}  collector: {}/{}/{}  subdivider: {}/{}/{}",
-            tier_cells[0], tier_placed[0], tier_fail[0],
-            tier_cells[1], tier_placed[1], tier_fail[1],
-            tier_cells[2], tier_placed[2], tier_fail[2],
-        );
-        println!(
-            "Per-tier skips [short-chain / rect-unfit] — arterial: {}/{}  collector: {}/{}  subdivider: {}/{}",
-            tier_short[0], tier_unfit[0],
-            tier_short[1], tier_unfit[1],
-            tier_short[2], tier_unfit[2],
-        );
-
-        // Pave the verge: a forecourt of the road's own material in the gap
-        // between each main road and its houses, so the diagonal set-back reads
-        // as a paved shoulder. Painted at the live ground top (h-1), matching the
-        // post-flatten/foundation surface. Arterial verge = stone bricks (its
-        // road material), collector verge = cobblestone.
-        let verge_blocks = [
-            Block { id: "stone_bricks".into(), data: None, state: None },
-            Block { id: "cobblestone".into(), data: None, state: None },
-        ];
-        let mut verge_total = 0usize;
-        for (ti, cells) in tier_verge.iter().enumerate() {
-            for c in cells {
-                let h = editor.world().get_ocean_floor_height_at(*c);
-                editor.place_block(&verge_blocks[ti], Point3D::new(c.x, h - 1, c.y)).await;
-                verge_total += 1;
-            }
-        }
-        println!("Paved {} verge cells (arterial {} + collector {})", verge_total, tier_verge[0].len(), tier_verge[1].len());
-
-        // Street lighting: run last, after houses have claimed their cells, so
-        // lamps line every road's verge without landing on a building. The city
-        // generator picks the lantern type city-wide.
-        let city_rect = editor.world().world_rect_2d();
-        let city_centre = (city_rect.origin + city_rect.max()) / 2;
-        let cold = {
-            let n = editor.world().get_surface_biome_at(city_centre);
-            let n = n.name();
-            n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
-        };
-        let street_lantern: crate::minecraft::Block = if cold {
-            "minecraft:soul_lantern".into()
-        } else {
-            "minecraft:lantern".into()
-        };
-        let lamps = crate::generator::paths::place_street_lights(&editor, &all_paths, &street_lantern).await;
-        println!("Placed {} street lamps", lamps.len());
-
-        editor.flush_buffer().await;
     }
 }

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -1232,9 +1232,9 @@ mod tests {
         let urban_sd_refs: Vec<_> = urban_sds.iter().collect();
         let n_before = editor.world().structures.len();
         // Re-skin the industrial NBTs into the settlement's culture palette
-        // (their baked `resource_base` blocks → desert sandstone).
+        // (their baked `resource_base` blocks → medieval spruce/stone).
         let ind_palette = data.palettes
-            .get(&crate::generator::buildings_v2::Culture::Desert.palette_id())
+            .get(&crate::generator::buildings_v2::Culture::Medieval.palette_id())
             .expect("industry palette not found").clone();
         if let Err(e) = place_urban_buildings(&urban_sd_refs, &ind_counts, &mut rng, &mut editor, &data, Some(&ind_palette)).await {
             log::warn!("industrial placement failed: {}", e);
@@ -1493,9 +1493,10 @@ mod tests {
         use crate::generator::materials::{Palette, PaletteId};
         use crate::geometry::Point2D as P2;
 
-        // Culture for this settlement. Desert → sandstone palette, flat roofs,
-        // and domed square rects (see buildings_v2::roof::dome).
-        let culture = Culture::Desert;
+        // Culture for this settlement. Medieval → spruce/stone palette, gable
+        // roofs, glass windows, and timber-frame jetties (square_bias 0, so no
+        // domes; per-house wood/stone/roof variety via roll_palette below).
+        let culture = Culture::Medieval;
         let base_palette: Palette = data.palettes.get(&culture.palette_id())
             .expect("base palette not found").clone();
         let wood_ids: Vec<PaletteId> = vec!["oak".into(), "spruce".into(), "dark_oak".into()];

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -12,5 +12,7 @@ pub mod paths;
 pub mod placement;
 pub mod style;
 pub mod chronicle;
+pub mod settlement;
 
 pub use build_claim::BuildClaim;
+pub use settlement::generate_town;

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -1,0 +1,591 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::data::Loadable;
+use crate::editor::Editor;
+use crate::generator::data::LoadedData;
+use crate::generator::districts::{build_wall, generate_parcels, ParcelType, WallType};
+use crate::generator::materials::{Material, MaterialId, Placer};
+use crate::generator::nbts::Structure;
+use crate::generator::paths::{build_paths_merged, build_road_network, find_blocks, Path, PathPriority};
+use crate::generator::terrain::{flatten_urban_area, force_height, log_trees};
+use crate::geometry::{Point2D, Point3D};
+use crate::minecraft::Block;
+use crate::noise::{Seed, RNG};
+
+/// Full town-generation pipeline: feathered urban flatten + tiered A* road
+/// network, then hierarchical house placement.
+///
+/// parcels -> wall+gates -> flatten -> industrial buildings -> arterials(MST) +
+/// collectors(gates) -> blocks/subdivision -> roads -> houses -> verge + lights.
+///
+/// The caller is responsible for constructing the `Editor` (and the `World`
+/// behind it) and for flushing/finalising afterwards beyond the final
+/// `flush_buffer` performed here.
+pub async fn generate_town(
+    editor: &mut Editor,
+    seed: Seed,
+    culture: crate::generator::buildings_v2::Culture,
+) {
+    let mut rng = RNG::new(seed);
+    let mut rng2 = RNG::new(seed);
+
+    generate_parcels(seed, editor).await;
+
+    // EVAL AID: the live server hands out a different build area each run, and
+    // the urban classifier frequently collapses to a single parcel — too
+    // degenerate to evaluate the road network. Force a contiguous ~4-parcel
+    // urban core: keep the prime, then promote the nearest non-off-limits
+    // super-parcels to Urban.
+    {
+        const TARGET_URBAN: usize = 4;
+        let mut info: Vec<(crate::generator::districts::DistrictID, Point2D, bool)> =
+            editor.world().districts.iter()
+                .filter(|(id, sd)| {
+                    if sd.data.parcel_type == ParcelType::OffLimits {
+                        return false;
+                    }
+                    // Never force a water-heavy parcel urban — it would build the
+                    // town on a lake. (Matches URBAN_WATER_LIMIT in classification.)
+                    let water = editor.world().district_analysis_data
+                        .get(id)
+                        .map_or(0.0, |a| a.water_percentage());
+                    water <= 0.33
+                })
+                .map(|(id, sd)| {
+                    let pts = &sd.data.points_2d;
+                    let c = pts.iter().fold(Point2D::ZERO, |a, p| a + *p) / pts.len().max(1) as i32;
+                    (*id, c, sd.data.parcel_type == ParcelType::Urban)
+                })
+                .collect();
+        let anchor = info.iter().find(|(_, _, u)| *u).map(|(_, c, _)| *c)
+            .or_else(|| info.first().map(|(_, c, _)| *c));
+        if let Some(anchor) = anchor {
+            info.sort_by_key(|(_, c, _)| c.distance_squared(&anchor));
+            for (id, _, _) in info.iter().take(TARGET_URBAN) {
+                editor.world_mut().districts.get_mut(id).unwrap().data.parcel_type = ParcelType::Urban;
+            }
+        }
+    }
+
+    // Wall + gates — gates populate world.gate_locations, used by the network.
+    let materials = Material::load().expect("Failed to load materials");
+    let wall_material = MaterialId::new("stone_bricks".to_string());
+    let mut placer: Placer = Placer::new(&materials, &mut rng);
+    let structures = Structure::load().expect("Failed to load structures");
+    build_wall(
+        &editor.world().get_urban_points(), editor, &mut rng2,
+        &mut placer, &wall_material, &structures, WallType::Standard,
+    ).await;
+    drop(placer);
+
+    // DEBUG: how many urban super-parcels and gates did we actually get?
+    {
+        let n_urban = editor.world().districts.values()
+            .filter(|sd| sd.data.parcel_type == crate::generator::districts::ParcelType::Urban)
+            .count();
+        let n_total = editor.world().districts.len();
+        println!("URBAN super-parcels: {}/{} total | gates: {}", n_urban, n_total, editor.world().gate_locations.len());
+    }
+
+    // Phase 1 — feathered urban flatten.
+    let urban = editor.world().get_urban_points();
+    // Log (clear) the urban area of trees so roads, buildings, and houses
+    // aren't dropped into standing forest.
+    log_trees(&*editor, urban.clone()).await;
+    println!("Logged {} urban cells of trees", urban.len());
+    flatten_urban_area(editor, &urban, 16, 12, true).await;
+
+    let data = LoadedData::load().expect("Failed to load data");
+
+    // ---- Industrial buildings FIRST ----
+    // Place a handful of big processing buildings on the flattened ground (no
+    // roads yet → sited by flatness). They become the destinations the arterial
+    // network connects, plus a `blocked` barrier so nothing — roads, the
+    // subdivision, alleys, or houses — ever runs through them. (Fixed set here;
+    // the resource chain's `resolve_for_parcels` can supply the real mix later.)
+    use crate::generator::BuildClaim;
+    use crate::generator::placement::place_urban_buildings;
+
+    let mut ind_counts: HashMap<String, u32> = HashMap::new();
+    for b in ["smithy", "mill", "bakery", "carpenter", "tannery", "weaver"] {
+        ind_counts.insert(b.to_string(), 1);
+    }
+    let urban_sds: Vec<_> = editor.world().districts.values()
+        .filter(|sd| sd.data.parcel_type == crate::generator::districts::ParcelType::Urban)
+        .cloned()
+        .collect();
+    let urban_sd_refs: Vec<_> = urban_sds.iter().collect();
+    let n_before = editor.world().structures.len();
+    // Re-skin the industrial NBTs into the settlement's culture palette
+    // (their baked `resource_base` blocks → medieval spruce/stone).
+    let ind_palette = data.palettes
+        .get(&culture.palette_id())
+        .expect("industry palette not found").clone();
+    if let Err(e) = place_urban_buildings(&urban_sd_refs, &ind_counts, &mut rng, editor, &data, Some(&ind_palette)).await {
+        log::warn!("industrial placement failed: {}", e);
+    }
+    println!(
+        "Placed {} / {} industrial buildings",
+        editor.world().structures.len() - n_before, ind_counts.values().sum::<u32>(),
+    );
+
+    // Footprints → a `blocked` barrier (footprint + margin) and one node per
+    // building for the network to connect.
+    const IND_MARGIN: i32 = 2;
+    let mut ind_footprints: HashMap<u32, Vec<Point2D>> = HashMap::new();
+    for &p in &urban {
+        if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
+            ind_footprints.entry(id.id).or_default().push(p);
+        }
+    }
+    let building_cells: HashSet<Point2D> = ind_footprints.values().flatten().copied().collect();
+    let blocked: HashSet<Point2D> = building_cells.iter()
+        .flat_map(|p| {
+            (-IND_MARGIN..=IND_MARGIN).flat_map(move |dx| {
+                (-IND_MARGIN..=IND_MARGIN).map(move |dz| Point2D::new(p.x + dx, p.y + dz))
+            })
+        })
+        .collect();
+    let ind_nodes: Vec<Point3D> = ind_footprints.values()
+        .map(|cells| {
+            let c = cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
+            editor.world().add_height(c)
+        })
+        .collect();
+
+    // Phase 2 — tiered A* road network, connecting the industrial buildings
+    // (anchor nodes) and routed around them (the `blocked` barrier).
+    let arterial_material = MaterialId::new("stone_bricks".to_string());
+    let collector_material = MaterialId::new("cobblestone".to_string());
+    let paths = build_road_network(
+        &*editor, arterial_material, collector_material, true, &ind_nodes, &blocked, 1,
+    ).await.paths;
+    println!("Routed {} road segments", paths.len());
+
+    // DEBUG: Phase A merge check — how many of each path's cells coincide
+    // with cells already laid by earlier paths? High overlap = routes are
+    // merging onto the network instead of crossing it blindly.
+    {
+        let mut seen: HashSet<Point2D> = HashSet::new();
+        for path in &paths {
+            let cells: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
+            let shared = cells.iter().filter(|c| seen.contains(c)).count();
+            println!("  MERGE prio={:?} pts={} shared_with_network={}", path.priority(), cells.len(), shared);
+            seen.extend(cells);
+        }
+    }
+
+    // DEBUG: does the routed path y match the post-flatten heightmap?
+    if let Some(path) = paths.first() {
+        println!("--- path[0] sample: road_y vs ground_h vs ocean_h ---");
+        for p in path.points().iter().take(25) {
+            let xz = p.drop_y();
+            println!(
+                "  ({:>4},{:>4})  road_y={:>3}  ground_h={:>3}  ocean_h={:>3}",
+                xz.x, xz.y, p.y,
+                editor.world().get_height_at(xz),
+                editor.world().get_ocean_floor_height_at(xz),
+            );
+        }
+    }
+
+    // A path's *paved* cells — exactly what `build_paths_merged` lays:
+    // centreline ∪ (width-1) ring. Used for block barriers and frontage
+    // bands so blocks abut the real road edge (no gap ring).
+    let paved = |path: &Path| -> HashSet<Point2D> {
+        let centre: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
+        let mut cells = crate::geometry::get_surrounding_set(&centre, path.width().saturating_sub(1));
+        cells.extend(centre);
+        cells
+    };
+
+    // Blocks = urban minus the paved main roads and the wall.
+    let wall: HashSet<Point2D> = urban.iter()
+        .filter(|&&c| crate::geometry::CARDINALS_2D.iter().any(|&d| !urban.contains(&(c + d))))
+        .copied()
+        .collect();
+    let mut barriers: HashSet<Point2D> = HashSet::new();
+    for path in &paths {
+        barriers.extend(paved(path));
+    }
+    barriers.extend(&wall);
+    // Industrial buildings (footprint + margin) are barriers too, so blocks —
+    // and the subdivision, alleys, and houses inside them — form *around* the
+    // buildings, never through them.
+    barriers.extend(&blocked);
+
+    // Don't let blocks (and the lots/alleys/houses inside them) span steep
+    // terrain. A per-cell cliff test misses a *sustained* slope — a long
+    // staircase of 1-block risers passes cell-by-cell yet climbs far. So bar
+    // any cell whose local WIN-radius neighbourhood spans more than
+    // MAX_LOCAL_RELIEF blocks of height; the flood fill then breaks blocks
+    // along slope lines, keeping lots and their lanes on a flat shelf.
+    const WIN: i32 = 1; // 3×3 window
+    const MAX_LOCAL_RELIEF: i32 = 2;
+    let steep: HashSet<Point2D> = urban.iter()
+        .filter(|&&c| {
+            let (mut lo, mut hi) = (i32::MAX, i32::MIN);
+            for dx in -WIN..=WIN {
+                for dz in -WIN..=WIN {
+                    let n = Point2D::new(c.x + dx, c.y + dz);
+                    if !urban.contains(&n) { continue; }
+                    let h = editor.world().get_ocean_floor_height_at(n);
+                    lo = lo.min(h);
+                    hi = hi.max(h);
+                }
+            }
+            hi - lo > MAX_LOCAL_RELIEF
+        })
+        .copied()
+        .collect();
+    println!("Marked {} steep cells as barriers", steep.len());
+    barriers.extend(&steep);
+
+    let blocks = find_blocks(&urban, &barriers, 12);
+    println!("Found {} blocks", blocks.len());
+
+    // All main-road (arterial + collector) paved cells, used to peel a
+    // frontage ribbon off each block before subdividing its interior.
+    let main_road_cells: HashSet<Point2D> = {
+        let mut s = HashSet::new();
+        for path in &paths {
+            s.extend(paved(path));
+        }
+        s
+    };
+
+    // Per block: first reserve a frontage ribbon — a band one house deep
+    // against each main road — so the long arterial/collector-facing edge
+    // stays a single continuous lot instead of being chopped into stubs
+    // by subdivision. Then subdivide only the interior with tier-3 alleys.
+    // BSP cuts span the interior edge-to-edge, so an alley reaches its edge —
+    // adjacent (barriers = paved) to either a main road or the ribbon.
+    // Deep enough to absorb both the deepest House (depth_range 7..=10) AND
+    // the staircase rise of a diagonal frontage (an axis-aligned rect anchored
+    // at the slice's interior extreme reaches `rise + depth` into the band).
+    const RIBBON_DEPTH: i32 = 14;
+    let mut sub_blocks: Vec<HashSet<Point2D>> = Vec::new();
+    let mut alley_band: HashSet<Point2D> = HashSet::new();
+    let mut ribbon_lot_count = 0usize;
+    let mut ribbon_cells: HashSet<Point2D> = HashSet::new(); // DEBUG: all reserved ribbon cells
+    for block in &blocks {
+        let (mut ribbon_lots, interior) =
+            crate::generator::districts::subdivide::reserve_road_ribbon(block, &main_road_cells, RIBBON_DEPTH);
+        let (subs, alleys) = crate::generator::districts::subdivide::subdivide_block(&interior, &mut rng, 24);
+
+        // Connect the interior alleys to the main roads by carving through the
+        // ribbon, then convert those cells from frontage ribbon to alley.
+        let ribbon_union: HashSet<Point2D> = ribbon_lots.iter().flatten().copied().collect();
+        let connectors = crate::generator::districts::subdivide::carve_ribbon_connectors(
+            &ribbon_union, &alleys, &main_road_cells,
+        );
+        if !connectors.is_empty() {
+            for rp in &mut ribbon_lots { rp.retain(|c| !connectors.contains(c)); }
+            ribbon_lots.retain(|rp| !rp.is_empty());
+        }
+
+        ribbon_lot_count += ribbon_lots.len();
+        for rp in &ribbon_lots { ribbon_cells.extend(rp); }
+        sub_blocks.extend(ribbon_lots);
+        alley_band.extend(&alleys);
+        alley_band.extend(&connectors);
+        sub_blocks.extend(subs);
+    }
+    println!(
+        "Subdivided into {} lots ({} road-frontage ribbons), {} subdivider-road cells",
+        sub_blocks.len(), ribbon_lot_count, alley_band.len(),
+    );
+
+    // Assemble every road into one path list (mains + a synthesised width-1
+    // alley path), but DON'T build them yet — we build after the houses so
+    // house-foundation earth can't bury the road. Houses are placed first and
+    // sit their floor at the level of the road they front (see `road_h`).
+    let alley_pts: Vec<Point3D> = alley_band.iter().map(|c| editor.world().add_height(*c)).collect();
+    let alley_path = Path::new(alley_pts, 1, MaterialId::new("cobblestone".to_string()), PathPriority::Low);
+    let mut all_paths = paths.clone();
+    all_paths.push(alley_path);
+
+    // Road-height lookup over the paved band of every road (centreline +
+    // width ring, min y on overlap), so a house can pin its floor to the
+    // road it fronts. Built from `all_paths` so alley-facing houses get the
+    // alley level too.
+    let mut road_h: HashMap<Point2D, i32> = HashMap::new();
+    for path in &all_paths {
+        let w = path.width() as i32;
+        for pt in path.points() {
+            let base = pt.drop_y();
+            for dx in -w..=w {
+                for dz in -w..=w {
+                    let c = Point2D::new(base.x + dx, base.y + dz);
+                    road_h.entry(c).and_modify(|y| *y = (*y).min(pt.y)).or_insert(pt.y);
+                }
+            }
+        }
+    }
+
+    // Frontage bands per tier (paved cells, matching the roads we'll build).
+    let band = |prio: PathPriority| -> HashSet<Point2D> {
+        let mut s = HashSet::new();
+        for path in paths.iter().filter(|p| p.priority() == prio) {
+            s.extend(paved(path));
+        }
+        s
+    };
+    let arterial_band = band(PathPriority::High);
+    let collector_band = band(PathPriority::Medium);
+
+    // Build the roads FIRST, then the houses. force_height grades the corridor
+    // to the routed road heights, then build_paths_merged lays + melds the
+    // surface. We then claim every paved cell as `Path` so the following
+    // house foundations' terrain blending skips them (blend_terrain ignores
+    // Path claims) — the road can't be buried by foundation earth. The graded
+    // corridor is exactly `road_h` (same band, same min-on-overlap height).
+    let corridor_pts: HashSet<Point3D> = road_h
+        .iter()
+        .map(|(c, &y)| Point3D::new(c.x, y, c.y))
+        .collect();
+    force_height(editor, &corridor_pts, false).await;
+    // `build_paths_merged` returns the exact cells where it laid a half-step
+    // slab; we raise a house a block over a fronting slab off this set rather
+    // than reading the placed road back (the editor cache is keyed by local
+    // coords while get_block subtracts the build-area origin, so a read here
+    // returns world terrain, not the road).
+    let road_slabs: HashSet<Point3D> = build_paths_merged(&*editor, &data, &all_paths, &mut rng).await;
+    let slab_y_by_cell: HashMap<Point2D, i32> =
+        road_slabs.iter().map(|p| (p.drop_y(), p.y)).collect();
+
+    // Claim every paved road cell so house-foundation terraforming can't
+    // touch it (blend_terrain skips `BuildClaim::Path`).
+    for path in &all_paths {
+        for c in paved(path) {
+            editor.world_mut().claim(c, crate::generator::BuildClaim::Path(crate::generator::paths::PathType::Pavement));
+        }
+    }
+
+    // ---- Phase 4: hierarchical house placement ----
+    // Per lot, walk frontage densest-tier first: arterial → collector →
+    // subdivider. The lot's single Plot is shared across tiers, so houses
+    // placed against the arterial claim the prime frontage and later tiers
+    // can't overlap them. Size gradient: houses on roads, cottages on lanes.
+    use crate::generator::buildings_v2::{BuildCtx, BuildingContext, Culture, build_house};
+    use crate::generator::buildings_v2::roof::RoofStyle;
+    use crate::generator::buildings_v2::roof::gable::GablePitch;
+    use crate::generator::buildings_v2::footprint::{Footprint, SizeClass};
+    use crate::generator::city_houses::{
+        frontage_from_roads, plot_from_block, rect_from_frontage,
+        synthetic_plot_bounds, SIDE_BUFFER_CELLS,
+    };
+    use crate::generator::materials::{Palette, PaletteId};
+    use crate::geometry::Point2D as P2;
+
+    // Culture for this settlement. Medieval → spruce/stone palette, gable
+    // roofs, glass windows, and timber-frame jetties (square_bias 0, so no
+    // domes; per-house wood/stone/roof variety via roll_palette below).
+    let base_palette: Palette = data.palettes.get(&culture.palette_id())
+        .expect("base palette not found").clone();
+    let wood_ids: Vec<PaletteId> = vec!["oak".into(), "spruce".into(), "dark_oak".into()];
+    let stone_ids: Vec<PaletteId> = vec!["stone_bricks".into(), "cobblestone".into(), "deepslate".into()];
+    let roof_ids: Vec<PaletteId> = vec![
+        "acacia_wood_roof".into(), "brick_roof".into(), "oak_wood_roof".into(), "red_wood_roof".into(),
+    ];
+    let roof_styles = culture.roof_styles();
+
+    fn roll_palette(rng: &mut RNG, base: &Palette, data: &LoadedData, woods: &[PaletteId], stones: &[PaletteId], roofs: &[PaletteId]) -> Palette {
+        let w = &woods[rng.rand_i32_range(0, woods.len() as i32) as usize];
+        let s = &stones[rng.rand_i32_range(0, stones.len() as i32) as usize];
+        let r = &roofs[rng.rand_i32_range(0, roofs.len() as i32) as usize];
+        base.clone()
+            .merged_with(data.palettes.get(w).expect("wood palette not found"))
+            .merged_with(data.palettes.get(s).expect("stone palette not found"))
+            .merged_with(data.palettes.get(r).expect("roof palette not found"))
+    }
+    // Densest tier first; size pool per tier (houses on the main roads,
+    // cottages on the back lanes).
+    // House + Hall on every tier for now (district wealth will refine this
+    // later). Slots that can't fit a Hall's wider frontage just skip.
+    let tiers: [(&HashSet<Point2D>, &[SizeClass]); 3] = [
+        (&arterial_band, &[SizeClass::House, SizeClass::Hall]),
+        (&collector_band, &[SizeClass::House, SizeClass::Hall]),
+        (&alley_band, &[SizeClass::House, SizeClass::Hall]),
+    ];
+
+    let mut total_buildings = 0usize;
+    let mut tier_cells = [0usize; 3];   // frontage cells found per tier
+    let mut tier_placed = [0usize; 3];  // houses placed per tier
+    let mut tier_fail = [0usize; 3];    // build_house failures per tier
+    let mut tier_short = [0usize; 3];   // chains dropped: shorter than min_front
+    let mut tier_unfit = [0usize; 3];   // slots skipped: rect didn't fit the lot
+    // DEBUG: every cell detected as frontage, per tier, so we can float a
+    // marker above it and see what the placement loop actually "sees".
+    let mut tier_frontage: [HashSet<Point2D>; 3] = Default::default();
+    // Verge cells per main-road tier (arterial, collector): the gap between
+    // the road and each house front, which we pave into a forecourt so the
+    // unavoidable set-back on a diagonal reads as a shoulder, not bare grass.
+    let mut tier_verge: [HashSet<Point2D>; 2] = Default::default();
+    for lot in &sub_blocks {
+        if lot.is_empty() { continue; }
+        let Some(mut plot) = plot_from_block(lot) else { continue; };
+
+        for (ti, (band, pool)) in tiers.iter().enumerate() {
+            let min_front = pool.iter().map(|s| *s.front_width_range().start()).min().unwrap_or(0);
+            for frontage in frontage_from_roads(lot, band) {
+                tier_cells[ti] += frontage.cells.len();
+                tier_frontage[ti].extend(&frontage.cells);
+                let chain_len = frontage.cells.len() as i32;
+                if chain_len < min_front { tier_short[ti] += 1; continue; }
+                let mut cursor: i32 = if min_front > 1 { rng.rand_i32_range(0, min_front) } else { 0 };
+                // Shallowest depth we'll accept on a slice that can't take the
+                // rolled depth — lets diagonal frontage (where an axis-aligned
+                // rect overruns the staircased ribbon) still seat a house.
+                const MIN_FIT_DEPTH: i32 = 5;
+                while cursor + min_front <= chain_len {
+                    let size_class = *rng.choose(pool);
+                    let fw = rng.rand_i32_range(*size_class.front_width_range().start(), *size_class.front_width_range().end() + 1);
+                    let max_depth = rng.rand_i32_range(*size_class.depth_range().start(), *size_class.depth_range().end() + 1);
+                    if cursor + fw > chain_len { cursor += 1; continue; }
+                    let chain_slice = &frontage.cells[cursor as usize..(cursor + fw) as usize];
+                    // Square-frontage bias: with the culture's square chance,
+                    // make the house a square (depth = front width) if it fits,
+                    // so it gets a dome. Guarded so a 0 bias never draws RNG.
+                    // Otherwise pick the deepest depth (down to MIN_FIT_DEPTH)
+                    // that fits, shrinking the house to hug a diagonal ribbon.
+                    let want_square = culture.square_bias() > 0
+                        && rng.percent(culture.square_bias())
+                        && plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, fw));
+                    let depth = if want_square {
+                        fw
+                    } else if let Some(d) = (MIN_FIT_DEPTH..=max_depth).rev()
+                        .find(|&d| plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, d)))
+                    {
+                        d
+                    } else {
+                        tier_unfit[ti] += 1; cursor += 1; continue;
+                    };
+                    let rect = rect_from_frontage(chain_slice, frontage.outward, depth);
+
+                    // Desert keeps a uniform sandstone palette; other cultures
+                    // roll wood/stone/roof variants per house for variety.
+                    let palette = match culture {
+                        Culture::Desert => base_palette.clone(),
+                        _ => roll_palette(&mut rng, &base_palette, &data, &wood_ids, &stone_ids, &roof_ids),
+                    };
+                    let roof_style = roof_styles[rng.rand_i32_range(0, roof_styles.len() as i32) as usize];
+                    let plot_bounds = synthetic_plot_bounds(&rect, frontage.outward);
+                    let footprint = Footprint::from_rect(rect);
+                    // Align the main door with the road it faces: pin the floor
+                    // (= door sill) to the height of the *nearest* road cell to
+                    // this frontage. Probe outward from every frontage cell and
+                    // keep the closest road-height hit.
+                    let road_dir = P2::from(frontage.outward);
+                    let base_lvl = {
+                        let mut best: Option<(i32, i32, P2)> = None; // (dist, height, road cell)
+                        for &c in chain_slice {
+                            for step in 1..=RIBBON_DEPTH {
+                                let probe = c + P2::new(road_dir.x * step, road_dir.y * step);
+                                if let Some(&y) = road_h.get(&probe) {
+                                    if best.map_or(true, |(bd, _, _)| step < bd) { best = Some((step, y, probe)); }
+                                    break;
+                                }
+                            }
+                        }
+                        best.map(|(_, y, cell)| {
+                            // If the fronting road cell carries a half-step slab,
+                            // raise the floor one block above the slab so the door
+                            // steps down onto it instead of opening onto a lip.
+                            match slab_y_by_cell.get(&cell) {
+                                Some(&slab_y) => slab_y + 1,
+                                None => y,
+                            }
+                        })
+                    };
+                    let mut bctx = BuildingContext::new(culture, size_class, roof_style);
+                    bctx.base_y_override = base_lvl;
+                    let mut bctx_editor = BuildCtx::new(editor, &data, &palette, &mut rng);
+                    match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
+                        Ok(_) => {
+                            plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
+                            total_buildings += 1;
+                            tier_placed[ti] += 1;
+                            // Record the verge: from each frontage cell, walk
+                            // into the block (−outward) until we reach the
+                            // house. On a straight slice this is just the
+                            // frontage row; on a diagonal it's the triangular
+                            // set-back we want to pave over.
+                            if ti < 2 {
+                                let road_dir = P2::from(frontage.outward);
+                                let into = P2::new(-road_dir.x, -road_dir.y);
+                                for &c in chain_slice {
+                                    let mut p = c;
+                                    let mut guard = 0;
+                                    while !rect.contains(p) && guard < 32 {
+                                        tier_verge[ti].insert(p);
+                                        p = p + into;
+                                        guard += 1;
+                                    }
+                                }
+                            }
+                            cursor += fw + SIDE_BUFFER_CELLS;
+                        }
+                        Err(msg) => {
+                            tier_fail[ti] += 1;
+                            log::warn!("placement build_house failed: {}", msg);
+                            cursor += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    println!("Placed {} buildings across {} lots", total_buildings, sub_blocks.len());
+    println!(
+        "Per-tier [frontage cells / placed / failed] — arterial: {}/{}/{}  collector: {}/{}/{}  subdivider: {}/{}/{}",
+        tier_cells[0], tier_placed[0], tier_fail[0],
+        tier_cells[1], tier_placed[1], tier_fail[1],
+        tier_cells[2], tier_placed[2], tier_fail[2],
+    );
+    println!(
+        "Per-tier skips [short-chain / rect-unfit] — arterial: {}/{}  collector: {}/{}  subdivider: {}/{}",
+        tier_short[0], tier_unfit[0],
+        tier_short[1], tier_unfit[1],
+        tier_short[2], tier_unfit[2],
+    );
+
+    // Pave the verge: a forecourt of the road's own material in the gap
+    // between each main road and its houses, so the diagonal set-back reads
+    // as a paved shoulder. Painted at the live ground top (h-1), matching the
+    // post-flatten/foundation surface. Arterial verge = stone bricks (its
+    // road material), collector verge = cobblestone.
+    let verge_blocks = [
+        Block { id: "stone_bricks".into(), data: None, state: None },
+        Block { id: "cobblestone".into(), data: None, state: None },
+    ];
+    let mut verge_total = 0usize;
+    for (ti, cells) in tier_verge.iter().enumerate() {
+        for c in cells {
+            let h = editor.world().get_ocean_floor_height_at(*c);
+            editor.place_block(&verge_blocks[ti], Point3D::new(c.x, h - 1, c.y)).await;
+            verge_total += 1;
+        }
+    }
+    println!("Paved {} verge cells (arterial {} + collector {})", verge_total, tier_verge[0].len(), tier_verge[1].len());
+
+    // Street lighting: run last, after houses have claimed their cells, so
+    // lamps line every road's verge without landing on a building. The city
+    // generator picks the lantern type city-wide.
+    let city_rect = editor.world().world_rect_2d();
+    let city_centre = (city_rect.origin + city_rect.max()) / 2;
+    let cold = {
+        let n = editor.world().get_surface_biome_at(city_centre);
+        let n = n.name();
+        n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
+    };
+    let street_lantern: crate::minecraft::Block = if cold {
+        "minecraft:soul_lantern".into()
+    } else {
+        "minecraft:lantern".into()
+    };
+    let lamps = crate::generator::paths::place_street_lights(&*editor, &all_paths, &street_lantern).await;
+    println!("Placed {} street lamps", lamps.len());
+
+    editor.flush_buffer().await;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,24 +83,11 @@ async fn run_generation_once() {
     let provider = GDMCHTTPProvider::new();
     let world = World::new(&provider).await.unwrap();
     let mut editor = world.get_editor();
-    let mut rng = RNG::new(32);
-
-    generate_parcels(rng.next_i64().into(), &mut editor).await;
-    let mut info = SettlementInfo::new(editor.world());
-
-    let data = LoadedData::load().expect("Failed to load generator data");
-    let materials = Material::load().expect("Failed to load materials");
-    let material = MaterialId::new("spruce_planks".to_string());
-    let mut placer_rng = rng.derive();
-    let mut placer: Placer = Placer::new(&materials, &mut placer_rng);
-    let urban_points = &editor.world().get_urban_points();
-
-    log_trees(&mut editor, urban_points.clone()).await;
-    place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()], &info).await;
-    info = SettlementInfo::new(editor.world());
-    build_wall(urban_points, &mut editor, &mut rng.derive(), &mut placer, &material, &data.structures, WallType::Palisade).await;
-    editor.flush_buffer().await;
-    let _ = generate_chronicle(&mut editor, &mut info).await;
+    crate::generator::settlement::generate_town(
+        &mut editor,
+        crate::noise::Seed(12345),
+        crate::generator::buildings_v2::Culture::Medieval,
+    ).await;
 }
 
 #[tokio::main]

--- a/src/minecraft/form.rs
+++ b/src/minecraft/form.rs
@@ -28,6 +28,8 @@ pub enum BlockForm {
     PressurePlate,
     #[serde(rename = "chiseled")]
     Chiseled,
+    #[serde(rename = "shelf")]
+    Shelf,
     #[serde(rename = "wood")]
     Wood,
     #[serde(rename = "log")]
@@ -98,6 +100,10 @@ impl BlockForm {
             BlockForm::PressurePlate
         } else if id_string.contains("chiseled") {
             BlockForm::Chiseled
+        } else if id_string.contains("_shelf") {
+            // `oak_shelf`, `spruce_shelf`, … — the 1.21.9+ display shelf. The
+            // `_` guards against `bookshelf` (no underscore before "shelf").
+            BlockForm::Shelf
         } else if id_string.contains("air") || id_string.contains("water") || id_string.contains("lava") || id_string.contains("snow") {
             BlockForm::Sparse
         } else {
@@ -119,6 +125,7 @@ impl BlockForm {
             BlockForm::Button => 0.1,
             BlockForm::PressurePlate => 0.1,
             BlockForm::Chiseled => 1.0,
+            BlockForm::Shelf => 0.3,
             BlockForm::Sign | BlockForm::WallSign | BlockForm::HangingSign | BlockForm::HangingWallSign => 0.1,
             BlockForm::Sparse => 0.0,
             BlockForm::Wood => 1.0,


### PR DESCRIPTION
## Summary

Wires `main` to the modern **buildings_v2** town pipeline and generates a full medieval settlement, plus a batch of decoration/furnishing work.

### Commits
- **main: generate towns via buildings_v2 `generate_town` pipeline** — extracts the full settlement pipeline (parcels → wall → flatten → industrial buildings → tiered A* roads → block subdivision → houses → verge + street lights) out of the `hierarchical_roads` test into a reusable `generate_town(editor, seed, culture)` in `generator/settlement.rs`. `main` now calls it with `Culture::Medieval`, retiring the old buildings-v1 `place_buildings` path. The test became a thin wrapper so it and `main` can't drift.
- **test: medieval town generator** — switches the settlement generator from Desert to Medieval culture (spruce/stone palette, gable roofs, glass windows, timber-frame jetties, per-house wood/stone/roof variety) and re-skins the industrial buildings into the medieval palette.
- **furnish: display shelves + cellar/rooms WIP** — wall-mounted `*_shelf` display blocks with themed/renamed loot items, cellar rework, and `rooms.yaml` updates. Includes a fix for malformed JSON in the 7 `wood/log/*.json` material files (a missing comma made them fail to parse, silently dropping the log materials so `wood_pillar` had no block and timber poles didn't place).
- **furnish: thematic per-room furniture + attic headroom invariant** — `thematic.yaml` signature furniture so room types read distinctly; `check_building_invariants` now validates attic headroom via `roof_heightmaps`.

## Testing
- `cargo check` and `cargo check --tests` pass (warnings only).
- Generated a medieval town end-to-end via `cargo run` against a live GDMC server (MC 1.21.11): 74 buildings, 6/6 industrial buildings, tiered stone/cobble roads, 102 street lamps, no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)