### PR TITLE
Rural road network connecting resource buildings to gates

### DIFF
--- a/data/materials/ground/rural_road.json
+++ b/data/materials/ground/rural_road.json
@@ -1,0 +1,14 @@
+{
+    "id" : "rural_road",
+    "connections" : {},
+    "blocks" : {
+        "block" : {
+            "minecraft:packed_mud" : 5,
+            "minecraft:coarse_dirt" : 3,
+            "minecraft:dirt" : 2,
+            "minecraft:rooted_dirt" : 2
+        },
+        "slab" : "minecraft:mud_brick_slab",
+        "stairs" : "minecraft:mud_brick_stairs"
+    }
+}

--- a/docs/analysis/run-observations-2026-06-17.md
+++ b/docs/analysis/run-observations-2026-06-17.md
@@ -1,0 +1,153 @@
+# Run observations — 2026-06-17 (run_20260617_151600)
+
+Analysis of the latest generation run (`output/logs/2026-06-17/run_20260617_151600.log`,
+25,120 lines) plus the two in-game screenshots. Settlement sits on a grassland
+plateau at ~X1936 Z-2139, right on the western edge of a large Badlands biome,
+ocean to the west.
+
+## Headline numbers
+
+- **415 WARN, 12 ERROR.**
+- **412 of the 415 warnings are a single repeated message** (`No block found for
+  material white_wool with form Stairs`) — see #3. The other 3 warnings are the
+  real placement failures.
+- **Rural buildings: "Placed 6 of 8".** Two production buildings were
+  hard-rejected on terrain: `ranch` in `DistrictID(3)` and `farm` in
+  `DistrictID(98)`.
+- **Urban: `bakery` found no viable placement** ("No viable urban placement for
+  'bakery'").
+
+## 1. Terrain rejections silently break the resource chain  ⭐ (the wheat-farm issue)
+
+The resource-chain planner runs **first** and logs a balanced economy
+(`registry`, ~line 4172 onward):
+
+```
+settlement production: 8 producing parcels of 13 total
+parcel 80 -> wheat [farm]
+parcel 98 -> wheat [farm]
+parcel  3 -> cow  [ranch]
+parcel 105 -> cow [ranch]
+...
+supply: wheat x4
+supply: cow x4
+finished_good: bread x6
+finished_good: beef x5
+```
+
+Then placement runs and **drops 2 of those 8** because the chosen super-parcel
+has no footprint flat enough (`MAX_PLACEMENT_SLOPE = 4`):
+
+```
+WARN No viable placement for 'ranch' in super-parcel DistrictID(3)
+WARN No viable placement for 'farm'  in super-parcel DistrictID(98)
+INFO Placed 6 of 8 rural buildings
+```
+
+Net effect: **only 1 wheat farm (80) and 1 ranch (105) actually got built**, but
+the chronicle/economy still believes there are two of each (`wheat x4`,
+`bread x6`, `beef x5`). The plan and the world disagree.
+
+**Why it happens:** the planner picks resources from *ruggedness* (a parcel-wide
+roughness/gradient score) but placement rejects on the *footprint's local slope*.
+Parcel 98 had ruggedness 0.443 — passable as a parcel — yet no 0..4 height-range
+pad existed for the farm footprint. There's no feedback loop between the two
+stages.
+
+**Suggested improvements (in rough priority):**
+- **Reconcile the plan after placement.** When `place_rural_building` returns
+  `Ok(false)`, either (a) retry the same resource on one of the *dropped*
+  same-resource candidates (see #2), or (b) decrement the supply/finished-good
+  tallies so the chronicle reflects reality.
+- **Pre-validate feasibility before locking the plan.** Cheaply test "does any
+  footprint-sized window in this district fit under `MAX_PLACEMENT_SLOPE`?" during
+  resource assignment, and skip/swap parcels that can't seat their building.
+- Both of these keep the economy honest instead of advertising bread the town
+  can't make.
+
+## 2. The "2 per resource" competition cap throws away flatter backups
+
+In the same registry block, several parcels are dropped purely by the per-resource
+cap:
+
+```
+competition cap: dropped DistrictID(129) (resource wheat) — over 2 per resource
+competition cap: dropped DistrictID(219) (resource cow)   — over 2 per resource
+competition cap: dropped DistrictID(230) (resource wool)  — over 2 per resource
+...
+```
+
+Note **wheat parcel 129 had ruggedness 0.408 — flatter than the kept parcel 98
+(0.443)** that later failed placement. We discarded a flatter wheat site and kept
+a rougher one that couldn't be built. Same story is plausible for cow (dropped
+219 @ 0.375 was the flattest cow parcel of all, capped out in favor of 3 @ 0.538
+which then failed).
+
+**Suggestion:** keep the capped-out parcels as an ordered fallback list per
+resource. When a primary pick fails placement, promote the best dropped
+same-resource candidate instead of just losing the building. This directly
+recovers both rural failures above.
+
+## 3. `white_wool` + `Stairs` — 412 spurious warnings (99% of all warnings)
+
+```
+WARN [materials::material] No block found for material white_wool with form Stairs   ×412
+```
+
+Wool has no stairs block in Minecraft, so some palette / wall / roof component is
+requesting `form = Stairs` against a `white_wool` material and silently getting
+nothing back 412 times. This is almost certainly **missing geometry in the
+output** (wherever those stairs should be, there's a hole) and it's drowning the
+log so real warnings are hard to find.
+
+**Suggestion:** find the component/palette mapping `white_wool` to a `Stairs`
+form (likely a roof or trim set used by one of the placed buildings) and either
+point it at a material that *has* stairs, or fall back to the wool full block /
+slab. Worth fixing first purely for log signal-to-noise.
+
+## 4. 12 `world block is None` placement errors
+
+```
+ERROR [editor] Failed to place block minecraft:dirt at Point3D { x:1686, y:63, z:-2097 }, world block is None
+... (12×, dirt/stone, y 63–76)
+```
+
+These are terraforming/foundation fills landing on columns the `World` has no
+cached chunk for — likely foundation/blend cells just outside the loaded build
+area or below a parcel edge. Low count, but each is a block that didn't get
+placed (small cliffs/holes under building skirts). Worth guarding: skip-with-
+debug rather than error, or ensure the blend ring stays inside the loaded region.
+
+## 5. Screenshot observations
+
+- **Stray house outside the north wall** (top-center of the aerial shot) is
+  disconnected from the town with no road to it. Looks orphaned. Likely an urban
+  building placed in a district lobe that ended up outside the regularized wall,
+  or a rural building with no path connection. Worth a "connect or cull isolated
+  buildings" pass.
+- **Production buildings sit well outside the walls with no connecting paths.**
+  The sandstone wheat farm at the bottom-right of both shots, and the cattle out
+  east, read as detached from the settlement. Rural buildings could use a short
+  spur path back to the nearest gate/road.
+- **The curtain wall dominates the silhouette** — it's thick and tall relative to
+  the buildings, and its star/lobed shape (following district boundaries) snakes a
+  lot. Visually impressive but it's the loudest element. Consider thinner walls or
+  smoothing the most concave boundary runs.
+- **No biome adaptation at the Badlands border.** The town butts directly against
+  Badlands (orange) yet everything is oak/spruce medieval. A material or palette
+  nudge toward terracotta/red sandstone on the eastern, badlands-facing parcels
+  would tie it to the landscape.
+- **Marginal placements.** `shepherds_hut@62` and `farm@80` both placed at
+  `score 0.00` — accepted but at the floor of viability, i.e. the only pad that
+  fit. Consistent with the terrain being tight for rural footprints here; reinforces
+  #1/#2.
+
+## Quick-win ordering
+
+1. Fix the `white_wool`/`Stairs` mapping (#3) — kills 99% of warning noise and a
+   real visual hole, low effort.
+2. Add same-resource placement fallback from the capped/dropped pool (#2) — likely
+   recovers both rural failures, keeps the economy balanced.
+3. Reconcile economy tallies (or pre-validate) so the chronicle stops advertising
+   buildings that weren't placed (#1).
+4. Connect or cull isolated outside-the-wall buildings (#5).

--- a/docs/plans/rural_roads.md
+++ b/docs/plans/rural_roads.md
@@ -1,0 +1,246 @@
+# Rural Road Network
+
+Plan drafted 2026-06-17. Branch: `td/rural_roads`. **Status: implemented** (see
+"As built" at the end).
+
+## Goal
+
+Connect every **rural resource building** to the urban road network, so the
+countryside reads as one settlement instead of buildings scattered in empty
+land. Concretely:
+
+- Each rural resource building is joined to a **town gate** by a routed road.
+- The road attaches at the building's **door** when it has one, otherwise at the
+  nearest footprint-perimeter cell ("just connect anywhere").
+- Where a production area will paint a `rural_road` **border ring**, the network
+  **routes to / reuses that ring** instead of laying a redundant parallel path.
+- Rural and urban meet **at the gates** — the urban collectors already route each
+  gate inward, so the gate is the shared node; no change to the urban network.
+
+## Settled decisions
+
+These came out of the design discussion and are not open:
+
+1. **Junction = gates only.** Rural roads terminate at gate cells (stepped to the
+   rural/outward side). The existing urban network connects gates → town interior,
+   so the two systems join at the threshold with no reorder of the urban build.
+2. **Door attach = runtime door scan, perimeter fallback.** Rural buildings are
+   NBT structures with no door metadata (`Structure` has no door field). After
+   placement, scan the footprint's just-placed blocks for a door block and use
+   that cell; fall back to the nearest perimeter cell when none exists. No data to
+   maintain, can't drift from the NBT, and doorless buildings (mines, open
+   pastures/apiaries) get the fallback for free.
+3. **Ordering = three phases via ring prediction** (see below). The production
+   border ring is deterministic from district geometry, so we predict it and run
+   the road network *before* the painters.
+4. **Border use = route to / reuse the predicted ring.** The ring becomes a
+   first-class part of the network (a goal/merge set), not decoration.
+
+## Ordering — three phases
+
+The current `generate_town` loop (`settlement.rs:81-107`) interleaves *place rural
+building* with *paint production area* per district. We split it:
+
+```
+Phase R1  Place ALL rural buildings        (placement only — no painting)
+Phase R2  Build the rural road network      (predicting border rings)
+Phase R3  Paint ALL rural production areas  (painters; border ring overlays the routed road)
+```
+
+The painter (`paint_production_area`) filters border cells by `!is_claimed`, so a
+ring cell the road already claimed as `Path` is simply skipped by the painter —
+the two passes compose without double-paving. This is why R2-before-R3 is safe.
+
+### Why prediction works
+
+`paint_production_area` (`production_area.rs:53-90`) derives the border ring purely
+from `district.data.edges`: cells within `EDGE_BUFFER` (= 3) Chebyshev of any edge
+cell, that are interior, unclaimed, and not water. None of that depends on the
+painter running. Phase R2 replicates that computation to get the ring cells ahead
+of time. Only painters that actually use a border palette get a ring (see "Which
+areas have a ring").
+
+## Reuse — what already exists
+
+We are **not** writing a new router or a new road realizer. The rural network is a
+re-wiring of the urban primitives over a different node/region set.
+
+| Need | Reuse | Notes |
+|---|---|---|
+| Terrain-aware A* routing | `routing::get_path_with` + `RouteContext` / `RouteParams` | Already step-, turn-, grade-, water-, and blocked-aware. Region is just a different cell set. |
+| Road realization (slab smoothing, widening, melding) | `building::build_paths_merged` (and `build_path`) | Carries height as a float, lays half-step slabs, melds overlapping paths. Handles un-flattened grades. |
+| Door → nearest road connector | `connect::connect_doors_to_roads` | A*'s a 1-wide path from a door to the nearest road cell, around `blocked`. Needs its `MAX_CONNECTOR` (40) parameterized for longer rural runs. |
+| Path tier / width / material | `path::{Path, PathPriority, PathType}` | Reuse as-is. |
+| Network graph (MST + loop shortcuts) | `network::{mst_edges, shortcut_edges, edge_betweenness}` | Currently **private** in `network.rs`. Lift to `pub(crate)` (or a small `paths::graph` submodule) so the rural builder can reuse them. |
+| Cost-coupled sequential routing (later edges merge onto earlier ones) | the route loop in `build_road_network` (`network.rs:176-209`) | The pattern — record each routed path into `road_cells`/`road_height`, give later routes an on-road discount + y-snap — is exactly what keeps rural roads from running parallel. Factor the loop body so both networks share it, or mirror it. |
+
+`build_road_network` itself stays **urban-specific** (its nodes are district
+centres + gates + industry, its region is the urban set). We add a sibling rather
+than overloading it.
+
+## New code
+
+### `paths/rural.rs` — `build_rural_road_network`
+
+```rust
+pub async fn build_rural_road_network(
+    editor: &Editor,
+    assignments: &SettlementProductionResult,   // which district got which building + painter
+    data: &LoadedData,
+    material: MaterialId,                        // rural road surface material (knob)
+    route_step: i32,
+) -> Vec<Path>
+```
+
+Steps:
+
+1. **Anchors (sources).** For each placed rural structure, find its attach cell:
+   scan the footprint cells (from the `BuildClaim::Structure` claim map, as
+   `settlement.rs:146-150` already does for industry) for a door block via
+   `editor.get_block`; fall back to the nearest perimeter cell. One anchor per
+   building.
+2. **Gate nodes (destinations).** Each `world.gate_locations` entry, stepped a few
+   cells **outward** along its `Cardinal` (the rural side), lifted to surface y via
+   `world.add_height`. (Confirm outward sign against `gate.rs` — urban steps inward,
+   rural is the opposite side.)
+3. **Predicted rings.** For each district whose painter uses a border palette
+   ("relevant"), compute the `EDGE_BUFFER` ring cells exactly as
+   `paint_production_area` does. Store per-district ring sets; their union is a
+   `goal/merge` set the trunk can terminate on.
+4. **Graph.** Build an MST (reused `mst_edges`) over `{gates} ∪ {ring anchors / building anchors}`,
+   so multiple rural buildings share a spine before reaching a gate rather than each
+   shooting an independent path. Optionally add capped `shortcut_edges`.
+5. **Route, cost-coupled.** Route each edge with `get_path_with` over the **rural
+   region** (see below), recording each routed path into `road_cells`/`road_height`
+   so later edges merge onto the spine and snap height — same loop as the urban
+   builder. Ring cells and the running network are `goal_cells` so a trunk stops on
+   first touch.
+6. **Door connectors.** For each building anchor not already on/beside the routed
+   network or its predicted ring, run `connect_doors_to_roads` (with a raised
+   connector cap) to A* a 1-wide spur to the nearest network/ring cell.
+7. Return `Vec<Path>`; the caller realizes them with `build_paths_merged` and
+   claims paved cells as `BuildClaim::Path` (so Phase R3's painter skips them).
+
+### Rural region & blocked set
+
+- **Region** (allowed A* cells): the union of all **rural** district `points_2d`
+  plus a small approach corridor around each gate, minus water. Confining to rural
+  land keeps routes out of the urban interior (which the urban network owns) and
+  off the wall except at gates. Alternative knob: `region = None` (unconstrained
+  over the build area) with `blocked` doing all the work — simpler, but routes may
+  wander into urban land. Default to the rural-union region.
+- **Blocked**: building footprints (+ small margin, like `IND_MARGIN`), wall cells,
+  and existing claims — same construction as `settlement.rs:151-158`.
+
+### Wiring into `generate_town`
+
+Split the existing rural loop. Today (`settlement.rs:78-107`) it does, per district:
+`place_rural_building` → `paint_production_area`. Becomes:
+
+```rust
+// R1: place only
+for sd_id in &sd_ids { place_rural_building(...).await; record placed + assignment }
+
+// R2: rural roads (predicting rings), then realize + claim
+let paths = build_rural_road_network(&*editor, &result, &data, rural_material, 1).await;
+let slabs = build_paths_merged(&*editor, &data, &paths, &mut rng).await;
+claim every paved cell as BuildClaim::Path(PathType::Road);
+
+// R3: paint production areas (border ring overlays the routed road)
+for sd_id in &placed { paint_production_area(...).await; }
+```
+
+Keep the `resolve_for_parcels` resource resolution where it is (it already runs
+before placement). The per-building "resource for the placed building" lookup
+(`settlement.rs:96-101`) moves into R3 with the rest of the painting.
+
+## Knobs
+
+| Lever | Default | Notes |
+|---|---|---|
+| Rural road `MaterialId` | gravel / dirt-path (TBD) | See open question on matching the `rural_road` paint look. |
+| Rural road tier / width | `PathPriority::Low` (w1) or `Medium` (w2) | Narrower than urban arterials; lanes, not avenues. |
+| A* `route_step` | 1 | Per-cell over rough terrain; 4 (sparse) if perf bites on long inter-area legs. |
+| `EDGE_BUFFER` (ring width) | 3 | Must match `production_area.rs` — read the const, don't re-hardcode. |
+| Connector cap | raise from 40 | Rural door→spine spurs are longer than urban ones. |
+| Gate outward step | 2–4 cells | Far enough off the wall to start on clear rural ground. |
+| Region mode | rural-union | vs unconstrained-`None` (see above). |
+
+## Which areas have a ring
+
+From `production_area.rs`, a border ring exists only for painters that pass a
+border palette:
+
+- **Has ring:** `Palettes { border_palette: Some(..) }`; `pasture` and `sugarcane`
+  function painters (default `rural_road`).
+- **No ring:** `logging`, `bee_area`, `mine` function painters, and
+  `Palettes { border_palette: None }`.
+
+Phase R2 resolves each district's assigned painter from the registry and includes
+its ring only when the painter is one of the ring-bearing kinds. Doorless / ringless
+buildings just get a door connector straight to the gate spine.
+
+## Resolved decisions (post-discussion)
+
+- **Surface material = option (a).** A new `rural_road` material
+  (`data/materials/ground/rural_road.json`) — packed mud / coarse dirt / dirt /
+  rooted dirt to mirror the `rural_road` paint palette, with `mud_brick` slab +
+  stairs for the half-step grade lips `build_path` needs.
+- **Corridor flattening = yes.** After routing, the corridor is `force_height`-ed
+  to the routed road heights (skipping building/wall cells) before
+  `build_paths_merged`, so the road sits on graded ground — mirroring the urban
+  realization. (Slab smoothing then handles the residual.)
+
+## Open questions / risks (remaining)
+
+- **Gate-node side detection** uses `is_urban(gate + dir)` to pick the rural side,
+  stepping one cell out so the width-2 road's paved band still reaches the gate
+  tile. Verify in-world that rural and urban roads actually meet flush at gates.
+- **`region: None` perf.** Rural routing is unconstrained (only `blocked` =
+  urban ∪ footprints) at `route_step = 1`. Long building→gate legs over open
+  countryside could get expensive; bump `route_step` to 4 if it bites.
+- **No reachable gate / water crossings.** A building with no routable path logs +
+  skips (partial connectivity OK). `force_height(.., skip_water=false)` will fill a
+  small stream the road crosses into a dirt causeway — acceptable for v1.
+
+## As built
+
+- `data/materials/ground/rural_road.json` — new road material (option a).
+- `ProductionPainter::paints_border()` — which painters lay a `rural_road` ring.
+- `resource_chain::paint_production_area_for(.., structure_id, ..)` — explicit-id
+  variant so painting can run in a pass separate from placement without
+  mis-attributing the area to `structures.last()`. `EDGE_BUFFER` made `pub`.
+- `placement::try_place_rural` now returns `Option<PlacedRural>` (places only, no
+  inline paint); `PlacedRural` carries district, structure id, painter, resolved
+  resource, and the `has_border_ring` flag.
+- `paths::rural::build_rural_road_network` + `RuralBuilding` — the network: nearest
+  gate per building, door-scan/perimeter anchor, predicted-ring discount field,
+  cost-coupled routes (reuses `get_path_with`/`RouteContext`/`RouteParams`).
+  `network::mst_edges` was made `pub(crate)` for potential reuse (the v1 network
+  uses a nearest-gate star with cost-coupling rather than an MST, so it isn't
+  called yet — kept exposed for a future multi-destination rural trunk).
+- `settlement::generate_town` — rural flow is now three phases: place all rural
+  buildings → `build_rural_road_network` + realize + claim `Path` → paint all
+  production areas via `paint_production_area_for`.
+- **Door scan / live-server cache fix.** The door scan reads back blocks placed
+  this run. `get_block`/`try_get_block` subtract `build_area.origin` (they expect
+  absolute coords), but the pipeline uses local coords and the cache is local-keyed,
+  so on a live server (nonzero origin) those reads fell through to world terrain and
+  the door was never seen → every building used the perimeter fallback (path landed
+  at a corner). Added `Editor::get_cached_block(local)` — a cache read by the local
+  key, no origin adjustment — and the door scan uses it. (Invisible offline because
+  synthetic worlds have origin 0.) The broader `get_block` asymmetry is left alone
+  for now; worth fixing centrally as a follow-up.
+- **Tests:** no live-server harness added yet (see "Test harness" above). `cargo
+  check` and `build_furnished_houses_offline` pass; the live settlement path needs
+  an in-world run to validate routing/flattening and the door fix visually.
+
+## Test harness
+
+Mirror the existing live-server settlement test (`placement/test.rs`): world →
+parcels → wall + gates → place rural buildings → `build_rural_road_network` →
+`build_paths_merged` → paint production areas → `flush_buffer`, then inspect via the
+SVG/visualizer snapshot. Assert: every placed rural building has at least one paved
+cell within N cells of its anchor, and every routed rural path terminates on a gate
+node or the running network. An offline variant can assert anchor/ring computation
+(door scan, predicted ring == painter ring) without a server.

--- a/src/editor/editor.rs
+++ b/src/editor/editor.rs
@@ -226,6 +226,19 @@ impl Editor {
         self.world.get_block(point)
     }
 
+    /// Reads a block straight from the placement cache by its **local** coordinate
+    /// — the same space `place_block` writes with. Returns `None` when nothing has
+    /// been placed at `local` this run.
+    ///
+    /// Use this to read back blocks *this run placed*. `get_block`/`try_get_block`
+    /// subtract the build-area origin (so they expect absolute coords and, given
+    /// the pipeline's local coords, fall through to world terrain instead of the
+    /// freshly-placed block on a live server). The cache survives `flush_buffer`,
+    /// so a placed block stays readable here for the rest of the run.
+    pub fn get_cached_block(&self, local: Point3D) -> Option<Block> {
+        self.block_cache.borrow().get(&local).cloned()
+    }
+
     pub async fn flush_buffer(&self) {
         // Drain the buffer first, releasing the borrow before the await
         let buffer: Vec<_> = self.block_buffer.borrow_mut().drain(..).collect();

--- a/src/generator/paths/mod.rs
+++ b/src/generator/paths/mod.rs
@@ -5,6 +5,7 @@ mod path;
 mod building;
 mod connect;
 mod lights;
+mod rural;
 pub mod network;
 
 pub use a_star::a_star;
@@ -12,5 +13,6 @@ pub use building::{build_path, build_paths_merged};
 pub use connect::connect_doors_to_roads;
 pub use lights::place_street_lights;
 pub use network::{build_road_network, find_blocks};
+pub use rural::{build_rural_road_network, RuralBuilding};
 pub use path::{Path, PathPriority, PathType};
 pub use routing::{get_path, get_path_with, route_path, route_path_with, RouteContext, RouteParams};

--- a/src/generator/paths/network.rs
+++ b/src/generator/paths/network.rs
@@ -698,7 +698,7 @@ fn shortcut_edges(nodes: &[Point3D], mst: &[(usize, usize)]) -> Vec<(usize, usiz
 
 /// Prim's MST over `nodes`, edges weighted by XZ squared-distance. Returns the
 /// `(i, j)` index pairs of the tree edges.
-fn mst_edges(nodes: &[Point3D]) -> Vec<(usize, usize)> {
+pub(crate) fn mst_edges(nodes: &[Point3D]) -> Vec<(usize, usize)> {
     let n = nodes.len();
     if n < 2 {
         return Vec::new();

--- a/src/generator/paths/rural.rs
+++ b/src/generator/paths/rural.rs
@@ -1,0 +1,284 @@
+//! Rural road network: connects placed rural resource buildings to the urban
+//! road network **via the town gates**, over un-flattened countryside.
+//!
+//! Each building is routed to its nearest gate with a terrain-aware A* (the same
+//! router the urban network uses), attaching at the building's **door** when it
+//! has one and otherwise at the nearest footprint-perimeter cell. Routes are
+//! cost-coupled: later buildings merge onto roads already laid, so buildings
+//! sharing a direction share a spine instead of each carving a parallel track.
+//!
+//! Where a production area will paint a `rural_road` **border ring**, the network
+//! predicts that ring (it is deterministic from the district's edge geometry —
+//! see [`crate::generator::resource_chain::paint_production_area`]) and seeds it
+//! into the router's on-road discount field, so routes hug the ring rather than
+//! running beside it. The ring itself is paved later by the painter.
+//!
+//! Run **after** all rural buildings are placed and **before** the production
+//! painters. Realise the returned paths with
+//! [`build_paths_merged`](super::build_paths_merged).
+
+use std::collections::{HashMap, HashSet};
+
+use crate::editor::Editor;
+use crate::generator::BuildClaim;
+use crate::generator::districts::{District, DistrictID};
+use crate::generator::materials::MaterialId;
+use crate::generator::nbts::StructureID;
+use crate::generator::resource_chain::EDGE_BUFFER;
+use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
+
+use super::path::{Path, PathPriority};
+use super::routing::{get_path_with, RouteContext, RouteParams};
+
+/// A placed rural resource building the road network must connect to a gate.
+pub struct RuralBuilding {
+    pub district: DistrictID,
+    pub structure: StructureID,
+    /// Whether this building's production painter paints a `rural_road` border
+    /// ring — if so, the network predicts and reuses that ring.
+    pub has_border_ring: bool,
+}
+
+/// How far up a footprint column the door scan looks for a door block.
+const DOOR_SCAN_HEIGHT: i32 = 6;
+
+/// Build the rural road network. Returns one routed [`Path`] per building that
+/// reached a gate (buildings that fail to route are logged and skipped — partial
+/// connectivity is acceptable). `route_step` is the A* lattice step (1 = exact
+/// per-cell, 4 = sparse/faster over long open runs).
+pub async fn build_rural_road_network(
+    editor: &Editor,
+    buildings: &[RuralBuilding],
+    material: MaterialId,
+    route_step: i32,
+) -> Vec<Path> {
+    let gates = gate_nodes(editor);
+    if gates.is_empty() || buildings.is_empty() {
+        return Vec::new();
+    }
+
+    // Deterministic order so the cost-coupled merge result is reproducible.
+    let mut order: Vec<usize> = (0..buildings.len()).collect();
+    order.sort_by_key(|&i| buildings[i].district.0);
+
+    // Per building: its attach anchor (door approach or nearest perimeter cell)
+    // and the gate it heads for. Footprints accumulate into the blocked set, and
+    // predicted border rings into the router's on-road discount field.
+    let mut jobs: Vec<(Point2D, Point3D)> = Vec::new();
+    let mut footprints: HashSet<Point2D> = HashSet::new();
+    let mut ring_cells: HashSet<Point2D> = HashSet::new();
+
+    for &i in &order {
+        let b = &buildings[i];
+        let Some(district) = editor.world().districts.get(&b.district) else { continue };
+        let fc = footprint_cells(editor, district, &b.structure);
+        if fc.is_empty() {
+            continue;
+        }
+        footprints.extend(&fc);
+
+        let centroid = fc.iter().fold(Point2D::ZERO, |a, p| a + *p) / fc.len() as i32;
+        let gate = *gates
+            .iter()
+            .min_by_key(|g| g.drop_y().distance_squared(&centroid))
+            .expect("gates is non-empty");
+        let anchor = building_anchor(editor, &fc, gate.drop_y());
+        jobs.push((anchor, gate));
+
+        if b.has_border_ring {
+            ring_cells.extend(predict_border_ring(editor, district));
+        }
+    }
+
+    if jobs.is_empty() {
+        return Vec::new();
+    }
+
+    // Confine routing to the countryside: the urban interior is blocked so a
+    // rural road can't cut through the city (it meets the urban network at the
+    // gate), and every footprint is blocked so roads route *around* buildings.
+    // Gate nodes (and the anchors) are freed so routes can actually start/end on
+    // them even if they fall on an otherwise-blocked cell.
+    let mut blocked: HashSet<Point2D> = editor.world().get_urban_points();
+    blocked.extend(&footprints);
+    for g in &gates {
+        blocked.remove(&g.drop_y());
+    }
+    for (anchor, _) in &jobs {
+        blocked.remove(anchor);
+    }
+
+    let params = RouteParams { step: route_step, ..RouteParams::default() };
+
+    let mut paths: Vec<Path> = Vec::new();
+    // Cells of roads laid so far (a route may end on these to merge), plus their
+    // heights so the merge snaps flush.
+    let mut network_cells: HashSet<Point2D> = HashSet::new();
+    let mut road_height: HashMap<Point2D, i32> = HashMap::new();
+
+    for (anchor, gate) in jobs {
+        let start = editor.world().add_height(anchor);
+
+        // Discount field = laid roads ∪ predicted rings, so routes prefer running
+        // along an existing road or a ring rather than carving a parallel one.
+        let mut discount = network_cells.clone();
+        discount.extend(&ring_cells);
+
+        let routed = {
+            let ctx = RouteContext {
+                region: None,
+                road_cells: Some(&discount),
+                road_height: Some(&road_height),
+                // Stop early only on the already-laid network (NOT on rings — a
+                // ring isn't itself connected to a gate, so terminating on one
+                // would strand the building). Empty on the first route.
+                goal_cells: if network_cells.is_empty() { None } else { Some(&network_cells) },
+                wall_dist: None,
+                blocked: Some(&blocked),
+            };
+            get_path_with(editor, start, gate, PathPriority::Medium, material.clone(), params, ctx, async |_| {}).await
+        };
+
+        match routed {
+            Some(path) => {
+                for p in path.points() {
+                    network_cells.insert(p.drop_y());
+                    road_height.insert(p.drop_y(), p.y);
+                }
+                paths.push(path);
+            }
+            None => log::warn!(
+                "rural road: building anchor {:?} failed to route to gate {:?}",
+                anchor, gate.drop_y(),
+            ),
+        }
+    }
+
+    log::info!(
+        "rural road network: {} buildings, {} gates, {} segments routed, {} predicted ring cells",
+        buildings.len(), gates.len(), paths.len(), ring_cells.len(),
+    );
+    paths
+}
+
+/// Gate destination cells, each stepped one cell to the **rural** (non-urban)
+/// side of the gate. The route centreline thus ends just outside the wall (never
+/// on it), while the road's widened paved band still reaches back onto the gate
+/// tile — meeting the urban collector that paves through the gate from the inside.
+fn gate_nodes(editor: &Editor) -> Vec<Point3D> {
+    let world = editor.world();
+    world
+        .gate_locations
+        .iter()
+        .map(|(gate, dir)| {
+            let cell = gate.drop_y();
+            let d = Point2D::from(*dir);
+            // Step toward whichever side is not urban (the countryside).
+            let outward = if world.is_urban(cell + d) { Point2D::new(-d.x, -d.y) } else { d };
+            let out = cell + outward;
+            let node = if world.is_in_bounds_2d(out) { out } else { cell };
+            world.add_height(node)
+        })
+        .collect()
+}
+
+/// Footprint cells of `structure` within `district` — the cells claimed
+/// `BuildClaim::Structure` with this building's unique instance id.
+fn footprint_cells(editor: &Editor, district: &District, structure: &StructureID) -> HashSet<Point2D> {
+    district
+        .data
+        .points_2d
+        .iter()
+        .copied()
+        .filter(|&p| matches!(
+            editor.world().get_claim(p),
+            Some(BuildClaim::Structure(id)) if id.id == structure.id
+        ))
+        .collect()
+}
+
+/// The cell a road should attach to: the approach cell just outside a door if the
+/// building has one, otherwise the footprint-perimeter cell nearest `target`.
+fn building_anchor(editor: &Editor, footprint: &HashSet<Point2D>, target: Point2D) -> Point2D {
+    if let Some(approach) = door_approach(editor, footprint, target) {
+        return approach;
+    }
+    perimeter_outside(footprint)
+        .into_iter()
+        .min_by_key(|p| p.distance_squared(&target))
+        // A non-empty footprint always has at least one outside neighbour.
+        .unwrap_or_else(|| *footprint.iter().next().expect("footprint is non-empty"))
+}
+
+/// Scans the footprint columns for a door block; on a hit returns the outside
+/// approach cell (cardinal neighbour not in the footprint) nearest `target`.
+/// `None` if no door is found (mines, open pastures/apiaries).
+fn door_approach(editor: &Editor, footprint: &HashSet<Point2D>, target: Point2D) -> Option<Point2D> {
+    let mut approaches: Vec<Point2D> = Vec::new();
+    for &cell in footprint {
+        let ground = editor.world().get_non_tree_height(cell);
+        for dy in 0..DOOR_SCAN_HEIGHT {
+            // Read from the placement cache by local coord: the door was placed
+            // this run, and `try_get_block` would subtract the build-area origin
+            // and return world terrain instead (no door) on a live server.
+            let Some(block) = editor.get_cached_block(Point3D::new(cell.x, ground + dy, cell.y)) else {
+                continue;
+            };
+            let id = block.id.as_str();
+            // `door` matches all door variants; exclude trapdoors (also contain "door").
+            if id.contains("door") && !id.contains("trapdoor") {
+                for d in CARDINALS_2D {
+                    let n = cell + d;
+                    if !footprint.contains(&n) {
+                        approaches.push(n);
+                    }
+                }
+                break;
+            }
+        }
+    }
+    approaches.into_iter().min_by_key(|p| p.distance_squared(&target))
+}
+
+/// Cells just outside the footprint (cardinal neighbours not in it).
+fn perimeter_outside(footprint: &HashSet<Point2D>) -> Vec<Point2D> {
+    let mut out: HashSet<Point2D> = HashSet::new();
+    for &c in footprint {
+        for d in CARDINALS_2D {
+            let n = c + d;
+            if !footprint.contains(&n) {
+                out.insert(n);
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Predicts the `rural_road` border ring a production painter will lay for
+/// `district`: the interior cells within `EDGE_BUFFER` (Chebyshev) of an edge
+/// cell that are unclaimed and not water. Mirrors the `border_cells` computation
+/// in [`crate::generator::resource_chain::paint_production_area`], so the road
+/// network and the painter agree on the ring.
+fn predict_border_ring(editor: &Editor, district: &District) -> HashSet<Point2D> {
+    let edge_buffer: HashSet<Point2D> = district
+        .data
+        .edges
+        .iter()
+        .flat_map(|p| {
+            let p2 = p.drop_y();
+            (-EDGE_BUFFER..=EDGE_BUFFER).flat_map(move |dx| {
+                (-EDGE_BUFFER..=EDGE_BUFFER).map(move |dz| Point2D::new(p2.x + dx, p2.y + dz))
+            })
+        })
+        .collect();
+
+    district
+        .data
+        .points_2d
+        .iter()
+        .copied()
+        .filter(|p| edge_buffer.contains(p))
+        .filter(|&p| !editor.world().is_claimed(p))
+        .filter(|&p| !editor.world().is_water(p))
+        .collect()
+}

--- a/src/generator/paths/rural.rs
+++ b/src/generator/paths/rural.rs
@@ -24,7 +24,7 @@ use crate::generator::BuildClaim;
 use crate::generator::districts::{District, DistrictID};
 use crate::generator::materials::MaterialId;
 use crate::generator::nbts::StructureID;
-use crate::generator::resource_chain::EDGE_BUFFER;
+use crate::generator::resource_chain::border_ring_cells;
 use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
 
 use super::path::{Path, PathPriority};
@@ -86,7 +86,9 @@ pub async fn build_rural_road_network(
         jobs.push((anchor, gate));
 
         if b.has_border_ring {
-            ring_cells.extend(predict_border_ring(editor, district));
+            // Predict the painter's border ring (it hasn't run yet) from the same
+            // shared computation, so routes can hug the ring the painter will lay.
+            ring_cells.extend(border_ring_cells(district, editor));
         }
     }
 
@@ -252,33 +254,4 @@ fn perimeter_outside(footprint: &HashSet<Point2D>) -> Vec<Point2D> {
         }
     }
     out.into_iter().collect()
-}
-
-/// Predicts the `rural_road` border ring a production painter will lay for
-/// `district`: the interior cells within `EDGE_BUFFER` (Chebyshev) of an edge
-/// cell that are unclaimed and not water. Mirrors the `border_cells` computation
-/// in [`crate::generator::resource_chain::paint_production_area`], so the road
-/// network and the painter agree on the ring.
-fn predict_border_ring(editor: &Editor, district: &District) -> HashSet<Point2D> {
-    let edge_buffer: HashSet<Point2D> = district
-        .data
-        .edges
-        .iter()
-        .flat_map(|p| {
-            let p2 = p.drop_y();
-            (-EDGE_BUFFER..=EDGE_BUFFER).flat_map(move |dx| {
-                (-EDGE_BUFFER..=EDGE_BUFFER).map(move |dz| Point2D::new(p2.x + dx, p2.y + dz))
-            })
-        })
-        .collect();
-
-    district
-        .data
-        .points_2d
-        .iter()
-        .copied()
-        .filter(|p| edge_buffer.contains(p))
-        .filter(|&p| !editor.world().is_claimed(p))
-        .filter(|&p| !editor.world().is_water(p))
-        .collect()
 }

--- a/src/generator/placement/mod.rs
+++ b/src/generator/placement/mod.rs
@@ -3,9 +3,13 @@ mod placement;
 mod test;
 
 pub use placement::{
+    district_seatable_footprints,
     place_rural_building,
     place_urban_building,
     place_urban_buildings,
+    resolve_rural_production,
+    try_place_rural,
+    PlacedRural,
 };
 
 #[cfg(test)]

--- a/src/generator/placement/placement.rs
+++ b/src/generator/placement/placement.rs
@@ -215,11 +215,6 @@ pub async fn place_rural_building(
     Ok(true)
 }
 
-/// Attempts to place one rural gather building for `assignment` on district
-/// `sd_id`, painting its production area on success. Returns whether it placed.
-/// Used by the settlement pipeline for both the primary assignment pass and the
-/// competition-cap fallback promotion (a dropped same-resource parcel retried when
-/// a primary can't seat).
 /// A rural resource building that physically placed, carrying everything needed
 /// to (a) route the rural road network to it and (b) paint its production area.
 ///

--- a/src/generator/placement/placement.rs
+++ b/src/generator/placement/placement.rs
@@ -8,9 +8,10 @@ use crate::{
     generator::{
         BuildClaim,
         data::LoadedData,
-        districts::District,
+        districts::{District, DistrictID, ParcelAnalysis},
         materials::{Palette, Placer},
-        nbts::{Rotation, Structure, StructureID, place_structure},
+        nbts::{Rotation, Structure, StructureID, StructureType, place_structure},
+        resource_chain::{ParcelResourceAssignment, SettlementProductionResult},
         terrain::{force_height, log_trees},
     },
     geometry::{Cardinal, Point2D, Point3D, Rect2D},
@@ -214,6 +215,79 @@ pub async fn place_rural_building(
     Ok(true)
 }
 
+/// Attempts to place one rural gather building for `assignment` on district
+/// `sd_id`, painting its production area on success. Returns whether it placed.
+/// Used by the settlement pipeline for both the primary assignment pass and the
+/// competition-cap fallback promotion (a dropped same-resource parcel retried when
+/// a primary can't seat).
+/// A rural resource building that physically placed, carrying everything needed
+/// to (a) route the rural road network to it and (b) paint its production area.
+///
+/// Painting is **deferred**: the rural road network must be built between
+/// placement and painting (so it can predict and reuse each area's `rural_road`
+/// border ring), so `try_place_rural` no longer paints inline — the caller paints
+/// via [`paint_production_area_for`](crate::generator::resource_chain::paint_production_area_for)
+/// once the roads are down.
+pub struct PlacedRural {
+    pub district: DistrictID,
+    pub structure: StructureID,
+    /// Production painter name for this building, if any.
+    pub painter: Option<String>,
+    /// Resource resolved for the *placed* building (so a mine painter's ore
+    /// matches an overridden building), used when painting the production area.
+    pub resource: String,
+    /// Whether this building's production painter will lay a `rural_road` border
+    /// ring — the rural road network predicts and reuses it.
+    pub has_border_ring: bool,
+}
+
+/// Places a rural resource building for `sd_id` and returns its [`PlacedRural`]
+/// record on success (or `None` if the building couldn't be seated). Does **not**
+/// paint the production area — see [`PlacedRural`].
+pub async fn try_place_rural(
+    sd_id: DistrictID,
+    assignment: &ParcelResourceAssignment,
+    data: &LoadedData,
+    editor: &mut Editor,
+    rng: &mut RNG,
+) -> Option<PlacedRural> {
+    let building = assignment.building.clone();
+    let Some(district) = editor.world().districts.get(&sd_id).cloned() else { return None };
+    let Some(structure) = data.structures.get(&StructureType(building.clone())).cloned() else {
+        warn!("No structure for building '{}' (parcel {:?})", building, sd_id);
+        return None;
+    };
+    match place_rural_building(&district, &structure, rng, editor, data).await {
+        Ok(true) => {
+            let Some(structure_id) = editor.world().structures.last().cloned() else {
+                warn!("try_place_rural: placement reported success but pushed no structure for '{}'", building);
+                return None;
+            };
+            // Resource for the *placed* building (so the mine painter's ore
+            // matches an overridden building), falling back to the parcel's.
+            let resource = data.resource_registry.recipes().values()
+                .find(|r| r.inputs.is_empty() && r.building == building)
+                .and_then(|r| r.outputs.keys().next().cloned())
+                .unwrap_or_else(|| assignment.primary_resource.clone());
+            let has_border_ring = assignment.production_painter.as_deref().map_or(false, |name| {
+                data.resource_registry.production_painters.get(name).map_or(false, |p| p.paints_border())
+            });
+            Some(PlacedRural {
+                district: sd_id,
+                structure: structure_id,
+                painter: assignment.production_painter.clone(),
+                resource,
+                has_border_ring,
+            })
+        }
+        Ok(false) => None,
+        Err(e) => {
+            warn!("Rural placement failed for '{}' (parcel {:?}): {}", building, sd_id, e);
+            None
+        }
+    }
+}
+
 /// Picks placement-candidate centres biased toward the flattest interior ground.
 ///
 /// Uniform random sampling places `NUM_CANDIDATES` darts across the whole district;
@@ -281,6 +355,117 @@ fn local_height_range(cell: Point2D, radius: i32, height_at: &HashMap<Point2D, i
         return i32::MAX; // too close to the district edge to seat the footprint
     }
     max - min
+}
+
+/// Cheap feasibility probe used by the resource chain *before* it locks the
+/// settlement's economy: for a rural `district`, which of the given building
+/// `footprints` can actually be seated under `MAX_PLACEMENT_SLOPE`?
+///
+/// Each footprint is `(size_x, size_z, allow_steep)`. The check mirrors the
+/// interior + slope gating in `place_rural_building`/`select_best_candidate`:
+/// a footprint is seatable if some interior cell's footprint-sized window stays
+/// within the slope cap (the same `local_height_range` window the candidate
+/// ranker uses). `allow_steep` footprints (mines) bypass the cap and only need a
+/// non-empty interior. Returns one bool per input footprint, in order.
+///
+/// This is intentionally permissive: it answers "could this ever seat here?" so a
+/// resource is only excluded from a parcel when *no* viable pad exists — placement
+/// still does the exact per-candidate slope check. Sharing one interior height
+/// scan across all footprints keeps it to a single pass per district.
+pub fn district_seatable_footprints(
+    district: &District,
+    editor: &Editor,
+    footprints: &[(i32, i32, bool)],
+) -> Vec<bool> {
+    let edge_2d: HashSet<Point2D> =
+        district.data.edges.iter().map(|p| p.drop_y()).collect();
+
+    // Same interior as `place_rural_building`: drop edge, urban and water cells.
+    let interior: Vec<Point2D> = district
+        .data
+        .points_2d
+        .iter()
+        .filter(|p| {
+            !edge_2d.contains(p) && !editor.world().is_urban(**p) && !editor.world().is_water(**p)
+        })
+        .copied()
+        .collect();
+
+    if interior.is_empty() {
+        return vec![false; footprints.len()];
+    }
+
+    // Precompute non-tree surface heights once, reused for every footprint's window.
+    let height_at: HashMap<Point2D, i32> = interior
+        .iter()
+        .map(|&p| (p, editor.world().get_non_tree_height(p)))
+        .collect();
+
+    footprints
+        .iter()
+        .map(|&(sx, sz, allow_steep)| {
+            if sx <= 0 || sz <= 0 {
+                return false;
+            }
+            if allow_steep {
+                return true; // slope cap bypassed; interior is non-empty here
+            }
+            let probe_radius = (sx.max(sz) / 2).max(1);
+            interior
+                .iter()
+                .any(|&c| local_height_range(c, probe_radius, &height_at) <= MAX_PLACEMENT_SLOPE)
+        })
+        .collect()
+}
+
+/// Resolve the settlement's rural economy with placement feasibility folded in.
+///
+/// Wraps [`ResourceRegistry::resolve_for_parcels_seated`]: it derives each gather
+/// resource's building footprint from `data`, asks
+/// [`district_seatable_footprints`] which footprints every rural district can
+/// actually seat under the slope cap, and feeds that constraint into the resolver
+/// so the plan never assigns a building a parcel can't physically hold. Consumers
+/// (and tests) with a live `Editor` call this instead of `resolve_for_parcels` and
+/// get the seatability handling for free.
+pub fn resolve_rural_production(
+    data: &LoadedData,
+    editor: &Editor,
+    rural_analysis: &HashMap<DistrictID, ParcelAnalysis>,
+    rng: &mut RNG,
+) -> SettlementProductionResult {
+    // Map each gather resource to its building footprint (size + steep tolerance).
+    let mut gather_footprints: HashMap<String, (i32, i32, bool)> = HashMap::new();
+    for recipe in data.resource_registry.recipes().values() {
+        if !recipe.inputs.is_empty() {
+            continue; // only gather (no-input) recipes seat a rural building
+        }
+        let Some(structure) = data.structures.get(&StructureType(recipe.building.clone())) else {
+            continue;
+        };
+        let fp = (structure.size_xz.0, structure.size_xz.1, structure.allow_steep);
+        for resource in recipe.outputs.keys() {
+            gather_footprints.insert(resource.clone(), fp);
+        }
+    }
+
+    // Per rural district, the subset of gather resources whose footprint fits.
+    let resources: Vec<String> = gather_footprints.keys().cloned().collect();
+    let footprints: Vec<(i32, i32, bool)> = resources.iter().map(|r| gather_footprints[r]).collect();
+    let seatable: HashMap<DistrictID, HashSet<String>> = rural_analysis
+        .keys()
+        .filter_map(|id| {
+            let district = editor.world().districts.get(id)?.clone();
+            let fits = district_seatable_footprints(&district, editor, &footprints);
+            let set: HashSet<String> = resources
+                .iter()
+                .zip(fits)
+                .filter_map(|(r, ok)| ok.then(|| r.clone()))
+                .collect();
+            Some((*id, set))
+        })
+        .collect();
+
+    data.resource_registry.resolve_for_parcels_seated(rural_analysis, Some(&seatable), rng)
 }
 
 /// Places a single processing/secondary building somewhere in the urban region.

--- a/src/generator/resource_chain/mod.rs
+++ b/src/generator/resource_chain/mod.rs
@@ -8,4 +8,4 @@ mod tests;
 pub use types::{ResourceDef, RecipeDef, ParcelResourceAssignment};
 pub use registry::{ResourceRegistry, ResolvedChains, NearMiss, ChainSelection, ProductionPlan, SettlementProductionResult};
 pub use production_painter::{ProductionPainter, ProductionPaintersFile};
-pub use production_area::paint_production_area;
+pub use production_area::{paint_production_area, paint_production_area_for, EDGE_BUFFER};

--- a/src/generator/resource_chain/mod.rs
+++ b/src/generator/resource_chain/mod.rs
@@ -8,4 +8,4 @@ mod tests;
 pub use types::{ResourceDef, RecipeDef, ParcelResourceAssignment};
 pub use registry::{ResourceRegistry, ResolvedChains, NearMiss, ChainSelection, ProductionPlan, SettlementProductionResult};
 pub use production_painter::{ProductionPainter, ProductionPaintersFile};
-pub use production_area::{paint_production_area, paint_production_area_for, EDGE_BUFFER};
+pub use production_area::{paint_production_area, paint_production_area_for, border_ring_cells};

--- a/src/generator/resource_chain/production_area.rs
+++ b/src/generator/resource_chain/production_area.rs
@@ -21,7 +21,9 @@ use super::production_painter::{parse_params, ProductionPainter};
 
 /// Width (Chebyshev cells) of the buffer around a production district's edge.
 /// Excluded from the field interior; used as the border strip and feather band.
-const EDGE_BUFFER: i32 = 3;
+/// `pub` so the rural road network can predict the border ring's cells ahead of
+/// the painter running (see `paths::rural`) and keep the two in sync.
+pub const EDGE_BUFFER: i32 = 3;
 
 /// How far (cells) production-area smoothing reaches into neighbouring land, to
 /// feather the field's terrain into its surroundings rather than ending in a step.
@@ -30,10 +32,36 @@ const NEIGHBOUR_REACH: i32 = 2;
 /// Paints a production area across all unclaimed cells of `district` after
 /// a gathering building has been placed there. The area is claimed with
 /// `BuildClaim::ProductionArea` tied to the most-recently-placed structure on the world.
+///
+/// Use [`paint_production_area_for`] when the painting pass is decoupled from
+/// placement (e.g. all buildings placed first, then all areas painted): with the
+/// passes split, `structures.last()` no longer identifies *this* district's
+/// building, so the caller must pass the structure id explicitly.
 pub async fn paint_production_area(
     district: &District,
     painter_name: &str,
     resource: &str,
+    data: &LoadedData,
+    editor: &mut Editor,
+    rng: &mut RNG,
+) {
+    // Tie the production area to the most-recently placed structure.
+    let Some(structure_id) = editor.world().structures.last().cloned() else {
+        warn!("paint_production_area: no structure on world — was a building placed first?");
+        return;
+    };
+    paint_production_area_for(district, painter_name, resource, &structure_id, data, editor, rng).await;
+}
+
+/// As [`paint_production_area`], but the production area is tied to an explicitly
+/// supplied `structure_id` rather than `structures.last()`. Needed when buildings
+/// are all placed in one pass and their areas painted in a later pass (so the
+/// "last placed" structure is no longer the one for this district).
+pub async fn paint_production_area_for(
+    district: &District,
+    painter_name: &str,
+    resource: &str,
+    structure_id: &crate::generator::nbts::StructureID,
     data: &LoadedData,
     editor: &mut Editor,
     rng: &mut RNG,
@@ -43,12 +71,7 @@ pub async fn paint_production_area(
         return;
     };
     let painter = painter.clone();
-
-    // Tie the production area to the most-recently placed structure.
-    let Some(structure_id) = editor.world().structures.last().cloned() else {
-        warn!("paint_production_area: no structure on world — was a building placed first?");
-        return;
-    };
+    let structure_id = structure_id.clone();
 
     // Build a set of cells within EDGE_BUFFER blocks (Chebyshev) of any edge cell.
     let edge_buffer: HashSet<Point2D> = district.data.edges.iter()

--- a/src/generator/resource_chain/production_area.rs
+++ b/src/generator/resource_chain/production_area.rs
@@ -21,13 +21,42 @@ use super::production_painter::{parse_params, ProductionPainter};
 
 /// Width (Chebyshev cells) of the buffer around a production district's edge.
 /// Excluded from the field interior; used as the border strip and feather band.
-/// `pub` so the rural road network can predict the border ring's cells ahead of
-/// the painter running (see `paths::rural`) and keep the two in sync.
-pub const EDGE_BUFFER: i32 = 3;
+/// The rural road network reuses this strip via [`border_ring_cells`].
+const EDGE_BUFFER: i32 = 3;
 
 /// How far (cells) production-area smoothing reaches into neighbouring land, to
 /// feather the field's terrain into its surroundings rather than ending in a step.
 const NEIGHBOUR_REACH: i32 = 2;
+
+/// Cells within `EDGE_BUFFER` (Chebyshev) of any of `district`'s edge cells.
+fn edge_buffer_cells(district: &District) -> HashSet<Point2D> {
+    district.data.edges.iter()
+        .flat_map(|p| {
+            let p2 = p.drop_y();
+            (-EDGE_BUFFER..=EDGE_BUFFER).flat_map(move |dx| {
+                (-EDGE_BUFFER..=EDGE_BUFFER).map(move |dz| Point2D::new(p2.x + dx, p2.y + dz))
+            })
+        })
+        .collect()
+}
+
+/// The production area's border ring: interior cells within `EDGE_BUFFER` of an
+/// edge that are unclaimed and not water — the strip a border-painting painter
+/// paves with `rural_road`. The single source of truth shared with
+/// [`crate::generator::paths::rural`], so the road network's *predicted* ring and
+/// the painter's *actual* ring stay in lockstep. The result depends on claim state
+/// at call time: the road network calls this before the roads are claimed (to
+/// route along the ring); the painter calls it after (so road-claimed cells are
+/// already excluded).
+pub fn border_ring_cells(district: &District, editor: &Editor) -> HashSet<Point2D> {
+    let edge_buffer = edge_buffer_cells(district);
+    district.data.points_2d.iter()
+        .filter(|&&p| edge_buffer.contains(&p))
+        .filter(|&&p| !editor.world().is_claimed(p))
+        .filter(|&&p| !editor.world().is_water(p))
+        .copied()
+        .collect()
+}
 
 /// Paints a production area across all unclaimed cells of `district` after
 /// a gathering building has been placed there. The area is claimed with
@@ -74,14 +103,7 @@ pub async fn paint_production_area_for(
     let structure_id = structure_id.clone();
 
     // Build a set of cells within EDGE_BUFFER blocks (Chebyshev) of any edge cell.
-    let edge_buffer: HashSet<Point2D> = district.data.edges.iter()
-        .flat_map(|p| {
-            let p2 = p.drop_y();
-            (-EDGE_BUFFER..=EDGE_BUFFER).flat_map(move |dx| {
-                (-EDGE_BUFFER..=EDGE_BUFFER).map(move |dz| Point2D::new(p2.x + dx, p2.y + dz))
-            })
-        })
-        .collect();
+    let edge_buffer = edge_buffer_cells(district);
 
     // Free cells: parcel interior excluding edge buffer, not yet claimed, not water.
     let raw_free_cells: HashSet<Point2D> = district.data.points_2d.iter()
@@ -104,13 +126,9 @@ pub async fn paint_production_area_for(
 
     // Border cells: parcel interior points that fall within the edge buffer, not
     // yet claimed, not water. Painted with the border palette (e.g. rural_road) by
-    // both the palette and function painters.
-    let border_cells: HashSet<Point2D> = district.data.points_2d.iter()
-        .filter(|&&p| edge_buffer.contains(&p))
-        .filter(|&&p| !editor.world().is_claimed(p))
-        .filter(|&&p| !editor.world().is_water(p))
-        .copied()
-        .collect();
+    // both the palette and function painters. Shared with the rural road network's
+    // ring prediction (see `border_ring_cells`).
+    let border_cells = border_ring_cells(district, editor);
 
     match painter {
         ProductionPainter::Palettes { palettes, border_palette, irrigation, flatten_strength } => {

--- a/src/generator/resource_chain/production_painter.rs
+++ b/src/generator/resource_chain/production_painter.rs
@@ -32,6 +32,26 @@ pub enum ProductionPainter {
     },
 }
 
+impl ProductionPainter {
+    /// Whether this painter lays a border ring — the `rural_road` strip painted
+    /// around the production area's edge buffer. The rural road network predicts
+    /// and reuses that ring, so it needs to know which areas will have one.
+    ///
+    /// `palettes` painters have a ring iff they declare a `border_palette`; the
+    /// `pasture` and `sugarcane` function painters always paint one (their
+    /// `border_palette` param defaults to `rural_road`). Other function painters
+    /// (logging, bees, mine) lay no border.
+    pub fn paints_border(&self) -> bool {
+        match self {
+            ProductionPainter::Palettes { border_palette, .. } => border_palette.is_some(),
+            ProductionPainter::Function { function, .. } => matches!(
+                function.as_str(),
+                "pasture_production_painter" | "sugarcane_production_painter"
+            ),
+        }
+    }
+}
+
 /// Deserialize a painter's free-form `params` value into a function-specific
 /// struct. Optional fields rely on the target's `#[serde(default)]`. A null
 /// (absent) params value deserializes to the target's `Default` where derived.

--- a/src/generator/resource_chain/registry.rs
+++ b/src/generator/resource_chain/registry.rs
@@ -112,6 +112,12 @@ pub struct SettlementProductionResult {
     pub gather_buildings: HashMap<String, u32>,
     /// Processing buildings required, scaled by units of finished goods produced.
     pub processing_buildings: HashMap<String, u32>,
+    /// Districts dropped by the per-resource competition cap, kept as an ordered
+    /// fallback list per gather resource (flattest/most-seatable first). When a
+    /// primary `parcel_assignments` entry fails to physically place, the caller can
+    /// promote the best dropped same-resource candidate instead of losing the
+    /// building outright — preserving the planned economy without exceeding the cap.
+    pub fallback_assignments: HashMap<String, Vec<(DistrictID, ParcelResourceAssignment)>>,
 }
 
 #[derive(Debug)]
@@ -455,6 +461,23 @@ impl ResourceRegistry {
         parcel_analysis: &HashMap<DistrictID, ParcelAnalysis>,
         rng: &mut RNG,
     ) -> SettlementProductionResult {
+        self.resolve_for_parcels_seated(parcel_analysis, None, rng)
+    }
+
+    /// As [`resolve_for_parcels`], but additionally honours a per-parcel
+    /// *seatability* constraint: `seatable[id]` is the set of resources whose
+    /// gather building footprint can physically fit in district `id` under the
+    /// placement slope cap (computed by `placement::district_seatable_footprints`).
+    /// A resource absent from a parcel's set is excluded from that parcel exactly
+    /// like a terrain exclusion, so the planned economy never advertises a gather
+    /// building that placement would later drop for want of a flat pad. `None`
+    /// disables the constraint (all resources seatable everywhere).
+    pub fn resolve_for_parcels_seated(
+        &self,
+        parcel_analysis: &HashMap<DistrictID, ParcelAnalysis>,
+        seatable: Option<&HashMap<DistrictID, HashSet<String>>>,
+        rng: &mut RNG,
+    ) -> SettlementProductionResult {
         // caps to prevent extreme overproduction of certain goods that would skew the settlement's production profile
         const RAW_SURPLUS_CAP: u32 = 5;
         const INTERMEDIATE_CAP: u32 = 10;
@@ -516,7 +539,7 @@ impl ResourceRegistry {
         // resource keeps at least one parcel while overproduction is still reined in.
         let mut quota: HashMap<String, usize> = HashMap::new();
         for _ in 0..10 {
-            let trial_assignments = self.assign_parcel_resources_quota(&base_options, &quota, &ruggedness, false, &mut rng.derive());
+            let trial_assignments = self.assign_parcel_resources_quota(&base_options, &quota, &ruggedness, seatable, false, &mut rng.derive());
 
             // Compute trial supply, crediting all gather recipe outputs (handles multi-output
             // recipes like gather_bees which produces both honey and beeswax).
@@ -602,7 +625,7 @@ impl ResourceRegistry {
         // primary resource), respecting the per-resource parcel quotas computed above.
         // The primary output is credited at 2 units; co-products from multi-output recipes
         // (e.g. gather_bees → honey + beeswax) are scaled proportionally.
-        let mut parcel_assignments = self.assign_parcel_resources_quota(&base_options, &quota, &ruggedness, true, rng);
+        let mut parcel_assignments = self.assign_parcel_resources_quota(&base_options, &quota, &ruggedness, seatable, true, rng);
 
         // Competition cap: keep at most MAX_RURAL_PER_RESOURCE districts per gather
         // resource. Applied here, before supply/buildings/plan are derived, so the rest
@@ -610,6 +633,7 @@ impl ResourceRegistry {
         // for each over-represented resource we keep the lowest-ID districts and drop
         // the excess (those districts simply go unproduced). This is a *hard* cap the
         // quota system alone can't guarantee, since its diversity floor may overshoot.
+        let mut fallback_assignments: HashMap<String, Vec<(DistrictID, ParcelResourceAssignment)>> = HashMap::new();
         if COMPETITION_HARD_CAPS {
             let mut by_resource: HashMap<String, Vec<DistrictID>> = HashMap::new();
             for (id, a) in &parcel_assignments {
@@ -621,12 +645,25 @@ impl ResourceRegistry {
                 }
                 ids.sort_by_key(|id| id.0);
                 for drop_id in ids.into_iter().skip(MAX_RURAL_PER_RESOURCE) {
-                    parcel_assignments.remove(&drop_id);
+                    // Remove from the active plan, but retain it as a placement fallback
+                    // for this resource rather than discarding it entirely.
+                    if let Some(assignment) = parcel_assignments.remove(&drop_id) {
+                        fallback_assignments.entry(resource.clone()).or_default().push((drop_id, assignment));
+                    }
                     log::info!(
-                        "[resource-chain]   competition cap: dropped {:?} (resource {}) — over {} per resource",
+                        "[resource-chain]   competition cap: dropped {:?} (resource {}) — over {} per resource (kept as fallback)",
                         drop_id, resource, MAX_RURAL_PER_RESOURCE,
                     );
                 }
+            }
+            // Order each resource's fallbacks flattest-first, so the caller promotes the
+            // most placeable dropped parcel when a primary fails to seat.
+            for fallbacks in fallback_assignments.values_mut() {
+                fallbacks.sort_by(|(a, _), (b, _)| {
+                    let ra = ruggedness.get(a).copied().unwrap_or(1.0);
+                    let rb = ruggedness.get(b).copied().unwrap_or(1.0);
+                    ra.partial_cmp(&rb).unwrap_or(std::cmp::Ordering::Equal).then(a.0.cmp(&b.0))
+                });
             }
         }
 
@@ -703,6 +740,7 @@ impl ResourceRegistry {
             leftover_goods,
             gather_buildings,
             processing_buildings,
+            fallback_assignments,
         };
 
         // Log the full chain so multiple generation runs can be compared via the logs.
@@ -738,7 +776,7 @@ impl ResourceRegistry {
         options: &HashMap<ID, Vec<String>>,
         rng: &mut RNG,
     ) -> HashMap<ID, ParcelResourceAssignment> {
-        self.assign_parcel_resources_quota(options, &HashMap::new(), &HashMap::new(), false, rng)
+        self.assign_parcel_resources_quota(options, &HashMap::new(), &HashMap::new(), None, false, rng)
     }
 
     /// Like [`assign_parcel_resources`], but caps how many parcels may be assigned each
@@ -765,42 +803,53 @@ impl ResourceRegistry {
         options: &HashMap<ID, Vec<String>>,
         max_parcels: &HashMap<String, usize>,
         ruggedness: &HashMap<ID, f32>,
+        seatable: Option<&HashMap<ID, HashSet<String>>>,
         log_decisions: bool,
         rng: &mut RNG,
     ) -> HashMap<ID, ParcelResourceAssignment> {
-        // Filter each parcel's candidates to those with a known gather building AND whose
-        // flat-terrain requirement the parcel's terrain can satisfy (crops/pastures drop out
-        // on rough ground — see `terrain_allows`). We keep the rejected-for-terrain list per
-        // parcel only so the decision log can show what the terrain ruled out. Then sort
-        // most-constrained first.
-        let mut parcels: Vec<(ID, Vec<String>, Vec<String>)> = options.iter()
+        // Filter each parcel's candidates to those with a known gather building, whose
+        // flat-terrain requirement the parcel's terrain can satisfy (crops/pastures drop
+        // out on rough ground — see `terrain_allows`), AND whose building footprint can
+        // actually be seated in the parcel (`seatable`, when supplied — so we never plan a
+        // building placement can't physically fit). We keep the rejected-for-terrain and
+        // rejected-for-footprint lists per parcel only so the decision log can show what
+        // each filter ruled out. Then sort most-constrained first.
+        let mut parcels: Vec<(ID, Vec<String>, Vec<String>, Vec<String>)> = options.iter()
             .map(|(id, candidates)| {
                 let rugged = ruggedness.get(id).copied().unwrap_or(0.0);
                 let gatherable = candidates.iter()
                     .filter(|r| self.gather_building(r).is_some());
-                let (valid, excluded_terrain): (Vec<String>, Vec<String>) = gatherable
+                let (terrain_ok, excluded_terrain): (Vec<String>, Vec<String>) = gatherable
                     .cloned()
                     .partition(|r| self.terrain_allows(r, rugged));
-                (id.clone(), valid, excluded_terrain)
+                // A missing parcel entry means "unknown — allow"; only an explicit set
+                // that omits the resource counts as not-seatable. With `seatable = None`
+                // every resource passes, preserving the unconstrained behaviour.
+                let seatable_here = seatable.and_then(|m| m.get(id));
+                let (valid, excluded_footprint): (Vec<String>, Vec<String>) = terrain_ok
+                    .into_iter()
+                    .partition(|r| seatable_here.map_or(true, |s| s.contains(r)));
+                (id.clone(), valid, excluded_terrain, excluded_footprint)
             })
             .collect();
-        parcels.sort_by_key(|(_, candidates, _)| candidates.len());
+        parcels.sort_by_key(|(_, candidates, _, _)| candidates.len());
 
         let mut assigned_set: HashSet<String> = HashSet::new();
         let mut assigned_count: HashMap<String, usize> = HashMap::new();
         let mut result: HashMap<ID, ParcelResourceAssignment> = HashMap::new();
 
-        for (id, candidates, excluded_terrain) in parcels {
+        for (id, candidates, excluded_terrain, excluded_footprint) in parcels {
             let parcel_rugged = ruggedness.get(&id).copied().unwrap_or(0.0);
             let excluded_str = if excluded_terrain.is_empty() { "none".to_string() } else { excluded_terrain.join(", ") };
+            let footprint_str = if excluded_footprint.is_empty() { "none".to_string() } else { excluded_footprint.join(", ") };
 
             if candidates.is_empty() {
-                // No option survives (no gather building, or terrain ruled them all out) —
-                // leave this rural district unproduced.
+                // No option survives (no gather building, or terrain/footprint ruled them
+                // all out) — leave this rural district unproduced.
                 if log_decisions {
                     log::info!(
-                        "[resource-chain]   pick parcel {:?} -> (none) (ruggedness {:.3}); terrain-excluded: {}",
-                        id, parcel_rugged, excluded_str,
+                        "[resource-chain]   pick parcel {:?} -> (none) (ruggedness {:.3}); terrain-excluded: {}; footprint-excluded: {}",
+                        id, parcel_rugged, excluded_str, footprint_str,
                     );
                 }
                 continue;
@@ -863,8 +912,8 @@ impl ResourceRegistry {
                 let outcome = if skipped { format!("(none — best was {} at {})", resource, winning_score) }
                               else { format!("{} (score {})", resource, winning_score) };
                 log::info!(
-                    "[resource-chain]   pick parcel {:?} -> {} (ruggedness {:.3}); terrain-excluded: {}; balance penalties: {}",
-                    id, outcome, parcel_rugged, excluded_str, penalised,
+                    "[resource-chain]   pick parcel {:?} -> {} (ruggedness {:.3}); terrain-excluded: {}; footprint-excluded: {}; balance penalties: {}",
+                    id, outcome, parcel_rugged, excluded_str, footprint_str, penalised,
                 );
             }
 

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -6,7 +6,9 @@ use crate::generator::data::LoadedData;
 use crate::generator::districts::{build_wall, generate_parcels, ParcelType, WallType};
 use crate::generator::materials::{Material, MaterialId, Placer};
 use crate::generator::nbts::Structure;
-use crate::generator::paths::{build_paths_merged, build_road_network, find_blocks, Path, PathPriority};
+use crate::generator::paths::{build_paths_merged, build_road_network, build_rural_road_network, find_blocks, Path, PathPriority, RuralBuilding};
+use crate::generator::placement::{resolve_rural_production, try_place_rural, PlacedRural};
+use crate::generator::resource_chain::paint_production_area_for;
 use crate::generator::terrain::{flatten_urban_area, force_height, log_trees};
 use crate::geometry::{Point2D, Point3D};
 use crate::minecraft::Block;
@@ -31,41 +33,32 @@ pub async fn generate_town(
 
     generate_parcels(seed, editor).await;
 
-    // EVAL AID: the live server hands out a different build area each run, and
-    // the urban classifier frequently collapses to a single parcel — too
-    // degenerate to evaluate the road network. Force a contiguous ~4-parcel
-    // urban core: keep the prime, then promote the nearest non-off-limits
-    // super-parcels to Urban.
-    {
-        const TARGET_URBAN: usize = 4;
-        let mut info: Vec<(crate::generator::districts::DistrictID, Point2D, bool)> =
-            editor.world().districts.iter()
-                .filter(|(id, sd)| {
-                    if sd.data.parcel_type == ParcelType::OffLimits {
-                        return false;
-                    }
-                    // Never force a water-heavy parcel urban — it would build the
-                    // town on a lake. (Matches URBAN_WATER_LIMIT in classification.)
-                    let water = editor.world().district_analysis_data
-                        .get(id)
-                        .map_or(0.0, |a| a.water_percentage());
-                    water <= 0.33
-                })
-                .map(|(id, sd)| {
-                    let pts = &sd.data.points_2d;
-                    let c = pts.iter().fold(Point2D::ZERO, |a, p| a + *p) / pts.len().max(1) as i32;
-                    (*id, c, sd.data.parcel_type == ParcelType::Urban)
-                })
-                .collect();
-        let anchor = info.iter().find(|(_, _, u)| *u).map(|(_, c, _)| *c)
-            .or_else(|| info.first().map(|(_, c, _)| *c));
-        if let Some(anchor) = anchor {
-            info.sort_by_key(|(_, c, _)| c.distance_squared(&anchor));
-            for (id, _, _) in info.iter().take(TARGET_URBAN) {
-                editor.world_mut().districts.get_mut(id).unwrap().data.parcel_type = ParcelType::Urban;
-            }
-        }
-    }
+    
+    let data = LoadedData::load().expect("Failed to load data");
+
+    // ── Resource chain over rural districts ──────────────────────────────
+    let rural_analysis: HashMap<_, _> = editor.world().district_analysis_data.iter()
+        .filter(|(id, _)| {
+            editor.world().districts.get(id)
+                .map(|d| d.data.parcel_type == ParcelType::Rural)
+                .unwrap_or(false)
+        })
+        .map(|(id, analysis)| (*id, analysis.clone()))
+        .collect();
+    // Resolve the rural economy with placement feasibility folded in: parcels that
+    // can't physically seat a resource's gather building (footprint too big for any
+    // flat enough pad) are excluded during assignment, so the plan never promises a
+    // building placement would later drop. (Rural terrain is still natural here —
+    // flatten/walls only touch urban.)
+    let result = resolve_rural_production(&data, editor, &rural_analysis, &mut rng);
+
+    // Phase 1 — feathered urban flatten.
+    let urban = editor.world().get_urban_points();
+    // Log (clear) the urban area of trees so roads, buildings, and houses
+    // aren't dropped into standing forest.
+    log_trees(&*editor, urban.clone()).await;
+    println!("Logged {} urban cells of trees", urban.len());
+    flatten_urban_area(editor, &urban, 16, 12, true).await;
 
     // Wall + gates — gates populate world.gate_locations, used by the network.
     let materials = Material::load().expect("Failed to load materials");
@@ -87,15 +80,103 @@ pub async fn generate_town(
         println!("URBAN super-parcels: {}/{} total | gates: {}", n_urban, n_total, editor.world().gate_locations.len());
     }
 
-    // Phase 1 — feathered urban flatten.
-    let urban = editor.world().get_urban_points();
-    // Log (clear) the urban area of trees so roads, buildings, and houses
-    // aren't dropped into standing forest.
-    log_trees(&*editor, urban.clone()).await;
-    println!("Logged {} urban cells of trees", urban.len());
-    flatten_urban_area(editor, &urban, 16, 12, true).await;
+    let mut sd_ids: Vec<_> = result.parcel_assignments.keys().cloned().collect();
+        sd_ids.sort_by_key(|id| id.0);
+        // Dropped-by-competition-cap parcels, ordered flattest-first per resource:
+        // promoted when a primary fails to seat, so a terrain miss costs us a different
+        // parcel rather than the building (and the planned economy) entirely.
+        let mut fallbacks: HashMap<String, std::collections::VecDeque<_>> = result
+            .fallback_assignments
+            .iter()
+            .map(|(res, list)| (res.clone(), list.iter().cloned().collect()))
+            .collect();
+        let mut placed = 0usize;
+        // Placed rural buildings, collected so the road network can connect them
+        // and the production painters can run *after* the roads (R3 below).
+        let mut placed_rural: Vec<PlacedRural> = Vec::new();
+        for sd_id in &sd_ids {
+            let assignment = result.parcel_assignments[sd_id].clone();
+            if let Some(p) = try_place_rural(*sd_id, &assignment, &data, editor, &mut rng).await {
+                placed += 1;
+                placed_rural.push(p);
+                continue;
+            }
+            // Primary couldn't seat — promote the best dropped same-resource parcel(s)
+            // until one places, keeping the per-resource count at its cap.
+            while let Some((fb_id, fb_assignment)) = fallbacks
+                .get_mut(&assignment.primary_resource)
+                .and_then(|q| q.pop_front())
+            {
+                log::info!(
+                    "[resource-chain]   promoting fallback {:?} for resource {} after {:?} failed to place",
+                    fb_id, assignment.primary_resource, sd_id,
+                );
+                if let Some(p) = try_place_rural(fb_id, &fb_assignment, &data, editor, &mut rng).await {
+                    placed += 1;
+                    placed_rural.push(p);
+                    break;
+                }
+            }
+        }
+        log::info!("Placed {} of {} rural buildings", placed, sd_ids.len());
 
-    let data = LoadedData::load().expect("Failed to load data");
+    // ── Rural road network (built BEFORE the production painters) ─────────
+    // Connect every placed rural building to a town gate, predicting and reusing
+    // the `rural_road` border ring each painter will lay. Realise + claim the
+    // roads here so the painters' border rings skip the cells the road owns.
+    let rural_material = MaterialId::new("rural_road".to_string());
+    let rural_buildings: Vec<RuralBuilding> = placed_rural.iter().map(|p| RuralBuilding {
+        district: p.district,
+        structure: p.structure.clone(),
+        has_border_ring: p.has_border_ring,
+    }).collect();
+    let rural_paths = build_rural_road_network(&*editor, &rural_buildings, rural_material, 1).await;
+    if !rural_paths.is_empty() {
+        // Flatten the routed corridor to the road heights (skipping building /
+        // wall cells so a placed structure isn't re-graded), then meld the
+        // surface — mirrors the urban road realization.
+        let mut corridor: HashMap<Point2D, i32> = HashMap::new();
+        for path in &rural_paths {
+            let w = path.width() as i32;
+            for pt in path.points() {
+                let base = pt.drop_y();
+                for dx in -w..=w {
+                    for dz in -w..=w {
+                        let c = Point2D::new(base.x + dx, base.y + dz);
+                        corridor.entry(c).and_modify(|y| *y = (*y).min(pt.y)).or_insert(pt.y);
+                    }
+                }
+            }
+        }
+        let corridor_pts: HashSet<Point3D> = corridor.iter()
+            .filter(|(c, _)| !matches!(
+                editor.world().get_claim(**c),
+                Some(crate::generator::BuildClaim::Structure(_)
+                    | crate::generator::BuildClaim::Building(_)
+                    | crate::generator::BuildClaim::Wall)
+            ))
+            .map(|(c, &y)| Point3D::new(c.x, y, c.y))
+            .collect();
+        force_height(editor, &corridor_pts, false).await;
+        build_paths_merged(&*editor, &data, &rural_paths, &mut rng).await;
+        for path in &rural_paths {
+            let centre: HashSet<Point2D> = path.points().iter().map(|p| p.drop_y()).collect();
+            let mut paved = crate::geometry::get_surrounding_set(&centre, path.width().saturating_sub(1));
+            paved.extend(centre);
+            for c in paved {
+                editor.world_mut().claim(c, crate::generator::BuildClaim::Path(crate::generator::paths::PathType::Road));
+            }
+        }
+    }
+    println!("Rural roads: {} segments", rural_paths.len());
+
+    // ── R3: paint rural production areas (after the roads) ────────────────
+    for p in &placed_rural {
+        let Some(painter) = &p.painter else { continue };
+        let Some(district) = editor.world().districts.get(&p.district).cloned() else { continue };
+        paint_production_area_for(&district, painter, &p.resource, &p.structure, &data, editor, &mut rng).await;
+    }
+
 
     // ---- Industrial buildings FIRST ----
     // Place a handful of big processing buildings on the flattened ground (no


### PR DESCRIPTION
## What

Adds a **rural road network** that connects every placed rural resource building to the urban road network **via the town gates**, over un-flattened countryside. Runs **before** the production painters so each area's `rural_road` border ring ties into the road already laid.

## How

- **`paths/rural.rs`** — `build_rural_road_network` + `RuralBuilding`. Per building: routes to the nearest gate (reusing `get_path_with`/`RouteContext`/`RouteParams`), anchors on the **door** (block scan, perimeter fallback for doorless mines/pastures), **predicts and reuses** the `rural_road` border ring as the router's on-road discount field, and cost-couples routes so buildings share a spine instead of carving parallel tracks. New `rural_road` material (`data/materials/ground/rural_road.json`).
- **`settlement`** — rural flow split into three phases: place all buildings → build + claim roads (corridor `force_height` then `build_paths_merged`) → paint all production areas. `paint_production_area_for` added so the deferred paint pass ties each area to the right structure instead of `structures.last()`.
- **`placement`** — `try_place_rural` now returns `PlacedRural` (placement only, no inline paint); also carries the seatability + competition-cap fallback wiring.
- **`editor`** — `get_cached_block(local)` reads back blocks placed this run by their local key. `get_block`/`try_get_block` subtract the build-area origin and return world terrain on a live server, which made the door scan always miss and drop to the corner fallback.

Design notes and open items in `docs/plans/rural_roads.md`.

## Testing

`cargo check`, `cargo check --tests`, and `build_furnished_houses_offline` pass. The live settlement path (routing, corridor flattening, door attach) still needs an in-world run to validate visually — offline/synthetic worlds have origin 0, so they can't exercise the live-server cache path.
