### PR TITLE
NPCs: living-town population over the buildings_v2 town pipeline

### DIFF
--- a/data/furniture/items/common.yaml
+++ b/data/furniture/items/common.yaml
@@ -12,6 +12,10 @@ chest:
     - offset: [0, 0]
       constraint: blocked_reachable
       facing: away_from_wall
+  # Someone crouched at the open chest, facing into it.
+  anchors:
+    - dialogue: sorting
+      slots: [ { offset: [0, 1] } ]
 
 lantern:
   unique: true
@@ -459,6 +463,10 @@ crafting_table:
   constraints:
     - offset: [0, 0]
       constraint: blocked_reachable
+  # A crafter working at the bench.
+  anchors:
+    - dialogue: crafting
+      slots: [ { offset: [0, 1] } ]
 
 # Single block against a wall. Fletching_table reads as a small writing
 # surface — palette-neutral and period-appropriate.
@@ -471,6 +479,10 @@ desk:
     - offset: [0, 0]
       constraint: wall
       facing: away_from_wall
+  # Someone seated at the desk, facing the writing surface.
+  anchors:
+    - dialogue: reading
+      slots: [ { offset: [0, 1] } ]
 
 # Wooden stairs as a chair, facing into the room.
 chair:
@@ -528,6 +540,14 @@ table:
   constraints:
     - offset: [0, 0]
       constraint: blocked_reachable
+  # Two diners on opposite sides facing each other across the table. The far
+  # seat is optional, so a table boxed in on one side still seats one.
+  anchors:
+    - kind: conversation
+      dialogue: conversation
+      slots:
+        - { offset: [0, 1] }
+        - { offset: [0, -1], required: false }
 
 vase:
   blocks:

--- a/data/furniture/items/common.yaml
+++ b/data/furniture/items/common.yaml
@@ -482,7 +482,7 @@ desk:
   # Someone seated at the desk, facing the writing surface.
   anchors:
     - dialogue: reading
-      slots: [ { offset: [0, 1] } ]
+      slots: [ { offset: [0, 1], occupant: any_age } ]
 
 # Wooden stairs as a chair, facing into the room.
 chair:

--- a/data/furniture/items/decor.yaml
+++ b/data/furniture/items/decor.yaml
@@ -23,6 +23,10 @@ chiseled_bookshelf:
     - offset: [0, 0]
       constraint: wall
       facing: away_from_wall
+  # A reader browsing the shelf.
+  anchors:
+    - dialogue: reading
+      slots: [ { offset: [0, 1] } ]
 
 # Reading stand against a wall, lectern face (open book) toward the room.
 lectern:
@@ -34,6 +38,10 @@ lectern:
     - offset: [0, 0]
       constraint: wall
       facing: away_from_wall
+  # A reader at the lectern.
+  anchors:
+    - dialogue: reading
+      slots: [ { offset: [0, 1] } ]
 
 # 2-wide bench: two wooden stairs side by side against a wall, seats facing
 # into the room. Mirrors `chair` (oak_stairs, away_from_wall) but two cells

--- a/data/furniture/items/decor.yaml
+++ b/data/furniture/items/decor.yaml
@@ -26,7 +26,7 @@ chiseled_bookshelf:
   # A reader browsing the shelf.
   anchors:
     - dialogue: reading
-      slots: [ { offset: [0, 1] } ]
+      slots: [ { offset: [0, 1], occupant: any_age } ]
 
 # Reading stand against a wall, lectern face (open book) toward the room.
 lectern:
@@ -41,7 +41,7 @@ lectern:
   # A reader at the lectern.
   anchors:
     - dialogue: reading
-      slots: [ { offset: [0, 1] } ]
+      slots: [ { offset: [0, 1], occupant: any_age } ]
 
 # 2-wide bench: two wooden stairs side by side against a wall, seats facing
 # into the room. Mirrors `chair` (oak_stairs, away_from_wall) but two cells

--- a/data/furniture/items/house.yaml
+++ b/data/furniture/items/house.yaml
@@ -34,7 +34,7 @@ single_bed:
   # Standing at the foot of the bed (one past the foot block), facing it.
   anchors:
     - dialogue: resting
-      slots: [ { offset: [0, 2] } ]
+      slots: [ { offset: [0, 2], occupant: any_age } ]
 
 double_bed:
   unique: true
@@ -65,7 +65,7 @@ double_bed:
   # Standing at the foot of the bed, facing it.
   anchors:
     - dialogue: resting
-      slots: [ { offset: [0, 2] } ]
+      slots: [ { offset: [0, 2], occupant: any_age } ]
 
 canopy_bed:
   unique: true
@@ -263,5 +263,5 @@ bed_with_nightstand:
   # Standing at the foot of the bed, facing it.
   anchors:
     - dialogue: resting
-      slots: [ { offset: [0, 2] } ]
+      slots: [ { offset: [0, 2], occupant: any_age } ]
 

--- a/data/furniture/items/house.yaml
+++ b/data/furniture/items/house.yaml
@@ -31,6 +31,10 @@ single_bed:
     - offset: [0, 1]
       constraint: blocked_reachable
       facing: toward_wall
+  # Standing at the foot of the bed (one past the foot block), facing it.
+  anchors:
+    - dialogue: resting
+      slots: [ { offset: [0, 2] } ]
 
 double_bed:
   unique: true
@@ -58,6 +62,10 @@ double_bed:
     - offset: [1, 1]
       constraint: blocked_reachable
       facing: toward_wall
+  # Standing at the foot of the bed, facing it.
+  anchors:
+    - dialogue: resting
+      slots: [ { offset: [0, 2] } ]
 
 canopy_bed:
   unique: true
@@ -252,4 +260,8 @@ bed_with_nightstand:
     - offset: [0, 1]
       constraint: blocked_reachable
       facing: toward_wall
+  # Standing at the foot of the bed, facing it.
+  anchors:
+    - dialogue: resting
+      slots: [ { offset: [0, 2] } ]
 

--- a/data/furniture/items/industrial.yaml
+++ b/data/furniture/items/industrial.yaml
@@ -8,6 +8,10 @@ anvil:
     - offset: [0, 0]
       constraint: blocked_reachable
       facing: perpendicular
+  # A smith working the anvil.
+  anchors:
+    - dialogue: crafting
+      slots: [ { offset: [0, 1] } ]
 
 cauldron:
   unique: true
@@ -18,6 +22,10 @@ cauldron:
   constraints:
     - offset: [0, 0]
       constraint: blocked_reachable
+  # Someone stirring the cauldron.
+  anchors:
+    - dialogue: cooking
+      slots: [ { offset: [0, 1] } ]
 
 furnace:
   unique: true
@@ -32,6 +40,10 @@ furnace:
       facing: away_from_wall
     - offset: [0, 1]
       constraint: blocked_reachable
+  # A worker tending the furnace, standing on its reserved approach cell.
+  anchors:
+    - dialogue: cooking
+      slots: [ { offset: [0, 1] } ]
 
 loom:
   unique: true
@@ -43,6 +55,10 @@ loom:
     - offset: [0, 0]
       constraint: blocked_reachable
       facing: away_from_wall
+  # Someone working the loom.
+  anchors:
+    - dialogue: crafting
+      slots: [ { offset: [0, 1] } ]
 
 smoker:
   unique: true
@@ -55,3 +71,7 @@ smoker:
     - offset: [0, 0]
       constraint: blocked_reachable
       facing: away_from_wall
+  # Someone tending the smoker.
+  anchors:
+    - dialogue: cooking
+      slots: [ { offset: [0, 1] } ]

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -41,7 +41,7 @@ roof_canopy:
   # Someone relaxing in the shade under the canopy.
   anchors:
     - dialogue: resting
-      slots: [ { offset: [1, 1] } ]
+      slots: [ { offset: [1, 1], occupant: any_age } ]
 
 # ---------------------------------------------------------------------------
 # Sleeping mat — a carpet bedroll with a hay bolster for a headrest. Sleeping
@@ -56,7 +56,7 @@ roof_bedroll:
   # Someone settling down at the foot of the bedroll, under the stars.
   anchors:
     - dialogue: resting
-      slots: [ { offset: [0, 2] } ]
+      slots: [ { offset: [0, 2], occupant: any_age } ]
 
 # ---------------------------------------------------------------------------
 # Terrace lamp — a short fence post topped with a lantern, for night light.
@@ -105,7 +105,7 @@ roof_brazier:
   # Someone warming themselves at the fire.
   anchors:
     - dialogue: cooking
-      slots: [ { offset: [0, 1] } ]
+      slots: [ { offset: [0, 1], occupant: any_age } ]
 
 # ---------------------------------------------------------------------------
 # Pottery cluster — a pair of decorated pots, distinct from the single `vase`.
@@ -284,7 +284,7 @@ roof_tandoor:
   # A cook at the clay oven.
   anchors:
     - dialogue: cooking
-      slots: [ { offset: [0, 1] } ]
+      slots: [ { offset: [0, 1], occupant: any_age } ]
 
 # Cactus ledge — a row of three potted cacti, a little desert garden. 1×3.
 roof_cactus_row:

--- a/data/furniture/items/rooftop.yaml
+++ b/data/furniture/items/rooftop.yaml
@@ -38,6 +38,10 @@ roof_canopy:
     - { offset: [2, 0], constraint: blocked_reachable }
     - { offset: [0, 2], constraint: blocked_reachable }
     - { offset: [2, 2], constraint: blocked_reachable }
+  # Someone relaxing in the shade under the canopy.
+  anchors:
+    - dialogue: resting
+      slots: [ { offset: [1, 1] } ]
 
 # ---------------------------------------------------------------------------
 # Sleeping mat — a carpet bedroll with a hay bolster for a headrest. Sleeping
@@ -49,6 +53,10 @@ roof_bedroll:
     - { block: "minecraft:white_carpet", offset: [0, 0, 1], layer: ground, swap: color, walkable: true }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
+  # Someone settling down at the foot of the bedroll, under the stars.
+  anchors:
+    - dialogue: resting
+      slots: [ { offset: [0, 2] } ]
 
 # ---------------------------------------------------------------------------
 # Terrace lamp — a short fence post topped with a lantern, for night light.
@@ -94,6 +102,10 @@ roof_brazier:
     - { block: "minecraft:campfire",      offset: [0, 1, 0], layer: ground }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
+  # Someone warming themselves at the fire.
+  anchors:
+    - dialogue: cooking
+      slots: [ { offset: [0, 1] } ]
 
 # ---------------------------------------------------------------------------
 # Pottery cluster — a pair of decorated pots, distinct from the single `vase`.
@@ -269,6 +281,10 @@ roof_tandoor:
     - { block: "minecraft:smoker[lit=true,facing=north]", offset: [0, 1, 0], layer: ground }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
+  # A cook at the clay oven.
+  anchors:
+    - dialogue: cooking
+      slots: [ { offset: [0, 1] } ]
 
 # Cactus ledge — a row of three potted cacti, a little desert garden. 1×3.
 roof_cactus_row:
@@ -301,6 +317,10 @@ roof_grindstone:
     - { block: "minecraft:grindstone[face=floor,facing=north]", offset: [0, 0, 0], layer: ground }
   constraints:
     - { offset: [0, 0], constraint: blocked_reachable }
+  # Someone grinding grain at the millstone.
+  anchors:
+    - dialogue: crafting
+      slots: [ { offset: [0, 1] } ]
 
 # Rug runner — a long walkable carpet with alternating colours. 1×3. Like the
 # stock carpets, walkable blocks carry no constraints (they stay walkable).

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -112,6 +112,15 @@ dialogue:
     - "Busy on the square today, isn't it?"
     - "Wonder if they've any of those left..."
     - "My coin's near spent already."
+  # Guards posted at a gate or on a wall tower, watching the approaches.
+  guarding:
+    - "State your business at the gate."
+    - "Move along — nothing amiss here."
+    - "Keep the peace and we'll have no trouble."
+    - "Eyes on the road. You never know these days."
+    - "Halt. ...Right, on you go."
+    - "Quiet watch tonight, thank the gods."
+    - "No weapons drawn inside the walls."
 
 # Multi-person exchanges: each entry is one back-and-forth, its lines handed to
 # a scene's slots in order (line 0 = the opener, line 1 = the reply). Keyed like
@@ -132,3 +141,26 @@ exchanges:
       - "Don't say that too loud — you'll jinx it."
     - - "I heard wolves on the ridge last night."
       - "Best keep the gate barred, then."
+  # Stage performances, bucketed by cast size. The stage rolls 1–3 performers and
+  # staff_scene draws a `performing` entry with exactly that many lines (one per
+  # performer). Solos, duets, and trios live side by side here; every line is
+  # yelled out over the square, so each should stand on its own as a shout.
+  performing:
+    # — solo acts (1) —
+    - - "Gather round, good folk — a tale to chill your very blood!"
+    - - "Lend me your ears, and I'll lend you a song you'll never forget!"
+    - - "One night only! You'll be telling your grandchildren of this!"
+    # — duets (2) —
+    - - "Strike up the tune, my friend — let's give them a show!"
+      - "Aye! And I'll sing it sweet enough to still the birds!"
+    - - "I'll play the gallant knight, bold and true!"
+      - "And I the wicked dragon — flee, good people, flee!"
+    - - "Step closer for the ballad of the drowned sailor!"
+      - "And mind you weep, for it's a sorry end he met!"
+    # — trios (3) —
+    - - "A play in three parts, good people — settle in!"
+      - "I am the king, and I have lost my crown!"
+      - "And we the thieves who took it — catch us if you can!"
+    - - "Step up for the song of the three winds!"
+      - "I am the north wind, cold and cruel!"
+      - "And I the south — I'll thaw his frozen heart yet!"

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -172,6 +172,12 @@ dialogue:
     - "A good stew needs a slow flame."
     - "Smells done, doesn't it?"
     - "Bread's in. Come back at dusk."
+  # A child at the hearth (an `any_age` cooking slot — house/rooftop only).
+  cooking_child:
+    - "Is it ready yet? I'm starving!"
+    - "Can I stir it? Pleeease?"
+    - "It smells so good. Just one taste?"
+    - "Ow — the fire's too hot to sit near."
   crafting:
     - "Steady hands, that's the trick."
     - "One more and it's finished."
@@ -183,6 +189,12 @@ dialogue:
     - "So much here I'll never read it all."
     - "A quiet corner and a good book. Bliss."
     - "Now where did I leave off..."
+  # A child with a book at an `any_age` reading slot (shelf, lectern, desk).
+  reading_child:
+    - "Look at the pictures in this one!"
+    - "What's this big word mean?"
+    - "I read a whole page all by myself!"
+    - "Is this the one with the sea monster?"
   sorting:
     - "Swear I had more of these yesterday."
     - "Everything in its place, that's my way."
@@ -197,6 +209,13 @@ dialogue:
     - "Just turning in. Quiet night, I hope."
     - "These old bones need their rest."
     - "Wake me at first light, would you?"
+  # Spoken by a child filling a `resting` slot (an `any_age` bed). When a
+  # `<key>_child` pool exists, children draw from it instead of the adult lines.
+  resting_child:
+    - "I'm not even sleepy yet!"
+    - "Can I stay up just a little longer?"
+    - "Five more minutes, pleeease?"
+    - "Tell me the one about the dragon again!"
   # Market vendors hawking their wares from behind the stall counter. Rendered as
   # a "yelled" bubble — bigger and visible from across the square.
   market_cry:
@@ -224,6 +243,48 @@ dialogue:
     - "Busy on the square today, isn't it?"
     - "Wonder if they've any of those left..."
     - "My coin's near spent already."
+  # A child loose in the market crowd (a `ChildOnly` onlooker slot).
+  browsing_child:
+    - "Can we get the honey cakes? Pleeease?"
+    - "Look at all the shiny things!"
+    - "I want to see the puppets!"
+    - "Mama said stay close, but look over there!"
+    - "Are those sweets? Can I have one?"
+  # Folk loitering at the village well — fetching water, trading gossip.
+  at_the_well:
+    - "Cold and clear today — good water this year."
+    - "Heard the miller's daughter is to be wed."
+    - "Mind the bucket, the rope's frayed near the top."
+    - "Always someone to talk to at the well."
+    - "Three trips already and the trough's still low."
+  at_the_well_child:
+    - "Can I drop the bucket down? I'll be careful!"
+    - "Hellooo! Hear it echo?"
+    - "How deep does it go all the way down?"
+    - "I carried the little pail all by myself!"
+  # Folk idling around the fountain — resting, chatting, enjoying the spray.
+  by_the_fountain:
+    - "Nothing finer than the sound of water on a hot day."
+    - "I come here to sit and think a while."
+    - "They say a coin in the basin brings luck."
+    - "Cooler by the water, isn't it?"
+    - "A fine spot to meet a friend."
+  by_the_fountain_child:
+    - "Watch me splash! Look, look!"
+    - "I threw a coin in — now I get a wish!"
+    - "The water's so cold! Feel it!"
+    - "Can we stay just a bit longer?"
+  # Folk pausing at the monument — paying respects, gazing up at the pillar.
+  at_the_monument:
+    - "They built it before my grandfather's time, they say."
+    - "We owe the old names more than a glance."
+    - "Stand a moment. It's only right."
+    - "Quiet here. I like to stop and remember."
+  at_the_monument_child:
+    - "Who's it for? Were they very brave?"
+    - "It's so tall! Did giants make it?"
+    - "Why do we have to be quiet here?"
+    - "I can see the whole square from the steps!"
   # Guards posted at a gate or on a wall tower, watching the approaches.
   guarding:
     - "State your business at the gate."
@@ -277,53 +338,18 @@ exchanges:
       - "I am the north wind, cold and cruel!"
       - "And I the south — I'll thaw his frozen heart yet!"
 
-# Trade outfit for gate and tower guard fixtures.
-guard_profession: Armorer
+# Gate and tower guard fixture. `employment` is the job label baked onto each
+# guard and shown in the jobs summary; `looks` is the skin pool, rolled per guard
+# (mix villager and mob skins; repeat an entry to weight it, e.g.
+# [Armorer, Armorer, pillager] ≈ 2:1 villagers to pillagers). Each look is either
+# a villager Profession (PascalCase, e.g. Armorer) or a Mob (snake_case, e.g.
+# pillager, vindicator) spawned through the mob path. `looks` must be non-empty.
+guards:
+  employment: guard
+  looks: [Armorer, pillager]
 
-# Workplace (building NBT id) → trade outfit + crew size for worker fixtures
-# placed at the building's footprint edge. `professions` is rolled across, so
-# two of the same kind of shop don't always match. Unknown kinds fall back to
-# `default` (which must exist); every other key must match a loaded building
-# NBT id, validated at startup by `NpcData::validate`.
-workplaces:
-  default:          { professions: [Farmer], workers: 3 }
-
-  # — metal & stone —
-  smithy:           { professions: [Weaponsmith, Toolsmith, Armorer], workers: 3 }
-  smelter:          { professions: [Weaponsmith, Toolsmith, Armorer], workers: 3 }
-  iron_mine:        { professions: [Mason], workers: 2 }
-  coal_mine:        { professions: [Mason], workers: 2 }
-  charcoal_burner:  { professions: [Mason], workers: 2 }
-
-  # — wood —
-  carpenter:        { professions: [Fletcher, Mason], workers: 3 }
-  woodcutter_hut:   { professions: [Fletcher, Mason], workers: 2 }
-  sawmill:          { professions: [Farmer], workers: 3 }
-
-  # — grain, food, drink —
-  mill:             { professions: [Farmer], workers: 3 }
-  bakery:           { professions: [Butcher], workers: 3 }
-  butcher:          { professions: [Butcher], workers: 3 }
-  confectionery:    { professions: [Butcher], workers: 3 }
-  brewery:          { professions: [Farmer], workers: 3 }
-  apiary:           { professions: [Farmer], workers: 2 }
-  chandlery:        { professions: [Farmer], workers: 3 }
-
-  # — textile & hide —
-  weaver:           { professions: [Shepherd], workers: 3 }
-  tailor:           { professions: [Shepherd], workers: 3 }
-  tannery:          { professions: [Leatherworker], workers: 3 }
-
-  # — sugar & paper —
-  sugar_mill:       { professions: [Farmer], workers: 3 }
-  sugar_plantation: { professions: [Farmer], workers: 4 }
-  paper_mill_sugar: { professions: [Farmer], workers: 3 }
-  paper_mill_wood:  { professions: [Farmer], workers: 3 }
-
-  # — rural gather —
-  farm:             { professions: [Farmer], workers: 4 }
-  ranch:            { professions: [Shepherd], workers: 4 }
-  shepherds_hut:    { professions: [Shepherd], workers: 2 }
-
-  # — knowledge —
-  scriptorium:      { professions: [Librarian], workers: 3 }
+# Fallback worker staffing for buildings whose structure JSON declares no
+# `staffing` block of its own. Per-building staffing now lives on each building's
+# sidecar (e.g. data/structures/resource_buildings/woodcutter_hut.json); this
+# only covers the unstated ones. Same shape as a structure's `staffing`.
+default_staffing: { employment: laborer, looks: [Farmer], workers: 3 }

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -1,0 +1,134 @@
+# Placeholder NPC name + dialogue pools for the population pass.
+# (Per-culture / per-profession pools and richer lines can come later.)
+
+first_names:
+  - Hilda
+  - Bram
+  - Eda
+  - Joss
+  - Mira
+  - Tobin
+  - Greta
+  - Ansel
+  - Lena
+  - Cort
+  - Sable
+  - Wren
+  - Doral
+  - Petra
+  - Fenn
+  - Maja
+  - Roan
+  - Isolde
+  - Garr
+  - Nessa
+  - Odo
+  - Vesna
+  - Kael
+  - Bryn
+
+epithets:
+  - the Elder
+  - the Younger
+  - of the Hill
+  - Stonefoot
+  - Quickhand
+  - the Quiet
+  - Fairwind
+  - the Bold
+
+small_talk:
+  - "Fine weather for it, eh?"
+  - "Mind how you go."
+  - "Haven't seen you round here before."
+  - "Long day ahead."
+  - "The well's been low all season."
+  - "Heard there's trouble on the east road."
+  - "Spare a moment, traveller?"
+  - "Market's busy today."
+  - "Watch yourself after dark."
+  - "Good to see a new face."
+
+# Context dialogue pools, keyed by activity. A furniture anchor names one of
+# these keys (in its `anchors:` block); the same key can be shared by several
+# items — `cooking` covers the furnace, smoker, and cauldron, etc. A slot with
+# no key (or a key missing here) falls back to `small_talk` above.
+dialogue:
+  cooking:
+    - "Mind the fire — these coals run hot."
+    - "Almost ready. Won't be long now."
+    - "A good stew needs a slow flame."
+    - "Smells done, doesn't it?"
+    - "Bread's in. Come back at dusk."
+  crafting:
+    - "Steady hands, that's the trick."
+    - "One more and it's finished."
+    - "Measure twice, they always say."
+    - "This'll fetch a fair price."
+    - "Honest work, this."
+  reading:
+    - "Shh — I've nearly found the passage."
+    - "So much here I'll never read it all."
+    - "A quiet corner and a good book. Bliss."
+    - "Now where did I leave off..."
+  sorting:
+    - "Swear I had more of these yesterday."
+    - "Everything in its place, that's my way."
+    - "Plenty stocked for the winter."
+    - "Now where did that get to?"
+  conversation:
+    - "You won't believe what I heard at the market."
+    - "It's been too long, friend."
+    - "Between you and me..."
+  resting:
+    - "Long day. I've earned a sit-down."
+    - "Just turning in. Quiet night, I hope."
+    - "These old bones need their rest."
+    - "Wake me at first light, would you?"
+  # Market vendors hawking their wares from behind the stall counter. Rendered as
+  # a "yelled" bubble — bigger and visible from across the square.
+  market_cry:
+    - "Fresh today! Get it while it lasts!"
+    - "Finest wares in the whole town — come see!"
+    - "Two for the price of one, today only!"
+    - "Step up, step up! Best prices on the square!"
+    - "You'll not find better, I promise you that!"
+    - "Hot from the oven — come and get it!"
+    - "Half price before noon! Don't miss out!"
+    - "Come buy, come buy! Won't be here long!"
+  # A performer up on the stage, calling out over the crowd. Also yelled.
+  performing:
+    - "Gather round, good folk, gather round!"
+    - "A tale to chill your blood — come closer!"
+    - "Lend me your ears and I'll lend you a song!"
+    - "One night only — you'll tell your grandchildren!"
+    - "Strike up the tune! Let's have a dance!"
+    - "Hear ye! Hear ye! A story worth the telling!"
+  # Idle onlookers browsing the stalls or watching the show.
+  browsing:
+    - "Now that's a fair price, I'll give them that."
+    - "Did you hear the crier? Quite the show."
+    - "I only came for bread and look at me now."
+    - "Busy on the square today, isn't it?"
+    - "Wonder if they've any of those left..."
+    - "My coin's near spent already."
+
+# Multi-person exchanges: each entry is one back-and-forth, its lines handed to
+# a scene's slots in order (line 0 = the opener, line 1 = the reply). Keyed like
+# `dialogue` — a `conversation` anchor (two diners at a table) draws one of
+# these so the pair actually talks to each other. Keep line 0 standalone, in
+# case the scene is ever reduced to a single person.
+exchanges:
+  conversation:
+    - - "You won't believe what I heard at the market."
+      - "Go on then — don't keep me waiting!"
+    - - "Did you finish the harvest before the rain?"
+      - "Just barely. Last cart came in soaked."
+    - - "They say the smith's taking on an apprentice."
+      - "Is that so? My nephew could use the work."
+    - - "Have you tried the new baker on the square?"
+      - "Twice this week. Don't tell my wife."
+    - - "Quiet day, for once."
+      - "Don't say that too loud — you'll jinx it."
+    - - "I heard wolves on the ridge last night."
+      - "Best keep the gate barred, then."

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -348,6 +348,18 @@ guards:
   employment: guard
   looks: [Armorer, pillager]
 
+# Plaza fixtures: the vendor hawking wares behind a market stall, and a troupe
+# member up on a stage. Same shape as `guards` — an `employment` job label plus a
+# `looks` skin pool rolled per fixture (villager Professions and/or Mobs; a
+# wandering_trader vendor or a witch performer reads nicely). `looks` non-empty.
+vendors:
+  employment: vendor
+  looks: [Farmer, Butcher, Fletcher, wandering_trader]
+
+performers:
+  employment: performer
+  looks: [Cartographer, Cleric, witch]
+
 # Fallback worker staffing for buildings whose structure JSON declares no
 # `staffing` block of its own. Per-building staffing now lives on each building's
 # sidecar (e.g. data/structures/resource_buildings/woodcutter_hut.json); this

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -1,32 +1,144 @@
 # Placeholder NPC name + dialogue pools for the population pass.
 # (Per-culture / per-profession pools and richer lines can come later.)
 
-first_names:
-  - Hilda
-  - Bram
-  - Eda
-  - Joss
-  - Mira
-  - Tobin
-  - Greta
-  - Ansel
-  - Lena
-  - Cort
-  - Sable
-  - Wren
-  - Doral
-  - Petra
-  - Fenn
-  - Maja
-  - Roan
-  - Isolde
+# First names are generated on demand by concatenating a `first_name_prefix`
+# (consonant-ending stem) with a `first_name_suffix` (ending). All prefixes
+# are consonant-terminal so suffixes starting with a vowel don't produce
+# awkward double-vowels ("Edra"/"Mira" land naturally; we don't get "Edraa").
+# ~22 × ~12 ≈ 260 effective first names — collisions across a town of ~120
+# residents should be uncommon. See `roll_first_name` in
+# `src/generator/population.rs`.
+first_name_prefixes:
+  - Ael
+  - Bran
+  - Cael
+  - Cor
+  - Dor
+  - Edr
+  - Eldr
+  - Faer
   - Garr
-  - Nessa
-  - Odo
-  - Vesna
+  - Hild
+  - Iol
   - Kael
-  - Bryn
+  - Lor
+  - Mir
+  - Nael
+  - Orin
+  - Per
+  - Rael
+  - Sel
+  - Theod
+  - Vael
+  - Wen
+  - Yor
 
+first_name_suffixes:
+  - a
+  - ad
+  - an
+  - ar
+  - ed
+  - el
+  - en
+  - er
+  - ic
+  - in
+  - ric
+  - wyn
+
+# Surnames are generated on demand by concatenating a `surname_prefix` (capitalized,
+# noun-like root) with a `surname_suffix` (lowercase place-name ending). All
+# combinations are designed to read as plausible English family names —
+# Ashwood, Underhill, Hawkridge, Brightford, etc. With ~35 prefixes and ~25
+# suffixes the effective name space is ~875 surnames, so collisions across a
+# town of ~120 residents are rare. See `Npc.surname` and `roll_surname` in
+# `src/generator/population.rs`.
+surname_prefixes:
+  # — trees & growth —
+  - Ash
+  - Oak
+  - Elm
+  - Birch
+  - Yew
+  - Holly
+  - Thorn
+  - Willow
+  - Briar
+  - Hazel
+  # — ground, stone, element —
+  - Moss
+  - Fern
+  - Heath
+  - Marsh
+  - Fen
+  - Reed
+  - Stone
+  - Flint
+  - Marble
+  - Chalk
+  # — colour / quality —
+  - Bright
+  - White
+  - Black
+  - Grey
+  - Gold
+  - Silver
+  - Fair
+  - Dark
+  # — beast —
+  - Hawk
+  - Fox
+  - Wolf
+  - Raven
+  - Hart
+  - Dove
+  # — position —
+  - Under
+  - Over
+  - North
+  - High
+  - Long
+  - Old
+
+surname_suffixes:
+  # — land form —
+  - wood
+  - field
+  - hollow
+  - hill
+  - ridge
+  - dale
+  - vale
+  - glen
+  - shaw
+  - dell
+  - moor
+  - heath
+  - grove
+  - fell
+  # — water —
+  - brook
+  - ford
+  - burn
+  - bank
+  - mere
+  # — built —
+  - ton
+  - ham
+  - wick
+  - worth
+  - bury
+  - stead
+  - bridge
+  # — stone —
+  - stone
+  - crag
+
+# Epithets are flavour add-ons. When an NPC has an epithet, the display
+# replaces the surname with it ("Doral the Quiet") — but the surname is still
+# stored on the NPC for kin/family lookups. Most epithets are biased toward
+# elders (see `Npc::display_name` and household generation).
 epithets:
   - the Elder
   - the Younger
@@ -164,3 +276,54 @@ exchanges:
     - - "Step up for the song of the three winds!"
       - "I am the north wind, cold and cruel!"
       - "And I the south — I'll thaw his frozen heart yet!"
+
+# Trade outfit for gate and tower guard fixtures.
+guard_profession: Armorer
+
+# Workplace (building NBT id) → trade outfit + crew size for worker fixtures
+# placed at the building's footprint edge. `professions` is rolled across, so
+# two of the same kind of shop don't always match. Unknown kinds fall back to
+# `default` (which must exist); every other key must match a loaded building
+# NBT id, validated at startup by `NpcData::validate`.
+workplaces:
+  default:          { professions: [Farmer], workers: 3 }
+
+  # — metal & stone —
+  smithy:           { professions: [Weaponsmith, Toolsmith, Armorer], workers: 3 }
+  smelter:          { professions: [Weaponsmith, Toolsmith, Armorer], workers: 3 }
+  iron_mine:        { professions: [Mason], workers: 2 }
+  coal_mine:        { professions: [Mason], workers: 2 }
+  charcoal_burner:  { professions: [Mason], workers: 2 }
+
+  # — wood —
+  carpenter:        { professions: [Fletcher, Mason], workers: 3 }
+  woodcutter_hut:   { professions: [Fletcher, Mason], workers: 2 }
+  sawmill:          { professions: [Farmer], workers: 3 }
+
+  # — grain, food, drink —
+  mill:             { professions: [Farmer], workers: 3 }
+  bakery:           { professions: [Butcher], workers: 3 }
+  butcher:          { professions: [Butcher], workers: 3 }
+  confectionery:    { professions: [Butcher], workers: 3 }
+  brewery:          { professions: [Farmer], workers: 3 }
+  apiary:           { professions: [Farmer], workers: 2 }
+  chandlery:        { professions: [Farmer], workers: 3 }
+
+  # — textile & hide —
+  weaver:           { professions: [Shepherd], workers: 3 }
+  tailor:           { professions: [Shepherd], workers: 3 }
+  tannery:          { professions: [Leatherworker], workers: 3 }
+
+  # — sugar & paper —
+  sugar_mill:       { professions: [Farmer], workers: 3 }
+  sugar_plantation: { professions: [Farmer], workers: 4 }
+  paper_mill_sugar: { professions: [Farmer], workers: 3 }
+  paper_mill_wood:  { professions: [Farmer], workers: 3 }
+
+  # — rural gather —
+  farm:             { professions: [Farmer], workers: 4 }
+  ranch:            { professions: [Shepherd], workers: 4 }
+  shepherds_hut:    { professions: [Shepherd], workers: 2 }
+
+  # — knowledge —
+  scriptorium:      { professions: [Librarian], workers: 3 }

--- a/data/structures/resource_buildings/apiary.json
+++ b/data/structures/resource_buildings/apiary.json
@@ -11,5 +11,12 @@
     16,
     15
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "beekeeper",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/bakery.json
+++ b/data/structures/resource_buildings/bakery.json
@@ -11,5 +11,12 @@
     17
   ],
   "y_offset": 0,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "baker",
+    "looks": [
+      "Butcher"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/brewery.json
+++ b/data/structures/resource_buildings/brewery.json
@@ -11,5 +11,12 @@
     30,
     20
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "brewer",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/butcher.json
+++ b/data/structures/resource_buildings/butcher.json
@@ -11,5 +11,12 @@
     21,
     13
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "butcher",
+    "looks": [
+      "Butcher"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/carpenter.json
+++ b/data/structures/resource_buildings/carpenter.json
@@ -11,5 +11,13 @@
     14
   ],
   "y_offset": -1,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "carpenter",
+    "looks": [
+      "Fletcher",
+      "Mason"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/chandlery.json
+++ b/data/structures/resource_buildings/chandlery.json
@@ -11,5 +11,12 @@
     13,
     13
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "chandler",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/charcoal_burner.json
+++ b/data/structures/resource_buildings/charcoal_burner.json
@@ -11,5 +11,12 @@
     11
   ],
   "y_offset": -1,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "collier",
+    "looks": [
+      "Mason"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/coal_mine.json
+++ b/data/structures/resource_buildings/coal_mine.json
@@ -12,5 +12,12 @@
     9
   ],
   "allow_steep": true,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "miner",
+    "looks": [
+      "Mason"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/confectionery.json
+++ b/data/structures/resource_buildings/confectionery.json
@@ -11,5 +11,12 @@
     11,
     11
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "confectioner",
+    "looks": [
+      "Butcher"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/copper_mine.json
+++ b/data/structures/resource_buildings/copper_mine.json
@@ -12,5 +12,12 @@
     9
   ],
   "allow_steep": true,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "miner",
+    "looks": [
+      "Mason"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/copper_smelter.json
+++ b/data/structures/resource_buildings/copper_smelter.json
@@ -11,5 +11,14 @@
     13,
     13
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "smelter",
+    "looks": [
+      "Weaponsmith",
+      "Toolsmith",
+      "Armorer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/farm.json
+++ b/data/structures/resource_buildings/farm.json
@@ -11,5 +11,12 @@
     10
   ],
   "y_offset": -1,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "farmer",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 4
+  }
 }

--- a/data/structures/resource_buildings/iron_mine.json
+++ b/data/structures/resource_buildings/iron_mine.json
@@ -12,5 +12,12 @@
   ],
   "y_offset": -2,
   "allow_steep": true,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "miner",
+    "looks": [
+      "Mason"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/mill.json
+++ b/data/structures/resource_buildings/mill.json
@@ -11,5 +11,12 @@
     16
   ],
   "y_offset": 0,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "miller",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/paper_mill.json
+++ b/data/structures/resource_buildings/paper_mill.json
@@ -11,5 +11,12 @@
     15,
     23
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "papermaker",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/paper_mill_wood.json
+++ b/data/structures/resource_buildings/paper_mill_wood.json
@@ -11,5 +11,12 @@
     23,
     15
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "papermaker",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/ranch.json
+++ b/data/structures/resource_buildings/ranch.json
@@ -11,5 +11,12 @@
     21,
     11
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "rancher",
+    "looks": [
+      "Shepherd"
+    ],
+    "workers": 4
+  }
 }

--- a/data/structures/resource_buildings/sawmill.json
+++ b/data/structures/resource_buildings/sawmill.json
@@ -11,5 +11,12 @@
     17
   ],
   "y_offset": 0,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "sawyer",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/scriptorium.json
+++ b/data/structures/resource_buildings/scriptorium.json
@@ -11,5 +11,12 @@
     33,
     15
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "scribe",
+    "looks": [
+      "Librarian"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/shepherds_hut.json
+++ b/data/structures/resource_buildings/shepherds_hut.json
@@ -11,5 +11,12 @@
     17,
     9
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "shepherd",
+    "looks": [
+      "Shepherd"
+    ],
+    "workers": 2
+  }
 }

--- a/data/structures/resource_buildings/smelter.json
+++ b/data/structures/resource_buildings/smelter.json
@@ -11,5 +11,14 @@
     13
   ],
   "y_offset": 0,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "smelter",
+    "looks": [
+      "Weaponsmith",
+      "Toolsmith",
+      "Armorer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/smithy.json
+++ b/data/structures/resource_buildings/smithy.json
@@ -11,5 +11,14 @@
     18
   ],
   "y_offset": 0,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "smith",
+    "looks": [
+      "Weaponsmith",
+      "Toolsmith",
+      "Armorer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/sugar_mill.json
+++ b/data/structures/resource_buildings/sugar_mill.json
@@ -11,5 +11,12 @@
     15,
     23
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "miller",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/sugar_plantation.json
+++ b/data/structures/resource_buildings/sugar_plantation.json
@@ -11,5 +11,12 @@
     11,
     11
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "planter",
+    "looks": [
+      "Farmer"
+    ],
+    "workers": 4
+  }
 }

--- a/data/structures/resource_buildings/tailor.json
+++ b/data/structures/resource_buildings/tailor.json
@@ -11,5 +11,12 @@
     17,
     11
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "tailor",
+    "looks": [
+      "Shepherd"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/tannery.json
+++ b/data/structures/resource_buildings/tannery.json
@@ -11,5 +11,12 @@
     11,
     17
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "tanner",
+    "looks": [
+      "Leatherworker"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/weaver.json
+++ b/data/structures/resource_buildings/weaver.json
@@ -11,5 +11,12 @@
     11,
     15
   ],
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "weaver",
+    "looks": [
+      "Shepherd"
+    ],
+    "workers": 3
+  }
 }

--- a/data/structures/resource_buildings/woodcutter_hut.json
+++ b/data/structures/resource_buildings/woodcutter_hut.json
@@ -11,5 +11,13 @@
     9
   ],
   "y_offset": -1,
-  "palette": "resource_base"
+  "palette": "resource_base",
+  "staffing": {
+    "employment": "woodcutter",
+    "looks": [
+      "Fletcher",
+      "Mason"
+    ],
+    "workers": 2
+  }
 }

--- a/src/editor/editor.rs
+++ b/src/editor/editor.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use anyhow::Ok;
 use log::{error, info, warn};
 
-use crate::{data::Loadable, editor::World, generator::materials::{Material, MaterialId}, geometry::{Point3D, Rect3D}, http_mod::{CommandResponse, GDMCHTTPProvider, PositionedBlock, PositionedEntity}, minecraft::{Block, BlockForm, BlockID}, noise::RNG};
+use crate::{data::Loadable, editor::World, generator::materials::{Material, MaterialId}, geometry::{Point3D, Rect3D}, http_mod::{Coordinate, CommandResponse, GDMCHTTPProvider, PositionedBlock, PositionedEntity}, minecraft::{Block, BlockForm, BlockID}, noise::RNG};
 
 /// Editor provides the interface for modifying the Minecraft world.
 ///
@@ -307,6 +307,29 @@ impl Editor {
         let command = format!("place feature {} {} {} {}", feature, world.x, world.y, world.z);
         self.provider.command(vec![command]).await?;
         Ok(())
+    }
+
+    /// Spawn an entity of type `id` (e.g. `"minecraft:villager"`) at build-area-
+    /// local `point`, with optional SNBT `data` (entity tags such as `NoAI`,
+    /// `CustomName`, `Rotation`, …).
+    ///
+    /// `point` is in build-area-local coordinates (the origin is added to reach
+    /// world space, matching [`place_block`](Self::place_block)). Like
+    /// [`place_feature`](Self::place_feature) this goes straight to the server and
+    /// **bypasses the block buffer/cache**; it is a no-op in offline mode.
+    pub async fn spawn_entity(&self, id: &str, point: Point3D, data: Option<&str>) -> anyhow::Result<()> {
+        if self.offline {
+            return Ok(());
+        }
+        let world = point + self.build_area.origin;
+        let entity = PositionedEntity {
+            x: Coordinate::Absolute(world.x),
+            y: Coordinate::Absolute(world.y),
+            z: Coordinate::Absolute(world.z),
+            id: id.to_string(),
+            data: data.map(|s| s.to_string()),
+        };
+        self.provider.put_entities(0, 0, 0, &vec![entity]).await
     }
 }
 

--- a/src/editor/editor.rs
+++ b/src/editor/editor.rs
@@ -331,6 +331,30 @@ impl Editor {
         };
         self.provider.put_entities(0, 0, 0, &vec![entity]).await
     }
+
+    /// Like [`spawn_entity`] but raises the entity by a fractional `y_offset`
+    /// blocks (entity positions are doubles) — e.g. to stand an NPC on top of a
+    /// slab. The horizontal coordinates stay on the block grid.
+    pub async fn spawn_entity_offset(
+        &self,
+        id: &str,
+        point: Point3D,
+        y_offset: f32,
+        data: Option<&str>,
+    ) -> anyhow::Result<()> {
+        if self.offline {
+            return Ok(());
+        }
+        let world = point + self.build_area.origin;
+        let entity = PositionedEntity {
+            x: Coordinate::Absolute(world.x),
+            y: Coordinate::AbsoluteF(world.y as f64 + y_offset as f64),
+            z: Coordinate::Absolute(world.z),
+            id: id.to_string(),
+            data: data.map(|s| s.to_string()),
+        };
+        self.provider.put_entities(0, 0, 0, &vec![entity]).await
+    }
 }
 
 impl Drop for Editor {

--- a/src/editor/world.rs
+++ b/src/editor/world.rs
@@ -22,6 +22,10 @@ pub struct World {
     pub buildings : Vec<BuildingData>,
     pub structures : Vec<StructureID>,
     pub gate_locations : Vec<(Point3D, Cardinal)>,
+    /// Walkway guard posts grouped by wall tower: each inner Vec holds the
+    /// walkable feet positions (walkway cell at surface + 1) just outside one
+    /// tower's base, where a guard NPC can stand. Populated by `build_wall_towers`.
+    pub tower_guard_posts : Vec<Vec<Point3D>>,
     /// Regularized "inside the wall" cell set. When `Some`, `get_urban_points`
     /// returns it instead of the raw district union (see districts/footprint.rs).
     pub urban_footprint : Option<HashSet<Point2D>>,
@@ -101,6 +105,7 @@ impl World {
             buildings: Vec::new(),
             structures: Vec::new(),
             gate_locations: Vec::new(),
+            tower_guard_posts: Vec::new(),
             urban_footprint: None,
             ground_height_map,
             ocean_floor_height_map,
@@ -169,6 +174,7 @@ impl World {
             buildings: Vec::new(),
             structures: Vec::new(),
             gate_locations: Vec::new(),
+            tower_guard_posts: Vec::new(),
             urban_footprint: None,
             ground_height_map,
             ground_block_map,

--- a/src/generator/buildings_v2/cellar.rs
+++ b/src/generator/buildings_v2/cellar.rs
@@ -26,8 +26,9 @@ use super::footprint::{Footprint, SizeClass};
 use super::frame::{Frame, CELLAR_FLOOR};
 use super::pipeline::BuildCtx;
 use super::rooms::{compute_room_interior, CellState, ConstraintMap, RoomPlan};
-use super::furnish::furnish_interior;
+use super::furnish::{furnish_interior, harvest_anchors};
 use super::walls::{segment_cells, WallSegments};
+use crate::generator::population::AnchorScene;
 
 /// Roll cellar eligibility by size class. Larger, grander buildings are far
 /// more likely to have a cellar; a cottage only rarely gets a root cellar.
@@ -256,7 +257,7 @@ pub async fn maybe_build_cellar(
     floor_plan: &FloorPlan,
     room_plan: &RoomPlan,
     size_class: SizeClass,
-) -> Option<Vec<Point2D>> {
+) -> Option<(Vec<Point2D>, Vec<AnchorScene>)> {
     let mut rng = ctx.rng.derive();
     if !rolls_cellar(size_class, &mut rng) {
         return None;
@@ -299,8 +300,8 @@ pub async fn maybe_build_cellar(
     let (positions, dir) = stair;
     place_descending_stair(ctx, &positions, dir, floor_y, &main_stair_cells, &mut rng).await;
 
-    furnish_cellar(ctx, frame, interior, &positions).await;
-    Some(positions)
+    let anchors = furnish_cellar(ctx, frame, interior, &positions).await;
+    Some((positions, anchors))
 }
 
 /// Carve the cellar void and enclose it: stone floor slab under the whole core
@@ -430,7 +431,7 @@ async fn furnish_cellar(
     frame: &Frame,
     interior: Rect2D,
     positions: &[Point2D],
-) {
+) -> Vec<AnchorScene> {
     let mut constraints = ConstraintMap::new(&interior);
     for (i, pos) in positions.iter().enumerate() {
         let cell = (pos.x, pos.y);
@@ -455,7 +456,7 @@ async fn furnish_cellar(
         .or_else(|| ctx.data.furniture.rooms.get("storage"))
     {
         Some(list) => list,
-        None => return,
+        None => return Vec::new(),
     };
 
     // The cellar's deck sits at the CELLAR_FLOOR surface; its ceiling is the
@@ -470,7 +471,7 @@ async fn furnish_cellar(
     let palette = ctx.palette;
     let mut furn_rng = ctx.rng.derive();
 
-    furnish_interior(
+    let placed = furnish_interior(
         editor,
         &interior,
         &mut constraints,
@@ -486,6 +487,12 @@ async fn furnish_cellar(
         &mut furn_rng,
     )
     .await;
+
+    // Anchors for whoever works the cellar (a vintner at the racks, …).
+    let mut claimed: HashSet<(i32, i32, i32)> = HashSet::new();
+    let mut scenes: Vec<AnchorScene> = Vec::new();
+    harvest_anchors(&placed, &constraints, floor_y, &mut claimed, &mut scenes);
+    scenes
 }
 
 #[cfg(test)]

--- a/src/generator/buildings_v2/footprint/generate.rs
+++ b/src/generator/buildings_v2/footprint/generate.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use crate::geometry::{Point2D, Rect2D};
+use crate::geometry::{Cardinal, Point2D, Rect2D};
 use crate::noise::RNG;
 use super::{SizeClass, maximal_rect::find_largest_rect, Plot};
 
@@ -506,6 +506,174 @@ pub fn generate_cores(
     }
 
     cores
+}
+
+/// Generate a footprint whose **core is fixed** (the road-facing rect chosen
+/// by frontage placement) and which may sprout wings extending into the lot
+/// away from the road. Wings never attach to the road-facing side of the core
+/// — the front door stays unobstructed.
+///
+/// `road_outward` is the cardinal direction from the core to the road (same
+/// `frontage.outward` the placement loop already has). The candidate area
+/// passed to wing generation is grown from the core outward in the three
+/// non-road directions, expanding while the trial rect stays inside the
+/// plot's usable region — so wings can occupy unused lot cells behind/beside
+/// the building without leaking onto a road or another house's footprint.
+///
+/// Falls back to a single-rect footprint (just the core) if the size class
+/// allows no wings, the score-based wing search finds nothing better, or the
+/// candidate has no room to grow.
+pub fn generate_footprint_from_core(
+    rng: &mut RNG,
+    plot: &Plot,
+    core: Rect2D,
+    road_outward: Cardinal,
+    size_class: &SizeClass,
+    square_bias: i32,
+) -> super::Footprint {
+    if size_class.max_wings() == 0 {
+        return super::Footprint::from_rect(core);
+    }
+    let road_side = match road_outward {
+        Cardinal::North => Side::North,
+        Cardinal::South => Side::South,
+        Cardinal::West => Side::West,
+        Cardinal::East => Side::East,
+    };
+
+    let candidate = expand_candidate_around_core(&core, plot, road_side);
+
+    // Skip wing search if expansion got nothing — the lot's edge is flush
+    // with the core, so wings have nowhere to go.
+    if candidate.min() == core.min() && candidate.max() == core.max() {
+        return super::Footprint::from_rect(core);
+    }
+
+    // Target a generous area for this size class, capped by the candidate
+    // and floored at the core (wings on top of an already-decent core).
+    let target_area = rng
+        .rand_i32_range(size_class.target_area_min(), size_class.target_area_max() + 1)
+        .min(candidate.area())
+        .max(core.area());
+
+    // Generate several wing configurations; the existing score_layout +
+    // select_layout machinery picks the best by area-match / proportion /
+    // balance / complexity.
+    const WING_CONFIGS: i32 = 6;
+    let mut layouts = Vec::with_capacity(WING_CONFIGS as usize);
+    for _ in 0..WING_CONFIGS {
+        let wings = generate_wings_skipping_side(
+            rng, &core, &candidate, size_class, target_area, square_bias, road_side,
+        );
+        layouts.push(Layout { core, wings });
+    }
+
+    let mut select_rng = rng.derive();
+    let min_area = size_class.min_side() * size_class.min_side();
+    let Some(winner) =
+        select_layout(&mut select_rng, &layouts, target_area, &candidate, min_area)
+    else {
+        return super::Footprint::from_rect(core);
+    };
+    super::merge::merge_layout(&winner)
+}
+
+/// Greedily grow the core into the surrounding usable lot, one cell per
+/// direction per pass, skipping the road side. Caps growth per side at
+/// `MAX_EXTEND` so a giant lot doesn't produce an absurd candidate rect.
+fn expand_candidate_around_core(core: &Rect2D, plot: &Plot, road_side: Side) -> Rect2D {
+    const MAX_EXTEND: i32 = 16;
+    let mut min = core.min();
+    let mut max = core.max();
+    loop {
+        let mut changed = false;
+        // North: grow upward (-z). Skip if road is north.
+        if road_side != Side::North && (core.min().y - min.y) < MAX_EXTEND {
+            let new_min = Point2D::new(min.x, min.y - 1);
+            let trial = Rect2D::from_points(new_min, max);
+            if plot.is_rect_usable(&trial) {
+                min = new_min;
+                changed = true;
+            }
+        }
+        // South: grow downward (+z). Skip if road is south.
+        if road_side != Side::South && (max.y - core.max().y) < MAX_EXTEND {
+            let new_max = Point2D::new(max.x, max.y + 1);
+            let trial = Rect2D::from_points(min, new_max);
+            if plot.is_rect_usable(&trial) {
+                max = new_max;
+                changed = true;
+            }
+        }
+        // West: grow leftward (-x). Skip if road is west.
+        if road_side != Side::West && (core.min().x - min.x) < MAX_EXTEND {
+            let new_min = Point2D::new(min.x - 1, min.y);
+            let trial = Rect2D::from_points(new_min, max);
+            if plot.is_rect_usable(&trial) {
+                min = new_min;
+                changed = true;
+            }
+        }
+        // East: grow rightward (+x). Skip if road is east.
+        if road_side != Side::East && (max.x - core.max().x) < MAX_EXTEND {
+            let new_max = Point2D::new(max.x + 1, max.y);
+            let trial = Rect2D::from_points(min, new_max);
+            if plot.is_rect_usable(&trial) {
+                max = new_max;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    Rect2D::from_points(min, max)
+}
+
+/// Same shape as [`generate_wings`] but skips a single forbidden side — used
+/// to keep wings off the road-facing edge of the core.
+fn generate_wings_skipping_side(
+    rng: &mut RNG,
+    core: &Rect2D,
+    candidate: &Rect2D,
+    size_class: &SizeClass,
+    target_area: i32,
+    square_bias: i32,
+    forbidden_side: Side,
+) -> Vec<Rect2D> {
+    if size_class.max_wings() == 0 {
+        return vec![];
+    }
+    let allowed_sides: Vec<Side> = ALL_SIDES.iter().copied().filter(|&s| s != forbidden_side).collect();
+    if allowed_sides.is_empty() {
+        return vec![];
+    }
+    let mut wings = Vec::new();
+    let mut occupied: HashMap<Side, Vec<Span>> = HashMap::new();
+    let mut current_area = core.area();
+    let num_wings =
+        rng.rand_i32_range(size_class.min_wings().max(1), size_class.max_wings() + 1);
+
+    for attempt in 0..num_wings {
+        let remaining = target_area - current_area;
+        if remaining < MIN_WING_SIDE * MIN_WING_SIDE
+            && wings.len() as i32 >= size_class.min_wings()
+        {
+            break;
+        }
+        let &side = rng.choose(&allowed_sides);
+        let spans = occupied.get(&side).map(|v| v.as_slice()).unwrap_or(&[]);
+        let wings_left = num_wings - attempt;
+        if let Some((wing, span)) = attach_wing(
+            rng, core, side, candidate, remaining, MIN_WING_SIDE, core.area(),
+            wings_left, spans, square_bias,
+        ) {
+            current_area += wing.area();
+            occupied.entry(side).or_default().push(span);
+            wings.push(wing);
+        }
+    }
+    wings
 }
 
 #[cfg(test)]

--- a/src/generator/buildings_v2/furnish/data.rs
+++ b/src/generator/buildings_v2/furnish/data.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde_derive::Deserialize;
 
 use crate::data::{load_yaml, load_yaml_dir};
-use crate::generator::population::{SceneKind, SlotRole};
+use crate::generator::population::{Occupant, SceneKind, SlotRole};
 use super::{BlockLayer, CellConstraint, FacingMode};
 
 // ---------------------------------------------------------------------------
@@ -159,6 +159,11 @@ pub struct AnchorSlotSpec {
     /// informational until the workplace pass.
     #[serde(default = "default_role")]
     pub role: SlotRole,
+    /// Which age of NPC may stand here (`adult_only` default, `any_age`,
+    /// `child_only`). Lets a furniture/scene author open a domestic slot to
+    /// children or reserve a play scene for them.
+    #[serde(default)]
+    pub occupant: Occupant,
     /// If false, this slot drops out individually when its cell isn't usable;
     /// if true (default), an unusable cell drops the whole scene.
     #[serde(default = "default_true")]

--- a/src/generator/buildings_v2/furnish/data.rs
+++ b/src/generator/buildings_v2/furnish/data.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_derive::Deserialize;
 
 use crate::data::{load_yaml, load_yaml_dir};
+use crate::generator::population::{SceneKind, SlotRole};
 use super::{BlockLayer, CellConstraint, FacingMode};
 
 // ---------------------------------------------------------------------------
@@ -110,6 +111,12 @@ pub struct Furniture {
     pub blocks: Vec<FurnitureBlock>,
     #[serde(default)]
     pub constraints: Vec<FurnitureConstraint>,
+    /// NPC standing-spot scenes this item offers (a worker in front of a
+    /// furnace, two diners across a table, …). Offsets are in the same
+    /// `[along, away]` local frame as `constraints`, resolved against the
+    /// item's placed orientation. Empty for furniture nobody stands at.
+    #[serde(default)]
+    pub anchors: Vec<AnchorSpec>,
 }
 
 impl Default for Furniture {
@@ -122,8 +129,44 @@ impl Default for Furniture {
             weight: 1.0,
             blocks: Vec::new(),
             constraints: Vec::new(),
+            anchors: Vec::new(),
         }
     }
+}
+
+/// One NPC scene a furniture item offers. v1 emits these as solo or two-person
+/// scenes; the `kind` carries through to the population pass's scene weighting.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnchorSpec {
+    /// Scene type. Defaults to `solo`.
+    #[serde(default = "default_scene_kind")]
+    pub kind: SceneKind,
+    /// Default dialogue key for this scene's slots (e.g. `crafting`,
+    /// `conversation`), indexing a pool in `npcs.yaml`. A slot's own `dialogue`
+    /// overrides it. Keys are generic activities reusable across many items.
+    #[serde(default)]
+    pub dialogue: Option<String>,
+    pub slots: Vec<AnchorSlotSpec>,
+}
+
+/// One person's spot in an [`AnchorSpec`]. The NPC stands on `offset` (local
+/// `[along, away]`, resolved by the item's placed orientation) and faces the
+/// item's origin `[0, 0]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnchorSlotSpec {
+    pub offset: [i32; 2],
+    /// Role label (default `resident`). v1 doesn't bind professions, so this is
+    /// informational until the workplace pass.
+    #[serde(default = "default_role")]
+    pub role: SlotRole,
+    /// If false, this slot drops out individually when its cell isn't usable;
+    /// if true (default), an unusable cell drops the whole scene.
+    #[serde(default = "default_true")]
+    pub required: bool,
+    /// Per-slot dialogue key, overriding the scene's `dialogue`. `None` inherits
+    /// the scene key.
+    #[serde(default)]
+    pub dialogue: Option<String>,
 }
 
 /// A block within a furniture piece.
@@ -258,3 +301,6 @@ pub struct FixedSlot {
 fn default_weight() -> f32 { 1.0 }
 fn default_chance() -> f32 { 1.0 }
 fn default_place() -> bool { true }
+fn default_true() -> bool { true }
+fn default_scene_kind() -> SceneKind { SceneKind::Solo }
+fn default_role() -> SlotRole { SlotRole::Resident }

--- a/src/generator/buildings_v2/furnish/mod.rs
+++ b/src/generator/buildings_v2/furnish/mod.rs
@@ -21,5 +21,5 @@ mod types;
 
 pub use roof::decorate_rooftops;
 pub use room::furnish_rooms;
-pub(crate) use room::furnish_interior;
+pub(crate) use room::{furnish_interior, harvest_anchors};
 pub use types::{BlockLayer, CellConstraint, FacingMode};

--- a/src/generator/buildings_v2/furnish/placement.rs
+++ b/src/generator/buildings_v2/furnish/placement.rs
@@ -7,11 +7,13 @@ use std::collections::{HashSet, VecDeque};
 use crate::geometry::{Cardinal, Point2D, Point3D, Rect2D};
 use crate::minecraft::Block;
 
+use crate::generator::population::yaw_toward;
+
 use super::block::{apply_facing, parse_block, resolve_facing, resolve_offset, resolve_offset_2d, rotate_block};
 use super::data::{Furniture, PaletteSwap};
 use super::types::{BlockLayer, CellConstraint, FacingMode};
 use super::super::roof::heightmap::RoofHeightmap;
-use super::super::rooms::{CellState, ConstraintMap, Room};
+use super::super::rooms::{AnchorCandidate, AnchorSlotCandidate, CellState, ConstraintMap, Room};
 
 /// Whether a furniture item is a ceiling-only item (lanterns, etc.).
 pub(super) fn is_ceiling_item(item: &Furniture) -> bool {
@@ -241,6 +243,31 @@ pub(super) struct PlacementResult {
     pub(super) new_reserved: Vec<(i32, i32)>,
     /// EmptyReachable constraint cells: kept walkable, unplaceable.
     pub(super) new_empty_reachable: Vec<(i32, i32)>,
+    /// NPC anchor candidates this placement contributes (world cells + facing).
+    pub(super) anchors: Vec<AnchorCandidate>,
+}
+
+/// Resolve an item's declared `anchors` against its placed orientation: each
+/// slot's local `[along, away]` offset becomes a world cell, and the NPC faces
+/// the item's origin (`anchor`, where local `[0, 0]` lands). Validation against
+/// the final room layout happens later in `furnish_rooms`.
+fn resolve_anchors(item: &Furniture, anchor: Point2D, dir: Cardinal) -> Vec<AnchorCandidate> {
+    item.anchors.iter().map(|spec| {
+        let slots = spec.slots.iter().map(|s| {
+            let (dx, dz) = resolve_offset_2d(s.offset, dir);
+            let cell = (anchor.x + dx, anchor.y + dz);
+            // Face the item itself (its origin cell). yaw_toward only reads x/z,
+            // so the y here is irrelevant.
+            let facing = yaw_toward(
+                Point3D::new(cell.0, 0, cell.1),
+                Point3D::new(anchor.x, 0, anchor.y),
+            );
+            // Per-slot dialogue key wins; otherwise inherit the scene's key.
+            let dialogue = s.dialogue.clone().or_else(|| spec.dialogue.clone());
+            AnchorSlotCandidate { cell, facing, role: s.role, required: s.required, dialogue }
+        }).collect();
+        AnchorCandidate { kind: spec.kind, slots }
+    }).collect()
 }
 
 /// Try to place a furniture item anchored at a wall slot.
@@ -327,7 +354,8 @@ pub(super) fn try_place_at_wall_slot(
         });
     }
 
-    let placement = PlacementResult { blocks, new_blocked, new_reserved, new_empty_reachable };
+    let anchors = resolve_anchors(item, slot.cell, slot.wall_dir);
+    let placement = PlacementResult { blocks, new_blocked, new_reserved, new_empty_reachable, anchors };
     if let Some(rc) = roof_clearance {
         if !placement_fits_under_roof(&placement, rc) { return Option::None; }
     }
@@ -420,7 +448,8 @@ pub(super) fn try_place_freestanding(
             }
             if !ok { continue; }
 
-            let placement = PlacementResult { blocks, new_blocked, new_reserved, new_empty_reachable };
+            let anchors = resolve_anchors(item, Point2D::new(ax, az), dir);
+            let placement = PlacementResult { blocks, new_blocked, new_reserved, new_empty_reachable, anchors };
             if let Some(rc) = roof_clearance {
                 if !placement_fits_under_roof(&placement, rc) { continue; }
             }
@@ -456,5 +485,6 @@ pub(super) fn try_place_ceiling(
         });
     }
 
-    Some(PlacementResult { blocks, new_blocked: vec![], new_reserved: vec![], new_empty_reachable: vec![] })
+    // Ceiling items (lanterns, chandeliers) have nobody standing at them.
+    Some(PlacementResult { blocks, new_blocked: vec![], new_reserved: vec![], new_empty_reachable: vec![], anchors: vec![] })
 }

--- a/src/generator/buildings_v2/furnish/placement.rs
+++ b/src/generator/buildings_v2/furnish/placement.rs
@@ -264,7 +264,14 @@ fn resolve_anchors(item: &Furniture, anchor: Point2D, dir: Cardinal) -> Vec<Anch
             );
             // Per-slot dialogue key wins; otherwise inherit the scene's key.
             let dialogue = s.dialogue.clone().or_else(|| spec.dialogue.clone());
-            AnchorSlotCandidate { cell, facing, role: s.role, required: s.required, dialogue }
+            AnchorSlotCandidate {
+                cell,
+                facing,
+                role: s.role,
+                occupant: s.occupant,
+                required: s.required,
+                dialogue,
+            }
         }).collect();
         AnchorCandidate { kind: spec.kind, slots }
     }).collect()

--- a/src/generator/buildings_v2/furnish/roof.rs
+++ b/src/generator/buildings_v2/furnish/roof.rs
@@ -9,11 +9,14 @@
 //! Runs after interior furnishing and only for `RoofStyle::Flat`. Dome rects
 //! (square, ≥ `MIN_DOME_SIDE`) have no walkable deck and are skipped.
 
+use std::collections::HashSet;
+
 use crate::editor::Editor;
+use crate::generator::population::AnchorScene;
 use crate::geometry::{Point2D, Rect2D};
 use crate::minecraft::Color;
 
-use super::room::furnish_interior;
+use super::room::{furnish_interior, harvest_anchors};
 use super::super::frame::Frame;
 use super::super::pipeline::BuildCtx;
 use super::super::roof::dome::is_dome_eligible;
@@ -56,7 +59,7 @@ pub async fn decorate_rooftops(
     ctx: &mut BuildCtx<'_>,
     frame: &Frame,
     roof_ladder_wall: Option<(i32, i32)>,
-) {
+) -> Vec<AnchorScene> {
     let mut pick_rng = ctx.rng.derive();
 
     // Every flat roof gets dressed — the variety comes from the theme, the
@@ -67,7 +70,7 @@ pub async fn decorate_rooftops(
     let key = ROOF_ROOM_KEYS[pick_rng.rand_i32_range(0, ROOF_ROOM_KEYS.len() as i32) as usize];
     let room_list = match ctx.data.furniture.rooms.get(key) {
         Some(list) => list,
-        None => return,
+        None => return Vec::new(),
     };
 
     let editor: &Editor = &*ctx.editor;
@@ -81,6 +84,11 @@ pub async fn decorate_rooftops(
     let mut roof_palette = ctx.palette.clone();
     roof_palette.primary_color = Some(fabric);
     let palette = &roof_palette;
+
+    // Terrace anchors (someone tending the roof garden, sleeping under the
+    // stars, …) harvested across all decks of this building.
+    let mut claimed: HashSet<(i32, i32, i32)> = HashSet::new();
+    let mut scenes: Vec<AnchorScene> = Vec::new();
 
     let rects = top_floor_rects(frame);
     for (i, rect) in rects.iter().enumerate() {
@@ -122,7 +130,7 @@ pub async fn decorate_rooftops(
         }
 
         let mut roof_rng = ctx.rng.derive();
-        furnish_interior(
+        let placed = furnish_interior(
             editor,
             &interior,
             &mut constraints,
@@ -138,5 +146,8 @@ pub async fn decorate_rooftops(
             &mut roof_rng,
         )
         .await;
+        harvest_anchors(&placed, &constraints, floor_y, &mut claimed, &mut scenes);
     }
+
+    scenes
 }

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -6,7 +6,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::editor::Editor;
 use crate::generator::materials::{Material, MaterialId, Palette};
-use crate::geometry::Rect2D;
+use crate::generator::population::{AnchorScene, AnchorSlot};
+use crate::geometry::{Point3D, Rect2D};
 use crate::noise::RNG;
 
 use super::block::swap_block_for_palette;
@@ -19,7 +20,9 @@ use super::placement::{
 use super::super::frame::Frame;
 use super::super::pipeline::BuildCtx;
 use super::super::roof::heightmap::RoofHeightmap;
-use super::super::rooms::{CellState, ConstraintMap, PlacedFurniture, Room, RoomPlan, RoomRole};
+use super::super::rooms::{
+    AnchorCandidate, CellState, ConstraintMap, PlacedFurniture, Room, RoomPlan, RoomRole,
+};
 
 /// Default fraction of interior cells filled before stopping optional placement.
 /// Room types with `fill_threshold` set in rooms.yaml override this.
@@ -40,7 +43,7 @@ pub(super) async fn try_place_item(
     materials: &HashMap<MaterialId, Material>,
     loot_tables: &HashMap<String, LootTable>,
     rng: &mut RNG,
-) -> Option<Vec<(i32, i32)>> {
+) -> Option<(Vec<(i32, i32)>, Vec<AnchorCandidate>)> {
     let result = if is_ceiling_item(item) {
         try_place_ceiling(item, interior, constraints, ceiling_y)
     } else if needs_wall(item) {
@@ -88,7 +91,7 @@ pub(super) async fn try_place_item(
                 cells.push(cell);
             }
         }
-        Some(cells)
+        Some((cells, placement.anchors))
     } else {
         None
     }
@@ -216,7 +219,7 @@ pub(crate) async fn furnish_interior(
     for entry in &room_list.required {
         let candidates = resolve_candidates(entry, items, room_area, is_attic, &placed_tags, rng);
         for (name, item) in candidates {
-            if let Some(cells) = try_place_item(
+            if let Some((cells, anchors)) = try_place_item(
                 editor, item, interior, constraints,
                 &slots, &open_cells, floor_y, ceiling_y,
                 roof_clearance,
@@ -227,7 +230,7 @@ pub(crate) async fn furnish_interior(
                         placed_tags.insert(tag.to_string());
                     }
                 }
-                placed.push(PlacedFurniture { name: name.clone(), cells });
+                placed.push(PlacedFurniture { name: name.clone(), cells, anchors });
                 break;
             }
         }
@@ -248,7 +251,7 @@ pub(crate) async fn furnish_interior(
             if constraints.fill_ratio() >= fill_threshold { break; }
             let candidates = resolve_candidates(entry, items, room_area, is_attic, &placed_tags, rng);
             for (name, item) in candidates {
-                if let Some(cells) = try_place_item(
+                if let Some((cells, anchors)) = try_place_item(
                     editor, item, interior, constraints,
                     &slots, &open_cells, floor_y, ceiling_y,
                     roof_clearance,
@@ -259,7 +262,7 @@ pub(crate) async fn furnish_interior(
                             placed_tags.insert(tag.to_string());
                         }
                     }
-                    placed.push(PlacedFurniture { name: name.clone(), cells });
+                    placed.push(PlacedFurniture { name: name.clone(), cells, anchors });
                     placed_this_pass = true;
                     break;
                 }
@@ -273,15 +276,22 @@ pub(crate) async fn furnish_interior(
     placed
 }
 
-/// Furnish all rooms in a building using loaded furniture data.
+/// Furnish all rooms in a building using loaded furniture data, then harvest the
+/// validated NPC anchor scenes the placed furniture contributes.
+///
 /// `roof_heightmaps` is indexed by rect — used only by attic rooms to clamp
 /// furniture against the sloped roof above the attic floor.
+///
+/// Anchor harvesting runs after every room is furnished, so each room's
+/// `ConstraintMap` is final: a candidate slot is kept only if its cell isn't
+/// `Blocked` (furniture/wall) and isn't already claimed by another anchor, so
+/// NPCs never spawn inside furniture, in walls, or on top of one another.
 pub async fn furnish_rooms(
     ctx: &mut BuildCtx<'_>,
     room_plan: &mut RoomPlan,
     frame: &Frame,
     roof_heightmaps: &[RoofHeightmap],
-) {
+) -> Vec<AnchorScene> {
     let editor: &Editor = &*ctx.editor;
     let palette = ctx.palette;
     let furniture_data = &ctx.data.furniture;
@@ -302,6 +312,84 @@ pub async fn furnish_rooms(
             palette, materials, &furniture_data.loot, &mut room_rng,
         ).await;
     }
+
+    // Validate furniture anchor candidates against the finished layout. One
+    // `claimed` set spans every floor of the building (keyed in 3D, so a column
+    // shared by stacked rooms doesn't false-collide).
+    let mut claimed: HashSet<(i32, i32, i32)> = HashSet::new();
+    let mut scenes: Vec<AnchorScene> = Vec::new();
+    for room in &room_plan.rooms {
+        let floor_y = frame.floor_y(room.floor);
+        harvest_anchors(&room.furniture, &room.constraints, floor_y, &mut claimed, &mut scenes);
+    }
+    scenes
+}
+
+/// Validate the anchor candidates from a furnished space (a room, rooftop deck,
+/// or cellar) against its final layout and append the surviving scenes to `out`.
+/// `constraints` is the space's finished map and `floor_y` the level its NPCs
+/// stand on; `claimed` is threaded so no two anchors share a cell.
+///
+/// Shared by [`furnish_rooms`] and the rooftop/cellar furnishers, which run the
+/// same `furnish_interior` engine and so produce the same `PlacedFurniture`.
+pub(crate) fn harvest_anchors(
+    furniture: &[PlacedFurniture],
+    constraints: &ConstraintMap,
+    floor_y: i32,
+    claimed: &mut HashSet<(i32, i32, i32)>,
+    out: &mut Vec<AnchorScene>,
+) {
+    for f in furniture {
+        for candidate in &f.anchors {
+            if let Some(scene) = validate_anchor(candidate, constraints, floor_y, claimed) {
+                out.push(scene);
+            }
+        }
+    }
+}
+
+/// Validate one furniture anchor candidate against the final layout. A slot is
+/// usable if its cell exists in the space (in-bounds) and is not `Blocked` (so
+/// `Empty`, `UnblockedReachable`, and reserved approach cells all qualify) and
+/// isn't already claimed by another accepted anchor. A required slot that can't
+/// be staffed drops the whole scene; an optional one just drops itself. Returns
+/// the resolved [`AnchorScene`] (claiming its cells) or `None`.
+fn validate_anchor(
+    candidate: &AnchorCandidate,
+    constraints: &ConstraintMap,
+    floor_y: i32,
+    claimed: &mut HashSet<(i32, i32, i32)>,
+) -> Option<AnchorScene> {
+    let mut slots: Vec<AnchorSlot> = Vec::new();
+    for slot in &candidate.slots {
+        let key = (slot.cell.0, floor_y, slot.cell.1);
+        let usable = matches!(constraints.get(slot.cell), Some(s) if s != CellState::Blocked)
+            && !claimed.contains(&key);
+        if usable {
+            slots.push(AnchorSlot {
+                pos: Point3D::new(slot.cell.0, floor_y, slot.cell.1),
+                facing: slot.facing,
+                role: slot.role,
+                required: slot.required,
+                profession: None,
+                dialogue: slot.dialogue.clone(),
+                // Furniture-driven anchors are always ordinary indoor speech;
+                // only plaza fixtures yell.
+                volume: crate::generator::npc::DialogueVolume::Normal,
+            });
+        } else if slot.required {
+            return None; // a required spot is taken/blocked → drop the scene
+        }
+    }
+    if slots.is_empty() {
+        return None;
+    }
+    // Claim the kept cells so no later anchor reuses them (a dropped optional
+    // slot leaves its cell free for someone else).
+    for slot in &slots {
+        claimed.insert((slot.pos.x, slot.pos.y, slot.pos.z));
+    }
+    Some(AnchorScene::group(candidate.kind, slots))
 }
 
 pub(super) fn shuffle<T>(items: &mut [T], rng: &mut RNG) {

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -376,8 +376,9 @@ fn validate_anchor(
                 pos: Point3D::new(slot.cell.0, floor_y, slot.cell.1),
                 facing: slot.facing,
                 role: slot.role,
+                occupant: slot.occupant,
                 required: slot.required,
-                profession: None,
+                look: None,
                 dialogue: slot.dialogue.clone(),
                 // Furniture-driven anchors are always ordinary indoor speech;
                 // only plaza fixtures yell.

--- a/src/generator/buildings_v2/furnish/room.rs
+++ b/src/generator/buildings_v2/furnish/room.rs
@@ -349,11 +349,12 @@ pub(crate) fn harvest_anchors(
 }
 
 /// Validate one furniture anchor candidate against the final layout. A slot is
-/// usable if its cell exists in the space (in-bounds) and is not `Blocked` (so
-/// `Empty`, `UnblockedReachable`, and reserved approach cells all qualify) and
-/// isn't already claimed by another accepted anchor. A required slot that can't
-/// be staffed drops the whole scene; an optional one just drops itself. Returns
-/// the resolved [`AnchorScene`] (claiming its cells) or `None`.
+/// usable if its cell exists in the space (in-bounds), is not `Blocked` (so
+/// `Empty`, `UnblockedReachable`, and reserved approach cells all qualify), is
+/// not a staircase cell, and isn't already claimed by another accepted anchor. A
+/// required slot that can't be staffed drops the whole scene; an optional one
+/// just drops itself. Returns the resolved [`AnchorScene`] (claiming its cells)
+/// or `None`.
 fn validate_anchor(
     candidate: &AnchorCandidate,
     constraints: &ConstraintMap,
@@ -363,7 +364,12 @@ fn validate_anchor(
     let mut slots: Vec<AnchorSlot> = Vec::new();
     for slot in &candidate.slots {
         let key = (slot.cell.0, floor_y, slot.cell.1);
+        // Never stand an NPC on a staircase (steps, landings, tops, or the
+        // stairwell air-column) — it reads as a glitch. Stair steps are already
+        // `Blocked`, but landings/tops are `UnblockedReachable` and would
+        // otherwise slip through, so reject any stair cell explicitly.
         let usable = matches!(constraints.get(slot.cell), Some(s) if s != CellState::Blocked)
+            && !constraints.is_stair(slot.cell)
             && !claimed.contains(&key);
         if usable {
             slots.push(AnchorSlot {
@@ -376,6 +382,7 @@ fn validate_anchor(
                 // Furniture-driven anchors are always ordinary indoor speech;
                 // only plaza fixtures yell.
                 volume: crate::generator::npc::DialogueVolume::Normal,
+                y_offset: 0.0,
             });
         } else if slot.required {
             return None; // a required spot is taken/blocked → drop the scene

--- a/src/generator/buildings_v2/furnish/test.rs
+++ b/src/generator/buildings_v2/furnish/test.rs
@@ -127,6 +127,23 @@ fn test_bookshelf() -> Furniture {
 // interior_rect
 // ---------------------------------------------------------------------------
 
+/// Guards the `occupant: any_age` wiring end to end: the furniture YAML parses
+/// (the loader silently skips items it can't deserialize, so a bad `occupant`
+/// value would drop the bed rather than error), and at least one anchor slot —
+/// the beds we opened to children — comes through as `AnyAge`.
+#[test]
+fn any_age_occupant_parses_from_furniture_yaml() {
+    use crate::generator::population::Occupant;
+    let data = FurnitureData::load().expect("load furniture YAML");
+    let any_age = data
+        .items
+        .values()
+        .flat_map(|it| &it.anchors)
+        .flat_map(|a| &a.slots)
+        .any(|s| s.occupant == Occupant::AnyAge);
+    assert!(any_age, "expected at least one any_age anchor slot (beds) from furniture YAML");
+}
+
 #[test]
 fn interior_rect_normal() {
     let rect = Rect2D::from_points(Point2D::new(0, 0), Point2D::new(6, 6));

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -38,7 +38,7 @@ use super::rooms::{
 use super::walls::{
     TimberPattern, WallInfill, WallSegments, build_segments, boundary_cell_set,
     place_doors, place_frame, place_openings, place_terrace_doors,
-    place_wall_infill, place_windows,
+    place_wall_infill, place_windows, segment_cells,
 };
 
 /// Shared context threaded through every placer stage. Reborrow the fields
@@ -219,6 +219,16 @@ pub async fn build_house(
         stair
     });
 
+    // Drop any anchor whose feet sit in a doorway — the interior cell directly
+    // behind a door (where someone stepping through stands) or the exterior cell
+    // directly in front. An NPC anchored there blocks ingress/egress.
+    let door_keepout = door_keepout_cells(&wall_segs);
+    npc_anchors.retain(|scene| {
+        !scene.slots.iter().any(|slot| {
+            door_keepout.contains(&(slot.pos.y, Point2D::new(slot.pos.x, slot.pos.z)))
+        })
+    });
+
     // Claim the structural footprint (the actual house cells, no buffer) so a
     // later building's foundation blend won't raise earth/grass into this house
     // — `blend_terrain` skips Building-claimed cells.
@@ -243,4 +253,25 @@ pub async fn build_house(
         timber_pattern,
         npc_anchors,
     })
+}
+
+/// `(floor_base_y, cell)` pairs that NPC anchors must avoid: the interior step
+/// and the exterior step of every door. `seg.facing` is the wall's INWARD normal
+/// (see `WallSegment::facing`), so the interior side is `door_cell + facing` and
+/// the exterior side is `door_cell - facing`. Floor-aware so an upper-room cell
+/// directly above a ground-floor door is still eligible.
+fn door_keepout_cells(wall_segs: &WallSegments) -> HashSet<(i32, Point2D)> {
+    let mut out = HashSet::new();
+    for (seg, opening) in wall_segs.doors() {
+        let seg_cells = segment_cells(seg);
+        let inward: Point2D = seg.facing.into();
+        for w in 0..opening.width as usize {
+            let idx = opening.offset as usize + w;
+            if let Some(&door_cell) = seg_cells.get(idx) {
+                out.insert((seg.base_y, door_cell + inward));
+                out.insert((seg.base_y, door_cell - inward));
+            }
+        }
+    }
+    out
 }

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use crate::editor::Editor;
 use crate::generator::data::LoadedData;
 use crate::generator::materials::Palette;
+use crate::generator::population::AnchorScene;
 use crate::geometry::{Point2D, Rect2D};
 use crate::noise::RNG;
 
@@ -81,6 +82,9 @@ pub struct HouseOutput {
     pub roof_style: RoofStyle,
     pub size_class: SizeClass,
     pub timber_pattern: TimberPattern,
+    /// Candidate per-room NPC standing positions (solo scenes), emitted after
+    /// furnishing. The settlement's population pass picks how many to staff.
+    pub npc_anchors: Vec<AnchorScene>,
 }
 
 /// Runs the full per-building pipeline. Caller owns footprint generation and
@@ -188,12 +192,15 @@ pub async fn build_house(
     place_room_floors(ctx, &frame, &room_plan, bctx).await;
 
 
-    furnish_rooms(ctx, &mut room_plan, &frame, &roof_heightmaps).await;
+    // Furnish, then harvest the NPC anchor scenes the placed furniture offers
+    // (validated against the final per-room CellState inside furnish_rooms).
+    // Rooftop terraces and the cellar add their own anchors below.
+    let mut npc_anchors = furnish_rooms(ctx, &mut room_plan, &frame, &roof_heightmaps).await;
 
     // Flat roofs are open terraces — decorate the deck (shade, seating, plants)
     // once the interior is furnished. Keeps the ladder exit clear.
     if matches!(roof_style, RoofStyle::Flat) {
-        decorate_rooftops(ctx, &frame, roof_ladder_wall).await;
+        npc_anchors.extend(decorate_rooftops(ctx, &frame, roof_ladder_wall).await);
     }
 
     // A few sparse props against the outside walls (barrels, pots, …) so the
@@ -205,8 +212,12 @@ pub async fn build_house(
     // Cellar runs last: it carves below the finished building using a derived
     // RNG, so it neither perturbs the main stream nor disturbs the room_plan
     // that blueprint/invariant code iterates.
-    let cellar_stair = cellar::maybe_build_cellar(ctx, &frame, &footprint, &wall_segs, &floor_plan, &room_plan, size_class).await;
-    let has_cellar = cellar_stair.is_some();
+    let cellar = cellar::maybe_build_cellar(ctx, &frame, &footprint, &wall_segs, &floor_plan, &room_plan, size_class).await;
+    let has_cellar = cellar.is_some();
+    let cellar_stair = cellar.map(|(stair, anchors)| {
+        npc_anchors.extend(anchors);
+        stair
+    });
 
     // Claim the structural footprint (the actual house cells, no buffer) so a
     // later building's foundation blend won't raise earth/grass into this house
@@ -230,5 +241,6 @@ pub async fn build_house(
         roof_style,
         size_class,
         timber_pattern,
+        npc_anchors,
     })
 }

--- a/src/generator/buildings_v2/rooms/build.rs
+++ b/src/generator/buildings_v2/rooms/build.rs
@@ -350,12 +350,15 @@ pub async fn build_rooms(
                 if stair_bottoms.contains(&key) || stair_tops.contains(&key) {
                     constraints.set(xz, CellState::UnblockedReachable);
                     constraints.set_ceiling(xz);
+                    constraints.mark_stair(xz);
                 } else if this_floor_stair_cells.contains(&xz) {
                     constraints.set(xz, CellState::Blocked);
                     constraints.set_ceiling(xz);
+                    constraints.mark_stair(xz);
                 } else if floor_plan.stair_air_above.contains(&key) {
                     constraints.set(xz, CellState::UnblockedReachable);
                     constraints.set_ceiling(xz);
+                    constraints.mark_stair(xz);
                 }
             }
 

--- a/src/generator/buildings_v2/rooms/constraints.rs
+++ b/src/generator/buildings_v2/rooms/constraints.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::generator::population::{SceneKind, SlotRole};
+use crate::generator::population::{Occupant, SceneKind, SlotRole};
 use crate::geometry::Rect2D;
 
 /// State of a cell in a room's interior.
@@ -158,6 +158,8 @@ pub struct AnchorSlotCandidate {
     /// Yaw (degrees) the NPC faces — baked toward the furniture at emit time.
     pub facing: f32,
     pub role: SlotRole,
+    /// Which age of NPC may stand here (carried from the furniture anchor spec).
+    pub occupant: Occupant,
     /// If false, an unusable cell drops just this slot; if true, it drops the
     /// whole scene (e.g. one half of a two-person table is optional).
     pub required: bool,

--- a/src/generator/buildings_v2/rooms/constraints.rs
+++ b/src/generator/buildings_v2/rooms/constraints.rs
@@ -1,3 +1,4 @@
+use crate::generator::population::{SceneKind, SlotRole};
 use crate::geometry::Rect2D;
 
 /// State of a cell in a room's interior.
@@ -112,4 +113,35 @@ pub struct PlacedFurniture {
     pub name: String,
     /// World (x, z) cells occupied by this item.
     pub cells: Vec<(i32, i32)>,
+    /// NPC standing-spot scenes this item contributes, resolved to world cells
+    /// + facing at placement time but not yet validated against the final room
+    /// layout (see [`AnchorCandidate`]).
+    pub anchors: Vec<AnchorCandidate>,
+}
+
+/// A candidate NPC scene contributed by one placed furniture item: where people
+/// would stand around it and which way they'd face. Resolved to world cells at
+/// placement time, then validated after the whole room is furnished — a slot is
+/// kept only if its cell ended up walkable (not `Blocked`) and isn't already
+/// claimed by another anchor, so NPCs never spawn in furniture, walls, or on
+/// top of each other.
+#[derive(Debug, Clone)]
+pub struct AnchorCandidate {
+    pub kind: SceneKind,
+    pub slots: Vec<AnchorSlotCandidate>,
+}
+
+/// One person's candidate spot within an [`AnchorCandidate`].
+#[derive(Debug, Clone)]
+pub struct AnchorSlotCandidate {
+    /// World (x, z) cell the NPC would stand on.
+    pub cell: (i32, i32),
+    /// Yaw (degrees) the NPC faces — baked toward the furniture at emit time.
+    pub facing: f32,
+    pub role: SlotRole,
+    /// If false, an unusable cell drops just this slot; if true, it drops the
+    /// whole scene (e.g. one half of a two-person table is optional).
+    pub required: bool,
+    /// Context dialogue key for whoever stands here (e.g. `tending_furnace`).
+    pub dialogue: Option<String>,
 }

--- a/src/generator/buildings_v2/rooms/constraints.rs
+++ b/src/generator/buildings_v2/rooms/constraints.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::generator::population::{SceneKind, SlotRole};
 use crate::geometry::Rect2D;
 
@@ -25,6 +27,12 @@ pub struct ConstraintMap {
     pub ground: Vec<Vec<CellState>>,
     /// ceiling[x][z] — true if a ceiling item is placed here.
     pub ceiling: Vec<Vec<bool>>,
+    /// World (x, z) cells that belong to a staircase (steps, landings, tops, and
+    /// the stairwell air-column above). NPC anchors are never placed on these —
+    /// standing on a stair reads as a glitch — so they're tracked separately from
+    /// [`CellState`] (a stair landing is `UnblockedReachable`, indistinguishable
+    /// from a door entrance otherwise). See [`Self::is_stair`].
+    pub stairs: HashSet<(i32, i32)>,
 }
 
 impl ConstraintMap {
@@ -36,6 +44,7 @@ impl ConstraintMap {
             origin: (interior.min().x, interior.min().y),
             ground: vec![vec![CellState::Empty; h]; w],
             ceiling: vec![vec![false; h]; w],
+            stairs: HashSet::new(),
         }
     }
 
@@ -60,6 +69,16 @@ impl ConstraintMap {
         if let Some((x, z)) = self.local(cell) {
             self.ground[x][z] = state;
         }
+    }
+
+    /// Mark a world cell as part of a staircase (see [`Self::stairs`]).
+    pub fn mark_stair(&mut self, cell: (i32, i32)) {
+        self.stairs.insert(cell);
+    }
+
+    /// Whether a world cell belongs to a staircase — NPC anchors are barred here.
+    pub fn is_stair(&self, cell: (i32, i32)) -> bool {
+        self.stairs.contains(&cell)
     }
 
     pub fn ceiling_occupied(&self, cell: (i32, i32)) -> bool {

--- a/src/generator/buildings_v2/rooms/mod.rs
+++ b/src/generator/buildings_v2/rooms/mod.rs
@@ -21,7 +21,9 @@ mod build;
 mod invariants;
 mod plan;
 
-pub use constraints::{CellState, ConstraintMap, PlacedFurniture};
+pub use constraints::{
+    AnchorCandidate, AnchorSlotCandidate, CellState, ConstraintMap, PlacedFurniture,
+};
 pub use annotate::{mark_gable_doorways, mark_windows};
 pub use assign::{assign_attic_types, assign_room_floors, assign_types_to_rooms};
 pub use attic::place_attic_ladders;

--- a/src/generator/buildings_v2/rooms/test.rs
+++ b/src/generator/buildings_v2/rooms/test.rs
@@ -1176,9 +1176,16 @@ async fn cellar_built_under_manor_offline() {
     let floor_y = house.frame.floor_y(CELLAR_FLOOR);
     let slab_y = floor_y - 1;
     let core = house.footprint.rects()[0];
-    let center = core.midpoint();
 
-    let at = |y: i32| editor.try_get_block(Point3D::new(center.x, y, center.y));
+    // Probe the stair landing, not the core centroid: the centroid can host
+    // cellar furniture (a barrel, a hay pile), which would sit at floor_y and
+    // fail the "floor surface is air" check even though the void was carved
+    // correctly. The landing (cellar_stair position 0) is reserved walkable and
+    // carries no stair block, so it's reliably the carved void — air at floor_y,
+    // stone slab below.
+    let probe = house.cellar_stair.as_ref().expect("cellar must have a stair")[0];
+
+    let at = |y: i32| editor.try_get_block(Point3D::new(probe.x, y, probe.y));
     let is_air = |b: &Block| b.id == "air".into() || b.id == "minecraft:air".into();
     let floor_block = at(floor_y);
     let slab_block = at(slab_y);
@@ -1192,7 +1199,7 @@ async fn cellar_built_under_manor_offline() {
         "cellar floor slab at y={} should be solid stone, got {:?}", slab_y, slab_block,
     );
 
-    println!("Manor cellar carved: floor_y={}, slab_y={}, core={:?}", floor_y, slab_y, core);
+    println!("Manor cellar carved: floor_y={}, slab_y={}, probe={:?}, core={:?}", floor_y, slab_y, probe, core);
 }
 
 /// Property test: run the offline pipeline across many seeds and assert that

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{data::{Loadable, load_yaml}, generator::{districts::{PaintPalette, PaintPaletteId, PaintPalettesFile}, resource_chain::ResourceRegistry, buildings::{roofs::{RoofComponent, RoofSet, RoofSetId}, walls::{WallComponent, WallSet, WallSetId}, BuildingSet, BuildingSetID}, buildings_v2::furnish::data::FurnitureData, materials::{Material, MaterialId, Palette, PaletteId}, nbts::{Structure, StructureType}}};
+use crate::{data::{Loadable, load_yaml}, generator::{districts::{PaintPalette, PaintPaletteId, PaintPalettesFile}, population::NpcData, resource_chain::ResourceRegistry, buildings::{roofs::{RoofComponent, RoofSet, RoofSetId}, walls::{WallComponent, WallSet, WallSetId}, BuildingSet, BuildingSetID}, buildings_v2::furnish::data::FurnitureData, materials::{Material, MaterialId, Palette, PaletteId}, nbts::{Structure, StructureType}}};
 
 #[derive(Debug)]
 pub struct LoadedData {
@@ -15,6 +15,7 @@ pub struct LoadedData {
     pub resource_registry : ResourceRegistry,
     pub furniture : FurnitureData,
     pub paint_palettes : HashMap<PaintPaletteId, PaintPalette>,
+    pub npc_data : NpcData,
 }
 
 impl LoadedData {
@@ -28,6 +29,9 @@ impl LoadedData {
             file.paint_palettes.into_iter().map(|(k, v)| (PaintPaletteId(k), v)).collect()
         };
 
+        let npc_data = NpcData::load()?;
+        npc_data.validate(&structures)?;
+
         Ok(Self {
             palettes: Palette::load()?,
             materials: Material::load()?,
@@ -40,6 +44,7 @@ impl LoadedData {
             resource_registry,
             furniture: FurnitureData::load()?,
             paint_palettes,
+            npc_data,
         })
     }
 }
@@ -67,5 +72,7 @@ mod tests {
         assert!(!data.furniture.rooms.is_empty(), "no room furniture lists loaded");
         assert!(!data.paint_palettes.is_empty(), "no paint palettes loaded");
         assert!(!data.resource_registry.production_painters.is_empty(), "no production painters loaded");
+        assert!(!data.npc_data.workplaces.is_empty(), "no npc workplaces loaded");
+        assert!(data.npc_data.workplaces.contains_key("default"), "npc workplaces missing default");
     }
 }

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -72,7 +72,10 @@ mod tests {
         assert!(!data.furniture.rooms.is_empty(), "no room furniture lists loaded");
         assert!(!data.paint_palettes.is_empty(), "no paint palettes loaded");
         assert!(!data.resource_registry.production_painters.is_empty(), "no production painters loaded");
-        assert!(!data.npc_data.workplaces.is_empty(), "no npc workplaces loaded");
-        assert!(data.npc_data.workplaces.contains_key("default"), "npc workplaces missing default");
+        assert!(!data.npc_data.guards.looks.is_empty(), "no guard looks loaded");
+        assert!(!data.npc_data.default_staffing.looks.is_empty(), "no default staffing looks loaded");
+        // Inline staffing: resource buildings declare their own crew on the JSON.
+        let staffed = data.structures.values().filter(|s| s.staffing.is_some()).count();
+        assert!(staffed > 0, "no structures declare staffing");
     }
 }

--- a/src/generator/districts/mod.rs
+++ b/src/generator/districts/mod.rs
@@ -23,7 +23,7 @@ pub use district::District;
 pub use district::DistrictID;
 pub use data::{ParcelData, HasParcelData};
 pub use parcel_painter::*;
-pub use wall::{build_wall, get_wall_points, WallType};
+pub use wall::{build_wall, get_wall_points, TowerSkin, WallType};
 pub use footprint::{regularize_urban_footprint, reconcile_districts_to_footprint};
 pub use gate::build_wall_gate;
 pub use paint_palette::{PaintPaletteId, PaintPalette, PaintPalettesFile};

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -89,6 +89,75 @@ mod tests {
         editor.flush_buffer().await;
     }
 
+    /// Show off the parcel partition: paint every parcel cell in a wool colour
+    /// keyed to its parcel id, then raise the parcel's edge cells one block as a
+    /// wool ridge so boundaries stand up clearly above the painted ground.
+    /// Covers all parcel types (urban, rural, off-limits) — not just urban.
+    /// Needs a live Minecraft server.
+    /// Run with: `cargo test parcel_wool_borders -- --nocapture`.
+    #[tokio::test]
+    async fn parcel_wool_borders() {
+        init_logger();
+
+        let seed = Seed(12345);
+
+        let provider = GDMCHTTPProvider::new();
+        let build_area = provider.get_build_area().await.expect("Failed to get build area");
+        let height_map = provider.get_heightmap(
+            build_area.origin.x, build_area.origin.z,
+            build_area.size.x, build_area.size.z,
+            HeightMapType::WorldSurface,
+        ).await.expect("Failed to get heightmap");
+
+        let world = World::new(&provider).await.expect("Failed to create world");
+        let mut editor = world.get_editor();
+
+        let _parcels = generate_parcels(seed, &mut editor).await;
+
+        // Snapshot the per-parcel fill cells and edge cells before borrowing the
+        // editor for block writes. Keys: ParcelID → (points_2d, edges).
+        let parcel_snapshots: Vec<(usize, HashSet<Point2D>, HashSet<Point3D>)> = editor
+            .world()
+            .parcels
+            .iter()
+            .map(|(id, p)| (id.0 as usize, p.data.points_2d.clone(), p.data.edges.clone()))
+            .collect();
+
+        let mut total_cells = 0usize;
+        let mut total_edge_cells = 0usize;
+
+        for (pid, fill_cells, edge_cells) in &parcel_snapshots {
+            let wool = get_block_for_id(*pid);
+
+            // Base fill: wool at the surface height for every cell in the parcel.
+            for p in fill_cells {
+                if p.x < 0 || p.y < 0 || p.x >= build_area.size.x || p.y >= build_area.size.z {
+                    continue;
+                }
+                let h = height_map[p.x as usize][p.y as usize] - build_area.origin.y;
+                editor.place_block(&wool, Point3D::new(p.x, h, p.y)).await;
+                total_cells += 1;
+            }
+
+            // Ridge: one extra wool block directly above each edge cell, so the
+            // border stands a block proud of the parcel's painted floor.
+            for e in edge_cells {
+                if e.x < 0 || e.z < 0 || e.x >= build_area.size.x || e.z >= build_area.size.z {
+                    continue;
+                }
+                editor.place_block(&wool, Point3D::new(e.x, e.y + 1, e.z)).await;
+                total_edge_cells += 1;
+            }
+        }
+
+        println!(
+            "Painted {} parcels — {} fill cells, {} edge ridge blocks",
+            parcel_snapshots.len(), total_cells, total_edge_cells,
+        );
+
+        editor.flush_buffer().await;
+    }
+
     #[tokio::test]
     async fn district_test() {
         init_logger();

--- a/src/generator/districts/wall.rs
+++ b/src/generator/districts/wall.rs
@@ -184,11 +184,19 @@ fn parapet_is_outer(cell: Point2D, region: &HashSet<Point2D>, ring: &HashSet<Poi
     })
 }
 
-/// `palette` is the culture's output palette used to re-skin placed wall
-/// structures (towers) into the settlement's look — e.g. a desert town swaps the
-/// stone-brick/oak tower NBT to smooth_sandstone/birch. `None` leaves structures
-/// in their authored blocks.
-pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rng : &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, wall_type: WallType, palette: Option<&Palette>) {
+/// The inputs needed to re-skin placed wall structures (towers) into a culture's
+/// look — e.g. swapping the stone-brick/oak tower NBT to smooth_sandstone/birch.
+/// Both the loaded generator data and the output palette are required for the
+/// swap, so they're bundled to keep them from desyncing; pass `None` to leave
+/// structures in their authored blocks.
+pub struct TowerSkin<'a> {
+    pub data: &'a LoadedData,
+    pub palette: &'a Palette,
+}
+
+/// `skin` re-skins placed wall structures (towers) into the settlement's look;
+/// `None` leaves them in their authored blocks. See [`TowerSkin`].
+pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rng : &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, wall_type: WallType, skin: Option<&TowerSkin<'_>>) {
     let ordered_wall_points = trace_wall_loops(urban_points);
     let total_points: usize = ordered_wall_points.iter().map(|loop_| loop_.len()).sum();
     info!(
@@ -207,11 +215,11 @@ pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rn
 
     for wall_point_list in ordered_wall_points {
         if wall_type == WallType::Standard {
-            build_wall_standard(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, palette).await;
+            build_wall_standard(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, skin).await;
         } else if wall_type == WallType::Palisade {
             build_wall_palisade(&wall_point_list, editor, rng, material_placer, material_id, structures).await;
         } else if wall_type == WallType::StandardWithInner {
-            build_wall_standard_with_inner(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, palette).await;
+            build_wall_standard_with_inner(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, skin).await;
         }
     }
 }
@@ -261,7 +269,7 @@ pub async fn build_wall_palisade(wall_points: &Vec<Point2D>, editor: &mut Editor
 
 }
 
-pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, palette: Option<&Palette>) {
+pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, skin: Option<&TowerSkin<'_>>) {
     let wall_points_with_height = add_wall_points_height(wall_points, editor);
     let wall_set: HashSet<Point2D> = wall_points.iter().cloned().collect();
     let enhanced_wall_points = check_water(&mut add_wall_points_directionality(&wall_points_with_height, &wall_set, urban_points), editor);
@@ -348,14 +356,14 @@ pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor
         editor.world_mut().claim(*p, BuildClaim::Wall);
     }
     //add towers
-    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, palette).await;
+    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, skin).await;
     //add gates
     build_wall_gate(&wall_points_with_height, editor, rng, material_placer, true, false, None, None, structures, 6).await
 
 }
 
 
-pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, palette: Option<&Palette>) {
+pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, skin: Option<&TowerSkin<'_>>) {
     let wall_points_with_height = add_wall_points_height(wall_points, editor);
     let wall_set: HashSet<Point2D> = wall_points.iter().cloned().collect();
     let enhanced_wall_points = check_water(&mut add_wall_points_directionality(&wall_points_with_height, &wall_set, urban_points), editor);
@@ -502,7 +510,7 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
         editor.world_mut().claim(p.drop_y(), BuildClaim::Wall);
     }
     //add towers
-    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, palette).await;
+    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, skin).await;
     //add gates
     build_wall_gate(&wall_points_with_height, editor, rng, material_placer, false, false, Some(&enhanced_wall_points), Some(&inner_wall_points), structures, 6).await
 
@@ -850,7 +858,7 @@ pub async fn build_wall_towers(
     material_id: &MaterialId,
     structures: & HashMap<StructureType, Structure>,
     rng: &mut RNG,
-    palette: Option<&Palette>,
+    skin: Option<&TowerSkin<'_>>,
 ) {
     let distance_to_next_tower = 80;
     let mut tower_possible = rng.rand_i32_range(0, distance_to_next_tower / 2);
@@ -860,12 +868,6 @@ pub async fn build_wall_towers(
     // be read.
     let tower_size_y: i32 = load_nbt_structure(&tower.meta.path).map(|s| s.size[1]).unwrap_or(12);
     let walkway_set: HashSet<Point2D> = walkway_points.iter().cloned().collect();
-
-    // When a culture palette is supplied, load the generator data so the tower
-    // NBT (authored in the `wall_base` input palette) can be palette-swapped
-    // into the settlement's look — e.g. desert → smooth_sandstone/birch. Loaded
-    // once here, not per tower.
-    let data = palette.map(|_| LoadedData::load().expect("Failed to load data for tower palette swap"));
 
     for point in walkway_points {
         if tower_possible == 0 {
@@ -891,10 +893,10 @@ pub async fn build_wall_towers(
                     editor.world_mut().claim(*neighbour, BuildClaim::Wall);
                 }
                 info!("Placing tower at: {:?}", point.add_y(point_height+6));
-                // Re-skin the tower into the culture palette when one was given
+                // Re-skin the tower into the culture palette when a skin was given
                 // (data + output palette both present → place_structure runs the
                 // swap); otherwise place the authored blocks unchanged.
-                place_structure(editor, Some(material_placer), &tower, point.add_y(point_height+6), Cardinal::North, data.as_ref(), palette, false, false).await.expect("Failed to place tower");
+                place_structure(editor, Some(material_placer), &tower, point.add_y(point_height+6), Cardinal::North, skin.map(|s| s.data), skin.map(|s| s.palette), false, false).await.expect("Failed to place tower");
 
                 // Two guard posts on the tower's battlement top, where guards
                 // stand watch. The structure's origin maps to (point, point_height

--- a/src/generator/districts/wall.rs
+++ b/src/generator/districts/wall.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use log::info;
-use crate::{generator::{data::LoadedData, districts::build_wall_gate, materials::{MaterialId, Palette, Placer}, nbts::{place_structure, Structure, StructureType}, BuildClaim}, geometry::{get_neighbours_in_set, get_edge, is_point_surrounded_by_points, Cardinal, Point2D, Point3D, CARDINALS_2D}, minecraft::BlockForm, noise::RNG};
+use crate::{generator::{data::LoadedData, districts::build_wall_gate, materials::{MaterialId, Palette, Placer}, nbts::{load_nbt_structure, place_structure, Structure, StructureType}, BuildClaim}, geometry::{get_neighbours_in_set, get_edge, is_point_surrounded_by_points, Cardinal, Point2D, Point3D, CARDINALS_2D}, minecraft::BlockForm, noise::RNG};
 
 use crate::editor::Editor;
 
@@ -855,6 +855,10 @@ pub async fn build_wall_towers(
     let distance_to_next_tower = 80;
     let mut tower_possible = rng.rand_i32_range(0, distance_to_next_tower / 2);
     let tower = structures.get(&"basic_tower".into()).expect("Structure not found");
+    // Decode the tower NBT once to learn its height, so guards can be posted on
+    // the battlement top. Falls back to a typical tower height if the file can't
+    // be read.
+    let tower_size_y: i32 = load_nbt_structure(&tower.meta.path).map(|s| s.size[1]).unwrap_or(12);
     let walkway_set: HashSet<Point2D> = walkway_points.iter().cloned().collect();
 
     // When a culture palette is supplied, load the generator data so the tower
@@ -891,6 +895,19 @@ pub async fn build_wall_towers(
                 // (data + output palette both present → place_structure runs the
                 // swap); otherwise place the authored blocks unchanged.
                 place_structure(editor, Some(material_placer), &tower, point.add_y(point_height+6), Cardinal::North, data.as_ref(), palette, false, false).await.expect("Failed to place tower");
+
+                // Two guard posts on the tower's battlement top, where guards
+                // stand watch. The structure's origin maps to (point, point_height
+                // + 6); its highest blocks (the merlons) sit `size_y - 1 - origin.y`
+                // above that, and the battlement floor is level with the merlon
+                // tops — so feet stand at that y on the two centre cells.
+                // Drop 5 below the computed crown so feet land on the battlement
+                // floor rather than atop the merlons / above the roofline.
+                let top_y = point_height + 6 + (tower_size_y - 1) - tower.origin.y - 5;
+                editor.world_mut().tower_guard_posts.push(vec![
+                    Point3D::new(point.x, top_y, point.y),
+                    Point3D::new(point.x + 1, top_y, point.y),
+                ]);
             }
         } else {
                 tower_possible -= 1;

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -14,6 +14,8 @@ pub mod style;
 pub mod chronicle;
 pub mod settlement;
 pub mod open_space;
+pub mod npc;
+pub mod population;
 
 pub use build_claim::BuildClaim;
 pub use settlement::generate_town;

--- a/src/generator/nbts/mod.rs
+++ b/src/generator/nbts/mod.rs
@@ -7,7 +7,7 @@ mod meta;
 mod structure;
 
 
-pub use place::{place_nbt, place_structure};
+pub use place::{load_nbt_structure, place_nbt, place_structure};
 pub use structure::{Structure, StructureID, StructureType};
 pub use nbt::{NBTStructure};
 pub use transform::Transform;

--- a/src/generator/nbts/place.rs
+++ b/src/generator/nbts/place.rs
@@ -6,6 +6,22 @@ use log::info;
 
 use crate::{data::to_snbt, editor::Editor, generator::{data::LoadedData, materials::{Palette, PaletteSwapResult, Placer}, nbts::{Rotation, Structure, meta::NBTMeta, nbt::NBTStructure, transform::Transform}}, geometry::{Cardinal, Point3D}, minecraft::{Block, BlockForm}};
 
+/// Read and decode an NBT structure file (plain or gzip-compressed). Shared by
+/// placement and by callers that only need the structure's metadata — e.g. its
+/// `size` to find the top of a tower for guard placement.
+pub fn load_nbt_structure(path: &str) -> anyhow::Result<NBTStructure> {
+    let nbt_data = std::fs::read(path)?;
+    match fastnbt::from_bytes::<NBTStructure>(&nbt_data) {
+        Result::Ok(s) => Ok(s),
+        Err(_) => {
+            let mut decoder = GzDecoder::new(nbt_data.as_slice());
+            let mut buf = vec![];
+            decoder.read_to_end(&mut buf)?;
+            Ok(fastnbt::from_bytes(&buf)?)
+        }
+    }
+}
+
 /// Convert a block's stored NBT compound into the SNBT string the editor
 /// sends to the server. Empty compounds carry no real data and are dropped.
 fn block_nbt_to_snbt(value : &fastnbt::Value) -> Option<String> {
@@ -43,20 +59,7 @@ pub async fn place_structure<'materials>(editor: &Editor, placer: Option<&mut Pl
 pub async fn place_nbt<'materials>(data: &NBTMeta, transform: Transform, editor: &Editor, placer: Option<&mut Placer<'materials>>, generator_data: Option<&LoadedData>, input_palette: Option<&Palette>, output_palette: Option<&Palette>, mirror_x: Option<i32>, mirror_z: Option<i32>) -> anyhow::Result<()> {
     info!("Placing NBT structure: {}", data.path);
 
-    let nbt_data = std::fs::read(data.path.clone())?;
-    
-    let structure : Result<NBTStructure, fastnbt::error::Error> = fastnbt::from_bytes(&nbt_data);
-
-    // Try to decode the structure directly, if it fails, try decompressing and decoding
-    let structure = match structure {
-        Result::Ok(s) => s,
-        Err(_) => {
-            let mut decoder = GzDecoder::new(nbt_data.as_slice());
-            let mut buf = vec![];
-            decoder.read_to_end(&mut buf)?;
-            fastnbt::from_bytes(&buf)?
-        }
-    };
+    let structure = load_nbt_structure(&data.path)?;
 
     // Beds are pasted without block updates: with updates on, the server runs the
     // placement side effect of a bed foot auto-spawning its head — duplicating the

--- a/src/generator/nbts/structure.rs
+++ b/src/generator/nbts/structure.rs
@@ -69,6 +69,13 @@ pub struct Structure {
     /// buildings meant to cut into a hillside, e.g. mines. Default false.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub allow_steep : bool,
+
+    /// Worker staffing for this building, when it's a staffed workplace — the
+    /// crew's job label, skin pool, and size. Absent for non-workplace
+    /// structures (walls, towers, decoration). Read by the settlement worker
+    /// pass; a building without it falls back to `NpcData::default_staffing`.
+    #[serde(default, skip_serializing)]
+    pub staffing : Option<crate::generator::npc::Staffing>,
 }
 
 fn default_weight() -> f32 {

--- a/src/generator/nbts/test.rs
+++ b/src/generator/nbts/test.rs
@@ -174,14 +174,17 @@ mod tests {
         }, Point3D{
             x: match b.x {
                 Coordinate::Absolute(x) => x,
+                Coordinate::AbsoluteF(x) => x.round() as i32,
                 Coordinate::Relative(x) => build_area.origin.x + x,
             },
             y: match b.y {
                 Coordinate::Absolute(y) => y,
+                Coordinate::AbsoluteF(y) => y.round() as i32,
                 Coordinate::Relative(y) => build_area.origin.y + y,
             },
             z: match b.z {
                 Coordinate::Absolute(z) => z,
+                Coordinate::AbsoluteF(z) => z.round() as i32,
                 Coordinate::Relative(z) => build_area.origin.z + z,
             },
         } - build_area.origin)).collect::<Vec<_>>();
@@ -244,14 +247,17 @@ mod tests {
         }, Point3D{
             x: match b.x {
                 Coordinate::Absolute(x) => x,
+                Coordinate::AbsoluteF(x) => x.round() as i32,
                 Coordinate::Relative(x) => build_area.origin.x + x,
             },
             y: match b.y {
                 Coordinate::Absolute(y) => y,
+                Coordinate::AbsoluteF(y) => y.round() as i32,
                 Coordinate::Relative(y) => build_area.origin.y + y,
             },
             z: match b.z {
                 Coordinate::Absolute(z) => z,
+                Coordinate::AbsoluteF(z) => z.round() as i32,
                 Coordinate::Relative(z) => build_area.origin.z + z,
             },
         } - build_area.origin)).collect::<Vec<_>>();

--- a/src/generator/nbts/test.rs
+++ b/src/generator/nbts/test.rs
@@ -10,6 +10,86 @@ mod tests {
     use fastnbt::to_writer;
 
 
+    /// Authoring aid: for each industrial NBT, propose standable cells next to
+    /// ground-floor workstations so anchor coords can be hand-curated into the
+    /// JSON sidecars. A "stand" cell is non-solid with a solid floor below and
+    /// headroom above. Run: `cargo test propose_industrial_anchors -- --nocapture`.
+    #[test]
+    fn propose_industrial_anchors() {
+        use std::collections::HashSet;
+        use std::io::Read;
+        use flate2::read::GzDecoder;
+
+        fn load(path: &str) -> NBTStructure {
+            let raw = std::fs::read(path).expect("read nbt");
+            match fastnbt::from_bytes::<NBTStructure>(&raw) {
+                Ok(s) => s,
+                Err(_) => {
+                    let mut d = GzDecoder::new(raw.as_slice());
+                    let mut buf = vec![];
+                    d.read_to_end(&mut buf).expect("gunzip");
+                    fastnbt::from_bytes(&buf).expect("parse nbt")
+                }
+            }
+        }
+
+        // Per building, the "primary" job-site blocks worth standing at (the
+        // outfit follows the building, not the block).
+        let primary: &[(&str, &[&str])] = &[
+            ("smithy", &["smithing_table", "anvil", "furnace", "grindstone"]),
+            ("mill", &["stonecutter", "grindstone"]),
+            ("bakery", &["furnace", "smoker", "barrel"]),
+            ("carpenter", &["stonecutter", "fletching_table"]),
+            ("tannery", &["cauldron", "smithing_table", "anvil", "fletching_table"]),
+            ("weaver", &["loom"]),
+        ];
+
+        for (name, stations) in primary {
+            let s = load(&format!("data/structures/resource_buildings/{name}.nbt"));
+            let short = |b: &crate::generator::nbts::nbt::BlockData| {
+                let id = s.palette[b.state].name.as_str().to_string();
+                id.strip_prefix("minecraft:").unwrap_or(&id).to_string()
+            };
+            let solid: HashSet<(i32, i32, i32)> = s.blocks.iter()
+                .filter(|b| { let n = short(b); n != "air" && n != "cave_air" && n != "void_air" })
+                .map(|b| (b.pos[0], b.pos[1], b.pos[2]))
+                .collect();
+            let standable = |p: (i32, i32, i32)| {
+                solid.contains(&(p.0, p.1 - 1, p.2)) // floor below
+                    && !solid.contains(&p)            // feet clear
+                    && !solid.contains(&(p.0, p.1 + 1, p.2)) // headroom
+            };
+            println!("\n===== {name} =====");
+            let mut used: HashSet<(i32, i32, i32)> = HashSet::new();
+            for b in &s.blocks {
+                if b.pos[1] != 1 { continue; } // ground floor only
+                let n = short(b);
+                if !stations.iter().any(|st| n == *st) { continue; }
+                let st = (b.pos[0], b.pos[1], b.pos[2]);
+                // First cardinally-adjacent standable cell, preferring an unused one.
+                let cands = [(1, 0), (-1, 0), (0, 1), (0, -1)];
+                if let Some((dx, dz)) = cands.iter().copied()
+                    .find(|(dx, dz)| { let c = (st.0 + dx, st.1, st.2 + dz); standable(c) && !used.contains(&c) })
+                    .or_else(|| cands.iter().copied().find(|(dx, dz)| standable((st.0 + dx, st.1, st.2 + dz))))
+                {
+                    let stand = (st.0 + dx, st.1, st.2 + dz);
+                    used.insert(stand);
+                    println!("  {n}@{:?}  -> stand [{},{},{}] look [{},{},{}]",
+                        st, stand.0, stand.1, stand.2, st.0, st.1, st.2);
+                }
+            }
+            if used.is_empty() {
+                println!("  (no station-adjacent stand cells; standable ground-floor cells:)");
+                for b in &s.blocks {
+                    let p = (b.pos[0], b.pos[1], b.pos[2]);
+                    if p.1 == 1 && standable(p) {
+                        println!("    stand [{},{},{}]", p.0, p.1, p.2);
+                    }
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_place_nbt() {
         init_logger();

--- a/src/generator/nbts/test.rs
+++ b/src/generator/nbts/test.rs
@@ -214,6 +214,7 @@ mod tests {
                 size_xz: (0, 0),
                 y_offset: 0,
                 allow_steep: false,
+                staffing: None,
             },
             wall_type: Some(WallType::Support),
             vertical_position: Some(VerticalWallPosition::Bottom),
@@ -287,6 +288,7 @@ mod tests {
                 size_xz: (0, 0),
                 y_offset: 0,
                 allow_steep: false,
+                staffing: None,
             },
             roof_type: RoofType::Hip(HipRoofPart::Inner),
         };

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -1,0 +1,328 @@
+//! Town NPCs: static villagers that stand in place (`NoAI`), wear a floating
+//! name tag, and carry a "dialogue bubble" — a [`text_display`] entity hovering
+//! above their head that shows a line of text.
+//!
+//! Entities (unlike blocks) are spawned straight to the server via
+//! [`Editor::spawn_entity`] and bypass the block buffer/cache, so they are
+//! invisible to later `get_block` reads and to offline/dry-run mode.
+//!
+//! Text is written as a native SNBT text component (`{text:"…"}`), which is the
+//! 1.21.5+ form the server (1.21.11) expects for `text_display` and entity
+//! `CustomName`.
+
+use crate::editor::Editor;
+use crate::geometry::Point3D;
+
+/// How many blocks above the NPC's feet the dialogue bubble's cell sits, plus a
+/// fractional raise for fine height — together ~2.5 blocks up, clear of the head
+/// without floating too high above the name tag.
+const BUBBLE_HEIGHT: i32 = 2;
+const BUBBLE_RAISE: f32 = 0.5;
+
+/// Dialogue text colour — a soft light gray so it reads as muted speech rather
+/// than a stark white label. Hex text-component colour (vanilla "gray" is darker).
+const DIALOGUE_COLOR: &str = "#C8C8C8";
+
+/// Max line width (in pixels) before the bubble wraps to a new line. Keeps long
+/// dialogue as a tidy block instead of one runaway line.
+const DIALOGUE_LINE_WIDTH: i32 = 160;
+
+/// Uniform scale of the dialogue text (1.0 = vanilla size). Shrunk so the bubble
+/// reads as small floating speech rather than a billboard.
+const DIALOGUE_SCALE: f32 = 0.6;
+
+/// How far (roughly) the dialogue bubble stays visible. Render distance is
+/// `view_range * 64` blocks (scaled by the client's entity-distance setting), so
+/// 0.25 ≈ 16 blocks — the bubble fades out unless the player is close.
+const DIALOGUE_VIEW_RANGE: f32 = 0.03;
+
+// --- "Yelled" dialogue: a market crier's hawk or a stage performer's call.
+// Larger, bolder, warmer, and visible from much further than ordinary speech, so
+// it reads as a shout carrying across a square rather than a quiet aside. It also
+// floats a touch higher so it clears the heads of any crowd between the speaker
+// and the player.
+const YELL_HEIGHT: i32 = 3;
+const YELL_RAISE: f32 = 0.0;
+/// Warm parchment-gold so a shout stands out from the muted gray of small talk.
+const YELL_COLOR: &str = "#FFE9A8";
+const YELL_LINE_WIDTH: i32 = 220;
+const YELL_SCALE: f32 = 1.05;
+/// ~38 blocks (`view_range * 64`): a yell carries clear across the plaza, long
+/// before the player is close enough to read a normal bubble.
+const YELL_VIEW_RANGE: f32 = 0.6;
+
+/// How loudly an NPC's dialogue bubble reads. `Normal` is a quiet, close-range
+/// aside; `Yelled` is a big, bold, far-visible shout for market criers and stage
+/// performers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DialogueVolume {
+    #[default]
+    Normal,
+    Yelled,
+}
+
+/// The per-volume bubble styling: how high it floats, its colour, wrap width,
+/// uniform scale, fade-out range, and whether the text is bold.
+struct BubbleStyle {
+    height: i32,
+    raise: f32,
+    color: &'static str,
+    line_width: i32,
+    scale: f32,
+    view_range: f32,
+    bold: bool,
+}
+
+impl DialogueVolume {
+    fn style(self) -> BubbleStyle {
+        match self {
+            DialogueVolume::Normal => BubbleStyle {
+                height: BUBBLE_HEIGHT,
+                raise: BUBBLE_RAISE,
+                color: DIALOGUE_COLOR,
+                line_width: DIALOGUE_LINE_WIDTH,
+                scale: DIALOGUE_SCALE,
+                view_range: DIALOGUE_VIEW_RANGE,
+                bold: false,
+            },
+            DialogueVolume::Yelled => BubbleStyle {
+                height: YELL_HEIGHT,
+                raise: YELL_RAISE,
+                color: YELL_COLOR,
+                line_width: YELL_LINE_WIDTH,
+                scale: YELL_SCALE,
+                view_range: YELL_VIEW_RANGE,
+                bold: true,
+            },
+        }
+    }
+}
+
+/// The name tag is rendered as its own `text_display` rather than the villager's
+/// built-in `CustomNameVisible` tag, so it can fade with distance like the
+/// dialogue bubble — a vanilla name tag otherwise shows from far off (and
+/// through walls) at a fixed client distance, with no per-entity range. These
+/// tune the floating name: it sits just above the head, below the bubble.
+const NAME_HEIGHT: i32 = 2;
+const NAME_RAISE: f32 = 0.0;
+
+/// Uniform scale of the name tag (1.0 = vanilla size). A touch smaller than
+/// default so it reads as a tidy floating tag.
+const NAME_SCALE: f32 = 0.5;
+
+/// Render distance of the name tag, same `view_range * 64` blocks rule as the
+/// dialogue bubble. A touch further than [`DIALOGUE_VIEW_RANGE`] so the name
+/// fades in just before the dialogue does as the player approaches.
+const NAME_VIEW_RANGE: f32 = 0.05;
+
+/// The villager's biome "type" — the skin/outfit variant. These are the seven
+/// vanilla villager types. See <https://minecraft.wiki/w/Villager>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VillagerBiome {
+    Plains,
+    Desert,
+    Jungle,
+    Savanna,
+    Snow,
+    Swamp,
+    Taiga,
+}
+
+impl VillagerBiome {
+    /// The `minecraft:`-namespaced id used in the villager's `VillagerData.type`.
+    pub fn id(self) -> &'static str {
+        match self {
+            VillagerBiome::Plains => "minecraft:plains",
+            VillagerBiome::Desert => "minecraft:desert",
+            VillagerBiome::Jungle => "minecraft:jungle",
+            VillagerBiome::Savanna => "minecraft:savanna",
+            VillagerBiome::Snow => "minecraft:snow",
+            VillagerBiome::Swamp => "minecraft:swamp",
+            VillagerBiome::Taiga => "minecraft:taiga",
+        }
+    }
+}
+
+/// The villager's profession — sets its outfit (and, in vanilla, its trades).
+/// `None` is the unemployed green robe and `Nitwit` the lazy green-robe variant;
+/// the rest are the working professions. See <https://minecraft.wiki/w/Villager>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profession {
+    None,
+    Armorer,
+    Butcher,
+    Cartographer,
+    Cleric,
+    Farmer,
+    Fisherman,
+    Fletcher,
+    Leatherworker,
+    Librarian,
+    Mason,
+    Nitwit,
+    Shepherd,
+    Toolsmith,
+    Weaponsmith,
+}
+
+impl Profession {
+    /// The `minecraft:`-namespaced id used in `VillagerData.profession`.
+    pub fn id(self) -> &'static str {
+        match self {
+            Profession::None => "minecraft:none",
+            Profession::Armorer => "minecraft:armorer",
+            Profession::Butcher => "minecraft:butcher",
+            Profession::Cartographer => "minecraft:cartographer",
+            Profession::Cleric => "minecraft:cleric",
+            Profession::Farmer => "minecraft:farmer",
+            Profession::Fisherman => "minecraft:fisherman",
+            Profession::Fletcher => "minecraft:fletcher",
+            Profession::Leatherworker => "minecraft:leatherworker",
+            Profession::Librarian => "minecraft:librarian",
+            Profession::Mason => "minecraft:mason",
+            Profession::Nitwit => "minecraft:nitwit",
+            Profession::Shepherd => "minecraft:shepherd",
+            Profession::Toolsmith => "minecraft:toolsmith",
+            Profession::Weaponsmith => "minecraft:weaponsmith",
+        }
+    }
+}
+
+/// Escape a user string for embedding inside a double-quoted SNBT string.
+fn escape_snbt(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Spawn a stationary villager NPC at build-area-local `point` (its feet),
+/// facing `angle` (yaw in degrees, 0 = south, like vanilla), with a `name` tag
+/// and a `dialogue` bubble floating above its head. `biome` and `profession`
+/// pick the villager's appearance.
+///
+/// `home`, when set, is the index of the house this NPC belongs to; it's baked
+/// into the villager's entity `Tags` as `home_<id>` so the spawned NPC carries a
+/// persistent, queryable record of which house it came from (residents have one;
+/// workplace/plaza fixtures pass `None`).
+///
+/// The villager has `NoAI` so it won't wander or turn. Its `CustomName` is kept
+/// for identity (and the vanilla look-at hover) but not always-visible; the tag
+/// the player sees is a separate `text_display` with a `view_range`, so it (like
+/// the dialogue bubble) only shows once the player is near. Both displays are
+/// center-billboarded, so they always rotate to face the player.
+pub async fn spawn_villager_npc(
+    editor: &Editor,
+    point: Point3D,
+    angle: f32,
+    name: &str,
+    dialogue: &str,
+    biome: VillagerBiome,
+    profession: Profession,
+    volume: DialogueVolume,
+    home: Option<usize>,
+) -> anyhow::Result<()> {
+    // The villager itself: frozen, named, faced, and skinned by biome/profession.
+    // level:1 so a working profession shows its job outfit (level 0 reads as none).
+    // A resident also carries a `home_<id>` entity tag recording its house.
+    let home_tag = match home {
+        Some(id) => format!(",Tags:[\"home_{id}\"]"),
+        None => String::new(),
+    };
+    let villager_data = format!(
+        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:0b,Rotation:[{}f,0f],\
+         VillagerData:{{type:\"{}\",profession:\"{}\",level:1}}{}}}",
+        escape_snbt(name),
+        angle,
+        biome.id(),
+        profession.id(),
+        home_tag,
+    );
+    editor
+        .spawn_entity("minecraft:villager", point, Some(&villager_data))
+        .await?;
+
+    // The name tag: its own text_display, just above the head, so it fades with
+    // distance instead of showing from across the map like the built-in tag.
+    let tag = point + Point3D::new(0, NAME_HEIGHT, 0);
+    let tag_data = format!(
+        "{{text:{{text:\"{}\"}},billboard:\"center\",alignment:\"center\",view_range:{}f,\
+         transformation:{{translation:[0f,{}f,0f],scale:[{s}f,{s}f,{s}f],left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f]}},\
+         Rotation:[{}f,0f]}}",
+        escape_snbt(name),
+        NAME_VIEW_RANGE,
+        NAME_RAISE,
+        angle,
+        s = NAME_SCALE,
+    );
+    editor
+        .spawn_entity("minecraft:text_display", tag, Some(&tag_data))
+        .await?;
+
+    // The dialogue bubble: a text display hovering above the head, styled by how
+    // loud the line is (a quiet aside vs. a far-carrying yell). The transformation
+    // nudges it up a fractional block (entity coords are integer).
+    let style = volume.style();
+    let bubble = point + Point3D::new(0, style.height, 0);
+    let bubble_data = format!(
+        "{{text:{{text:\"{}\",color:\"{}\",bold:{}b}},line_width:{},billboard:\"center\",see_through:1b,alignment:\"center\",view_range:{}f,\
+         transformation:{{translation:[0f,{}f,0f],scale:[{s}f,{s}f,{s}f],left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f]}},\
+         Rotation:[{}f,0f]}}",
+        escape_snbt(dialogue),
+        style.color,
+        i32::from(style.bold),
+        style.line_width,
+        style.view_range,
+        style.raise,
+        angle,
+        s = style.scale,
+    );
+    editor
+        .spawn_entity("minecraft:text_display", bubble, Some(&bubble_data))
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::{Editor, World};
+    use crate::geometry::{Point2D, Point3D};
+    use crate::http_mod::GDMCHTTPProvider;
+    use crate::util::init_logger;
+
+    /// Spawn a placeholder NPC at the centre of the build area, on the ground, so
+    /// it can be eyeballed in-game. Needs a live server.
+    /// Run with: `cargo test spawn_test_npc -- --nocapture`.
+    #[tokio::test]
+    async fn spawn_test_npc() {
+        init_logger();
+
+        let provider = GDMCHTTPProvider::new();
+        let build_area = provider.get_build_area().await.expect("Failed to get build area");
+        let world = World::new(&provider).await.expect("Failed to create world");
+        let editor = Editor::new(build_area, world);
+
+        // Build-area-local coordinates: the editor adds the origin back on spawn.
+        let size = editor.world().world_rect_2d().size;
+        let centre = Point2D::new(size.x / 2, size.y / 2);
+        let ground = editor.world().get_ocean_floor_height_at(centre);
+        let feet = Point3D::new(centre.x, ground, centre.y);
+
+        spawn_villager_npc(
+            &editor,
+            feet,
+            180.0, // face north (toward a player approaching from +z)
+            "Hilda the Baker",
+            "Fresh bread, half price today! Loaves still warm from the oven, \
+             and the honey rolls are going fast — best grab a few before my \
+             neighbour buys the lot again.",
+            VillagerBiome::Desert,
+            Profession::Butcher,
+            DialogueVolume::Normal,
+            Some(0),
+        )
+        .await
+        .expect("failed to spawn NPC");
+
+        println!("Spawned test NPC at local {:?} (ground y={})", centre, ground);
+    }
+}

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -10,6 +10,8 @@
 //! 1.21.5+ form the server (1.21.11) expects for `text_display` and entity
 //! `CustomName`.
 
+use serde_derive::Deserialize;
+
 use crate::editor::Editor;
 use crate::geometry::Point3D;
 
@@ -129,7 +131,7 @@ impl VillagerBiome {
 /// The villager's profession — sets its outfit (and, in vanilla, its trades).
 /// `None` is the unemployed green robe and `Nitwit` the lazy green-robe variant;
 /// the rest are the working professions. See <https://minecraft.wiki/w/Villager>.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum Profession {
     None,
     Armorer,
@@ -267,7 +269,7 @@ pub async fn spawn_villager_npc(
             .await?;
     }
 
-    spawn_dialogue_bubble(editor, point, angle, dialogue, volume).await
+    spawn_dialogue_bubble(editor, point, angle, dialogue, volume, child).await
 }
 
 /// Spawn a stationary mob NPC (e.g. a [`Mob::Witch`] or [`Mob::WanderingTrader`])
@@ -294,22 +296,27 @@ pub async fn spawn_mob_npc(
     );
     editor.spawn_entity(mob.id(), point, Some(&mob_data)).await?;
 
-    spawn_dialogue_bubble(editor, point, angle, dialogue, volume).await
+    spawn_dialogue_bubble(editor, point, angle, dialogue, volume, false).await
 }
 
 /// Spawn the dialogue bubble: a `text_display` hovering above an NPC's head,
 /// styled by how loud the line is (a quiet aside vs. a far-carrying yell). The
 /// transformation nudges it up a fractional block (entity coords are integer).
 /// Shared by [`spawn_villager_npc`] and [`spawn_mob_npc`].
+///
+/// `child` drops the bubble one block — baby villagers are roughly a block
+/// shorter than adults, so the adult bubble height would float over empty air.
 async fn spawn_dialogue_bubble(
     editor: &Editor,
     point: Point3D,
     angle: f32,
     dialogue: &str,
     volume: DialogueVolume,
+    child: bool,
 ) -> anyhow::Result<()> {
     let style = volume.style();
-    let bubble = point + Point3D::new(0, style.height, 0);
+    let height = if child { style.height - 1 } else { style.height };
+    let bubble = point + Point3D::new(0, height, 0);
     let bubble_data = format!(
         "{{text:{{text:\"{}\",color:\"{}\",bold:{}b}},line_width:{},billboard:\"center\",see_through:1b,alignment:\"center\",view_range:{}f,\
          transformation:{{translation:[0f,{}f,0f],scale:[{s}f,{s}f,{s}f],left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f]}},\

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -171,13 +171,44 @@ impl Profession {
             Profession::Weaponsmith => "minecraft:weaponsmith",
         }
     }
+
+    /// The town job a resident of this look works, if any — the bridge from the
+    /// *look* axis (this Minecraft outfit) to the *employment* axis (a free-form
+    /// job label). Real trades map across to their lowercase name; the jobless
+    /// green-robe `None` and the lazy `Nitwit` look have no employment.
+    ///
+    /// Employment is a plain string, not an enum: it's presentation data we only
+    /// display and tally (never branch on), and fixtures declare arbitrary job
+    /// labels in `npcs.yaml` ("woodcutter", "smith", …), so an open vocabulary
+    /// fits better than ~30 enum variants. A resident villager's employment is a
+    /// villager trade; a fixture's comes from its data entry.
+    pub fn employment(self) -> Option<&'static str> {
+        Some(match self {
+            Profession::None | Profession::Nitwit => return None,
+            Profession::Armorer => "armorer",
+            Profession::Butcher => "butcher",
+            Profession::Cartographer => "cartographer",
+            Profession::Cleric => "cleric",
+            Profession::Farmer => "farmer",
+            Profession::Fisherman => "fisherman",
+            Profession::Fletcher => "fletcher",
+            Profession::Leatherworker => "leatherworker",
+            Profession::Librarian => "librarian",
+            Profession::Mason => "mason",
+            Profession::Shepherd => "shepherd",
+            Profession::Toolsmith => "toolsmith",
+            Profession::Weaponsmith => "weaponsmith",
+        })
+    }
 }
 
 /// A non-villager townsfolk mob we can drop in as a static fixture, the same way
 /// as [`spawn_villager_npc`] but without the villager-specific biome/profession.
 /// Witches and wandering traders are the colourful background characters that
-/// make a town feel lived-in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// make a town feel lived-in. Deserialized from data (e.g. a `guard_mob:
+/// pillager` in `npcs.yaml`) in snake_case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Mob {
     Witch,
     WanderingTrader,
@@ -201,6 +232,35 @@ impl Mob {
             Mob::ZombieVillager => "minecraft:zombie_villager",
         }
     }
+}
+
+/// How an NPC looks when spawned: either a villager wearing a [`Profession`] or a
+/// non-villager [`Mob`]. This is the render axis — orthogonal to a resident's
+/// *employment* (`Npc::profession`), which a mob-look NPC simply doesn't carry.
+///
+/// Deserialized untagged from a single string, so a config list can mix the two —
+/// a `Profession` name (PascalCase, e.g. `Armorer`) parses as `Villager`, a `Mob`
+/// name (snake_case, e.g. `pillager`) as `Mob`. The two name sets are disjoint,
+/// so there's no ambiguity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum NpcLook {
+    Villager(Profession),
+    Mob(Mob),
+}
+
+/// Worker staffing for a building, declared in the structure's own JSON sidecar
+/// (e.g. `data/structures/resource_buildings/woodcutter_hut.json`). `employment`
+/// is the job label shared by the whole crew (and tallied in the jobs summary);
+/// `looks` is the skin pool rolled per worker, so a shop's crew isn't uniform
+/// and can mix villager and mob skins; `workers` is the target crew size (capped
+/// by the stand cells actually available at placement). A building with no
+/// `staffing` block falls back to the town-wide default in `npcs.yaml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Staffing {
+    pub employment: String,
+    pub looks: Vec<NpcLook>,
+    pub workers: usize,
 }
 
 /// Escape a user string for embedding inside a double-quoted SNBT string.
@@ -279,6 +339,10 @@ pub async fn spawn_villager_npc(
 /// This is the villager-free counterpart to [`spawn_villager_npc`]: the same
 /// frozen (`NoAI`), named, faced, talking fixture, but for the colourful
 /// non-villager townsfolk that don't carry a biome or profession.
+///
+/// `y_offset` raises the mob's feet by a fractional block (e.g. `0.5` to stand a
+/// pillager guard on a battlement slab), matching [`spawn_villager_npc`]; `0.0`
+/// keeps the integer-grid spawn.
 pub async fn spawn_mob_npc(
     editor: &Editor,
     point: Point3D,
@@ -287,6 +351,7 @@ pub async fn spawn_mob_npc(
     dialogue: &str,
     mob: Mob,
     volume: DialogueVolume,
+    y_offset: f32,
 ) -> anyhow::Result<()> {
     // Frozen, named, and faced — same fixture treatment as a villager NPC.
     let mob_data = format!(
@@ -294,7 +359,13 @@ pub async fn spawn_mob_npc(
         escape_snbt(name),
         angle,
     );
-    editor.spawn_entity(mob.id(), point, Some(&mob_data)).await?;
+    if y_offset != 0.0 {
+        editor
+            .spawn_entity_offset(mob.id(), point, y_offset, Some(&mob_data))
+            .await?;
+    } else {
+        editor.spawn_entity(mob.id(), point, Some(&mob_data)).await?;
+    }
 
     spawn_dialogue_bubble(editor, point, angle, dialogue, volume, false).await
 }

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -47,9 +47,9 @@ const YELL_RAISE: f32 = 0.0;
 const YELL_COLOR: &str = "#FFE9A8";
 const YELL_LINE_WIDTH: i32 = 220;
 const YELL_SCALE: f32 = 1.05;
-/// ~38 blocks (`view_range * 64`): a yell carries clear across the plaza, long
-/// before the player is close enough to read a normal bubble.
-const YELL_VIEW_RANGE: f32 = 0.6;
+/// ~10 blocks (`view_range * 64`): a yell carries noticeably further than a
+/// normal close-range aside, but still only reads once the player is fairly near.
+const YELL_VIEW_RANGE: f32 = 0.16;
 
 /// How loudly an NPC's dialogue bubble reads. `Normal` is a quiet, close-range
 /// aside; `Yelled` is a big, bold, far-visible shout for market criers and stage
@@ -171,6 +171,36 @@ impl Profession {
     }
 }
 
+/// A non-villager townsfolk mob we can drop in as a static fixture, the same way
+/// as [`spawn_villager_npc`] but without the villager-specific biome/profession.
+/// Witches and wandering traders are the colourful background characters that
+/// make a town feel lived-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mob {
+    Witch,
+    WanderingTrader,
+    Evoker,
+    Pillager,
+    Vindicator,
+    Husk,
+    ZombieVillager,
+}
+
+impl Mob {
+    /// The `minecraft:`-namespaced entity id passed to [`Editor::spawn_entity`].
+    pub fn id(self) -> &'static str {
+        match self {
+            Mob::Witch => "minecraft:witch",
+            Mob::WanderingTrader => "minecraft:wandering_trader",
+            Mob::Evoker => "minecraft:evoker",
+            Mob::Pillager => "minecraft:pillager",
+            Mob::Vindicator => "minecraft:vindicator",
+            Mob::Husk => "minecraft:husk",
+            Mob::ZombieVillager => "minecraft:zombie_villager",
+        }
+    }
+}
+
 /// Escape a user string for embedding inside a double-quoted SNBT string.
 fn escape_snbt(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
@@ -186,6 +216,10 @@ fn escape_snbt(s: &str) -> String {
 /// persistent, queryable record of which house it came from (residents have one;
 /// workplace/plaza fixtures pass `None`).
 ///
+/// `child`, when true, spawns a baby villager: `Age` is pinned to the most
+/// negative value so it never grows up (baby `Age` ticks toward 0; starting at
+/// `i32::MIN` keeps it a child for any realistic run).
+///
 /// The villager has `NoAI` so it won't wander or turn, and `CustomNameVisible`
 /// so the name tag always shows. The bubble is a center-billboarded
 /// `text_display`, so it always rotates to face the player.
@@ -199,6 +233,8 @@ pub async fn spawn_villager_npc(
     profession: Profession,
     volume: DialogueVolume,
     home: Option<usize>,
+    child: bool,
+    y_offset: f32,
 ) -> anyhow::Result<()> {
     // The villager itself: frozen, named, faced, and skinned by biome/profession.
     // level:1 so a working profession shows its job outfit (level 0 reads as none).
@@ -207,22 +243,71 @@ pub async fn spawn_villager_npc(
         Some(id) => format!(",Tags:[\"home_{id}\"]"),
         None => String::new(),
     };
+    // Babies start at the most negative Age so they never visibly grow up.
+    let age_tag = if child { format!(",Age:{}", i32::MIN) } else { String::new() };
     let villager_data = format!(
         "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f],\
-         VillagerData:{{type:\"{}\",profession:\"{}\",level:1}}{}}}",
+         VillagerData:{{type:\"{}\",profession:\"{}\",level:1}}{}{}}}",
         escape_snbt(name),
         angle,
         biome.id(),
         profession.id(),
+        age_tag,
         home_tag,
     );
-    editor
-        .spawn_entity("minecraft:villager", point, Some(&villager_data))
-        .await?;
+    // Raise onto a slab top (e.g. a tower battlement) when asked; otherwise keep
+    // the integer-grid spawn so ground NPCs are unchanged.
+    if y_offset != 0.0 {
+        editor
+            .spawn_entity_offset("minecraft:villager", point, y_offset, Some(&villager_data))
+            .await?;
+    } else {
+        editor
+            .spawn_entity("minecraft:villager", point, Some(&villager_data))
+            .await?;
+    }
 
-    // The dialogue bubble: a text display hovering above the head, styled by how
-    // loud the line is (a quiet aside vs. a far-carrying yell). The transformation
-    // nudges it up a fractional block (entity coords are integer).
+    spawn_dialogue_bubble(editor, point, angle, dialogue, volume).await
+}
+
+/// Spawn a stationary mob NPC (e.g. a [`Mob::Witch`] or [`Mob::WanderingTrader`])
+/// at build-area-local `point` (its feet), facing `angle`, with a `name` tag and
+/// a `dialogue` bubble floating above its head.
+///
+/// This is the villager-free counterpart to [`spawn_villager_npc`]: the same
+/// frozen (`NoAI`), named, faced, talking fixture, but for the colourful
+/// non-villager townsfolk that don't carry a biome or profession.
+pub async fn spawn_mob_npc(
+    editor: &Editor,
+    point: Point3D,
+    angle: f32,
+    name: &str,
+    dialogue: &str,
+    mob: Mob,
+    volume: DialogueVolume,
+) -> anyhow::Result<()> {
+    // Frozen, named, and faced — same fixture treatment as a villager NPC.
+    let mob_data = format!(
+        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f]}}",
+        escape_snbt(name),
+        angle,
+    );
+    editor.spawn_entity(mob.id(), point, Some(&mob_data)).await?;
+
+    spawn_dialogue_bubble(editor, point, angle, dialogue, volume).await
+}
+
+/// Spawn the dialogue bubble: a `text_display` hovering above an NPC's head,
+/// styled by how loud the line is (a quiet aside vs. a far-carrying yell). The
+/// transformation nudges it up a fractional block (entity coords are integer).
+/// Shared by [`spawn_villager_npc`] and [`spawn_mob_npc`].
+async fn spawn_dialogue_bubble(
+    editor: &Editor,
+    point: Point3D,
+    angle: f32,
+    dialogue: &str,
+    volume: DialogueVolume,
+) -> anyhow::Result<()> {
     let style = volume.style();
     let bubble = point + Point3D::new(0, style.height, 0);
     let bubble_data = format!(
@@ -283,6 +368,8 @@ mod tests {
             Profession::Butcher,
             DialogueVolume::Normal,
             Some(0),
+            false,
+            0.0,
         )
         .await
         .expect("failed to spawn NPC");

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -98,23 +98,6 @@ impl DialogueVolume {
     }
 }
 
-/// The name tag is rendered as its own `text_display` rather than the villager's
-/// built-in `CustomNameVisible` tag, so it can fade with distance like the
-/// dialogue bubble — a vanilla name tag otherwise shows from far off (and
-/// through walls) at a fixed client distance, with no per-entity range. These
-/// tune the floating name: it sits just above the head, below the bubble.
-const NAME_HEIGHT: i32 = 2;
-const NAME_RAISE: f32 = 0.0;
-
-/// Uniform scale of the name tag (1.0 = vanilla size). A touch smaller than
-/// default so it reads as a tidy floating tag.
-const NAME_SCALE: f32 = 0.5;
-
-/// Render distance of the name tag, same `view_range * 64` blocks rule as the
-/// dialogue bubble. A touch further than [`DIALOGUE_VIEW_RANGE`] so the name
-/// fades in just before the dialogue does as the player approaches.
-const NAME_VIEW_RANGE: f32 = 0.05;
-
 /// The villager's biome "type" — the skin/outfit variant. These are the seven
 /// vanilla villager types. See <https://minecraft.wiki/w/Villager>.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -203,11 +186,9 @@ fn escape_snbt(s: &str) -> String {
 /// persistent, queryable record of which house it came from (residents have one;
 /// workplace/plaza fixtures pass `None`).
 ///
-/// The villager has `NoAI` so it won't wander or turn. Its `CustomName` is kept
-/// for identity (and the vanilla look-at hover) but not always-visible; the tag
-/// the player sees is a separate `text_display` with a `view_range`, so it (like
-/// the dialogue bubble) only shows once the player is near. Both displays are
-/// center-billboarded, so they always rotate to face the player.
+/// The villager has `NoAI` so it won't wander or turn, and `CustomNameVisible`
+/// so the name tag always shows. The bubble is a center-billboarded
+/// `text_display`, so it always rotates to face the player.
 pub async fn spawn_villager_npc(
     editor: &Editor,
     point: Point3D,
@@ -227,7 +208,7 @@ pub async fn spawn_villager_npc(
         None => String::new(),
     };
     let villager_data = format!(
-        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:0b,Rotation:[{}f,0f],\
+        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f],\
          VillagerData:{{type:\"{}\",profession:\"{}\",level:1}}{}}}",
         escape_snbt(name),
         angle,
@@ -237,23 +218,6 @@ pub async fn spawn_villager_npc(
     );
     editor
         .spawn_entity("minecraft:villager", point, Some(&villager_data))
-        .await?;
-
-    // The name tag: its own text_display, just above the head, so it fades with
-    // distance instead of showing from across the map like the built-in tag.
-    let tag = point + Point3D::new(0, NAME_HEIGHT, 0);
-    let tag_data = format!(
-        "{{text:{{text:\"{}\"}},billboard:\"center\",alignment:\"center\",view_range:{}f,\
-         transformation:{{translation:[0f,{}f,0f],scale:[{s}f,{s}f,{s}f],left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f]}},\
-         Rotation:[{}f,0f]}}",
-        escape_snbt(name),
-        NAME_VIEW_RANGE,
-        NAME_RAISE,
-        angle,
-        s = NAME_SCALE,
-    );
-    editor
-        .spawn_entity("minecraft:text_display", tag, Some(&tag_data))
         .await?;
 
     // The dialogue bubble: a text display hovering above the head, styled by how

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -307,8 +307,10 @@ pub async fn spawn_villager_npc(
     };
     // Babies start at the most negative Age so they never visibly grow up.
     let age_tag = if child { format!(",Age:{}", i32::MIN) } else { String::new() };
+    // `Invulnerable` so a fixture never dies — no suffocation if it ends up a
+    // hair inside a block, no mob/fire/fall damage in a persistent town.
     let villager_data = format!(
-        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f],\
+        "{{NoAI:1b,Invulnerable:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f],\
          VillagerData:{{type:\"{}\",profession:\"{}\",level:1}}{}{}}}",
         escape_snbt(name),
         angle,
@@ -353,9 +355,10 @@ pub async fn spawn_mob_npc(
     volume: DialogueVolume,
     y_offset: f32,
 ) -> anyhow::Result<()> {
-    // Frozen, named, and faced — same fixture treatment as a villager NPC.
+    // Frozen, named, faced, and invulnerable — same fixture treatment as a
+    // villager NPC (see `spawn_villager_npc` for why `Invulnerable`).
     let mob_data = format!(
-        "{{NoAI:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f]}}",
+        "{{NoAI:1b,Invulnerable:1b,CustomName:{{text:\"{}\"}},CustomNameVisible:1b,Rotation:[{}f,0f]}}",
         escape_snbt(name),
         angle,
     );

--- a/src/generator/open_space/mod.rs
+++ b/src/generator/open_space/mod.rs
@@ -279,30 +279,6 @@ fn cull_thin(green: &HashSet<Point2D>) -> HashSet<Point2D> {
 /// become the watershed cuts that split sprawling regions apart.
 const CORE_MIN_DIST: i32 = 2;
 
-/// Multi-source BFS distance of every green cell from the nearest non-green
-/// boundary (boundary-adjacent cells are 0).
-fn boundary_distance(green: &HashSet<Point2D>) -> HashMap<Point2D, i32> {
-    let mut dist: HashMap<Point2D, i32> = HashMap::new();
-    let mut queue: VecDeque<Point2D> = VecDeque::new();
-    for &c in green {
-        if CARDINALS_2D.iter().any(|d| !green.contains(&(c + *d))) {
-            dist.insert(c, 0);
-            queue.push_back(c);
-        }
-    }
-    while let Some(c) = queue.pop_front() {
-        let dc = dist[&c];
-        for d in CARDINALS_2D {
-            let n = c + d;
-            if green.contains(&n) && !dist.contains_key(&n) {
-                dist.insert(n, dc + 1);
-                queue.push_back(n);
-            }
-        }
-    }
-    dist
-}
-
 /// Flood the cells reachable from `start` within `allowed` that aren't already
 /// labelled, tagging them `id` in `label`.
 fn flood_label(
@@ -330,7 +306,9 @@ fn flood_label(
 /// nearest core. Sprawling shapes split at their necks; coreless components
 /// (uniformly thin blobs) stay whole.
 fn partition_cells(green: &HashSet<Point2D>) -> Vec<Vec<Point2D>> {
-    let dist = boundary_distance(green);
+    // Multi-source BFS distance of every green cell from the nearest non-green
+    // boundary (boundary-adjacent cells are 0) — the canonical impl in `props`.
+    let dist = props::edge_depth(green);
 
     // Cores: cells deep enough to be a lobe centre.
     let core: HashSet<Point2D> = green

--- a/src/generator/open_space/park.rs
+++ b/src/generator/open_space/park.rs
@@ -451,7 +451,7 @@ async fn furnish_lawn(
         if grand_tree {
             if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
                 lay_soil_patch(editor, centre, h).await;
-                let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y)).await;
+                let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
             } else {
                 place_monument(editor, centre, h, theme).await;
             }
@@ -533,7 +533,7 @@ async fn furnish_zen(
         if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
             let h = world.get_ocean_floor_height_at(centre);
             lay_soil_patch(editor, centre, h).await;
-            let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y)).await;
+            let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
             used.insert(centre);
             for d in CARDINALS_2D {
                 used.insert(centre + d);
@@ -689,7 +689,7 @@ async fn furnish_cactus(
         }
         let h = world.get_ocean_floor_height_at(c);
         // Grow the cactus through the Tree system; it lays its own sand footing.
-        let _ = generate_tree_feature(Tree::Cactus, editor, Point3D::new(c.x, h, c.y)).await;
+        let _ = generate_tree_feature(Tree::Cactus, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
         // Keep the four sides clear so the cactus survives the next tick.
         for d in CARDINALS_2D {
@@ -866,7 +866,7 @@ async fn scatter_trees(
         };
         let h = world.get_ocean_floor_height_at(c);
         lay_soil_patch(editor, c, h).await;
-        let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y)).await;
+        let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
         for d in CARDINALS_2D {
             used.insert(c + d);

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -11,13 +11,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::editor::Editor;
 use crate::generator::npc::DialogueVolume;
-use crate::generator::population::{yaw_toward, AnchorScene, SlotRole};
+use crate::generator::population::{yaw_toward, AnchorScene, AnchorSlot, SceneKind, SlotRole};
 use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
 use crate::noise::RNG;
 
 use super::props::{
-    chebyshev, edge_depth, flatten_blend, inward_dir, is_building, is_path, place_bench,
-    place_lantern_post, place_planter, place_tree, put, put_forced,
+    cardinal_facing, chebyshev, edge_depth, flatten_blend, inward_dir, is_building, is_path,
+    place_bench, place_lantern_post, place_planter, place_tree, put, put_forced,
 };
 use super::theme::Theme;
 use super::Region;
@@ -262,19 +262,35 @@ async fn furnish_plaza_inner(
         PlazaType::Fountain => build_fountain(editor, centre, centre_h, theme).await,
         PlazaType::Monument => build_monument(editor, centre, centre_h, radius >= 1, theme).await,
         PlazaType::Stage => {
-            build_stage(editor, centre, centre_h, theme).await;
-            // A performer up on the deck, calling out over the square. The deck
+            // Orient the stage toward the largest open stretch of the square, so
+            // the troupe plays to as much of the plaza as possible. `front` is the
+            // cardinal with the most plaza cells ahead of the centre — the side the
+            // audience gathers on, and the way the performers (and the stage's
+            // front step) face.
+            let front = stage_front(region, centre);
+            build_stage(editor, centre, centre_h, front, theme).await;
+            // A troupe up on the deck, calling out over the square. The deck
             // planks sit at `centre_h + 1`, so feet stand on top at `centre_h + 2`.
-            // Face north (−z), out over the audience away from the back-rail.
-            let feet = Point3D::new(centre.x, centre_h + 2, centre.y);
-            let facing = yaw_toward(feet, feet + Point3D::new(0, 0, -8));
-            scenes.push(AnchorScene::solo_with(
-                feet,
-                facing,
-                SlotRole::Idle,
-                Some("performing".to_string()),
-                DialogueVolume::Yelled,
-            ));
+            // The stage rolls its own cast — a solo act, a duet, or a trio — and
+            // `staff_scene` then draws a `performing` script with that many lines
+            // (see `NpcData::exchange_of_len`). The cast stands in a row across the
+            // deck (perpendicular to `front`), all facing `front` out over the
+            // audience.
+            let perp = Point2D::new(-front.y, front.x);
+            let cast = *rng.choose(&[1, 2, 3]);
+            let slots = (0..cast)
+                .map(|i| {
+                    let off = i - cast / 2;
+                    let stand = centre + Point2D::new(perp.x * off, perp.y * off);
+                    let feet = Point3D::new(stand.x, centre_h + 2, stand.y);
+                    let facing = yaw_toward(feet, feet + Point3D::new(front.x * 8, 0, front.y * 8));
+                    let mut slot = AnchorSlot::new(feet, facing, SlotRole::Idle);
+                    slot.dialogue = Some("performing".to_string());
+                    slot.volume = DialogueVolume::Yelled;
+                    slot
+                })
+                .collect();
+            scenes.push(AnchorScene::group(SceneKind::Performance, slots));
         }
         // A market has no centrepiece — it's defined by its U-shaped stalls,
         // placed below across the whole open floor.
@@ -656,38 +672,67 @@ async fn build_cart(editor: &Editor, base: Point2D, perp: Point2D, dir: Point2D,
     put(editor, handle.x, h, handle.y, &fence).await;
 }
 
+/// The cardinal direction a stage should face: the one with the most plaza cells
+/// ahead of the centre, so the troupe plays to the largest part of the square.
+/// Falls back to north (−z) for a perfectly symmetric plaza.
+fn stage_front(region: &Region, centre: Point2D) -> Point2D {
+    CARDINALS_2D
+        .iter()
+        .copied()
+        .max_by_key(|d| {
+            region
+                .cells
+                .iter()
+                .filter(|p| (p.x - centre.x) * d.x + (p.y - centre.y) * d.y > 0)
+                .count()
+        })
+        .unwrap_or(Point2D::new(0, -1))
+}
+
 /// A raised performance stage: a wooden 5×5 deck on fence legs (open
-/// underneath), a low back-rail, and a step up at the front. `h` is the first
-/// air cell above the (flat) centre paving.
-async fn build_stage(editor: &Editor, c: Point2D, h: i32, theme: &Theme) {
+/// underneath), a low back-rail, and an access staircase up one side. `h` is the
+/// first air cell above the (flat) centre paving. `front` is the cardinal
+/// direction the stage faces — the audience sits on this side and the performers
+/// look out over it; the back-rail is opposite, and the access stairs climb the
+/// deck's side so they never block the front.
+async fn build_stage(editor: &Editor, c: Point2D, h: i32, front: Point2D, theme: &Theme) {
     let pr = 2; // deck half-side: always a 5×5 deck
+    // Local axes: `front`/`back` run front-to-back, `perp` spans the width.
+    let perp = Point2D::new(-front.y, front.x);
+    let cell = |i: i32, j: i32| Point2D::new(c.x + perp.x * i + front.x * j, c.y + perp.y * i + front.y * j);
     let fence = format!("minecraft:{}_fence", theme.wood);
     let deck = format!("minecraft:{}_planks", theme.wood);
-    // Front-edge deck cells are stairs (rising toward the back) so the access step
-    // climbs cleanly onto the deck instead of butting against a full block.
-    let lip = format!("minecraft:{}_stairs[facing=north,half=bottom]", theme.wood);
     // Legs on the perimeter at floor level; plank deck one block up across the
-    // whole footprint (the interior is left open, held by the deck above).
-    for dx in -pr..=pr {
-        for dz in -pr..=pr {
-            let (x, z) = (c.x + dx, c.y + dz);
-            if dx.abs() == pr || dz.abs() == pr {
-                put(editor, x, h, z, &fence).await;
+    // whole footprint (the interior is left open, held by the deck above). `j`
+    // runs back (−pr) to front (+pr); `i` spans the width.
+    for i in -pr..=pr {
+        for j in -pr..=pr {
+            let p = cell(i, j);
+            if i.abs() == pr || j.abs() == pr {
+                put(editor, p.x, h, p.y, &fence).await;
             }
-            let top = if dz == pr { &lip } else { &deck };
-            put(editor, x, h + 1, z, top).await;
+            put(editor, p.x, h + 1, p.y, &deck).await;
         }
     }
     // Low back-rail along the far edge, with lanterns on its corners.
-    for dx in -pr..=pr {
-        put(editor, c.x + dx, h + 2, c.y - pr, &fence).await;
+    for i in -pr..=pr {
+        let p = cell(i, -pr);
+        put(editor, p.x, h + 2, p.y, &fence).await;
     }
-    for &dx in &[-pr, pr] {
-        put(editor, c.x + dx, h + 3, c.y - pr, "minecraft:lantern").await;
+    for &i in &[-pr, pr] {
+        let p = cell(i, -pr);
+        put(editor, p.x, h + 3, p.y, "minecraft:lantern").await;
     }
-    // A step up at the front edge: a stair just outside the deck, facing in.
-    let stair = format!("minecraft:{}_stairs[facing=north,half=bottom]", theme.wood);
-    put(editor, c.x, h, c.y + pr + 1, &stair).await;
+    // Access staircase up the `+perp` side: a two-step climb (ground stair just
+    // outside the deck, then the deck-edge cell turned into a stair) rising toward
+    // the deck centre, so the performers' front stays clear.
+    let side = perp; // the side the stairs climb (arbitrary; either flank works)
+    let toward_deck = Point2D::new(-side.x, -side.y);
+    let step = format!("minecraft:{}_stairs[facing={},half=bottom]", theme.wood, cardinal_facing(toward_deck));
+    let upper = cell(pr, 0); // deck-edge cell → stair up to deck level
+    let lower = cell(pr + 1, 0); // one cell out, sitting on the paving
+    put(editor, upper.x, h + 1, upper.y, &step).await;
+    put(editor, lower.x, h, lower.y, &step).await;
 }
 
 /// 3×3 covered well centred at `c`; `h` is the first air cell above the paving.

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -10,7 +10,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::editor::Editor;
-use crate::geometry::{Point2D, CARDINALS_2D};
+use crate::generator::npc::DialogueVolume;
+use crate::generator::population::{yaw_toward, AnchorScene, SlotRole};
+use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
 use crate::noise::RNG;
 
 use super::props::{
@@ -97,14 +99,16 @@ fn centre_cell(region: &Region, cells: &HashSet<Point2D>) -> (Point2D, i32) {
 }
 
 /// Furnish one plaza region in place, returning the [`PlazaType`] it was built
-/// as (so the caller can name it for what it is). The type is rolled from the
-/// open room at the centre.
+/// as (so the caller can name it for what it is) plus the NPC standing-spot
+/// scenes it offers — a stage performer, market vendors at their stalls, and a
+/// scatter of onlookers in the crowd. The type is rolled from the open room at
+/// the centre. The caller staffs the scenes via the population pass.
 pub async fn furnish_plaza(
     editor: &Editor,
     region: &Region,
     rng: &mut RNG,
     theme: &Theme,
-) -> PlazaType {
+) -> (PlazaType, Vec<AnchorScene>) {
     furnish_plaza_inner(editor, region, rng, theme, None).await
 }
 
@@ -117,7 +121,7 @@ pub(crate) async fn furnish_plaza_as(
     rng: &mut RNG,
     theme: &Theme,
     plaza_type: PlazaType,
-) -> PlazaType {
+) -> (PlazaType, Vec<AnchorScene>) {
     furnish_plaza_inner(editor, region, rng, theme, Some(plaza_type)).await
 }
 
@@ -127,7 +131,7 @@ async fn furnish_plaza_inner(
     rng: &mut RNG,
     theme: &Theme,
     forced: Option<PlazaType>,
-) -> PlazaType {
+) -> (PlazaType, Vec<AnchorScene>) {
     let world = editor.world();
     let cells: HashSet<Point2D> = region.cells.iter().copied().collect();
     let height_at = |c: Point2D| world.get_ocean_floor_height_at(c);
@@ -214,12 +218,17 @@ async fn furnish_plaza_inner(
     }
 
     let mut used: HashSet<Point2D> = HashSet::new();
+    // NPC scenes this plaza offers, staffed later by the population pass.
+    let mut scenes: Vec<AnchorScene> = Vec::new();
 
     // --- Centrepiece on the most-interior cell. ---
     // Bigger squares unlock the roomier types; a cramped centre falls back to a
     // monument, the only piece that fits a single cell. The centre and its
     // footprint are measured within the flat plateau so the structure sits level.
     let (centre, radius) = centre_cell(region, &flat);
+    // Yaw for an NPC at `feet` looking toward the plaza centre — the shared focal
+    // point that market vendors and onlookers all orient on.
+    let face_centre = |feet: Point3D| yaw_toward(feet, Point3D::new(centre.x, feet.y, centre.y));
     // A forced type still needs to fit: the 5×5 fountain and the 5×5 stage need
     // radius ≥ 2, the other built pieces radius ≥ 1; anything tighter falls back
     // to a monument.
@@ -252,7 +261,21 @@ async fn furnish_plaza_inner(
         PlazaType::Well => build_well(editor, centre, centre_h, theme).await,
         PlazaType::Fountain => build_fountain(editor, centre, centre_h, theme).await,
         PlazaType::Monument => build_monument(editor, centre, centre_h, radius >= 1, theme).await,
-        PlazaType::Stage => build_stage(editor, centre, centre_h, theme).await,
+        PlazaType::Stage => {
+            build_stage(editor, centre, centre_h, theme).await;
+            // A performer up on the deck, calling out over the square. The deck
+            // planks sit at `centre_h + 1`, so feet stand on top at `centre_h + 2`.
+            // Face north (−z), out over the audience away from the back-rail.
+            let feet = Point3D::new(centre.x, centre_h + 2, centre.y);
+            let facing = yaw_toward(feet, feet + Point3D::new(0, 0, -8));
+            scenes.push(AnchorScene::solo_with(
+                feet,
+                facing,
+                SlotRole::Idle,
+                Some("performing".to_string()),
+                DialogueVolume::Yelled,
+            ));
+        }
         // A market has no centrepiece — it's defined by its U-shaped stalls,
         // placed below across the whole open floor.
         PlazaType::Market => {}
@@ -356,6 +379,19 @@ async fn furnish_plaza_inner(
                 used.insert(p);
             }
             stalls.push(mouth);
+
+            // The vendor stands inside the U, one cell back from the mouth, so
+            // they look out over the front counter toward the square — and hawk
+            // their wares with a yelled line that carries across the market.
+            let stand = mouth + out;
+            let feet = Point3D::new(stand.x, surf[&mouth] + 1, stand.y);
+            scenes.push(AnchorScene::solo_with(
+                feet,
+                face_centre(feet),
+                SlotRole::Worker,
+                Some("market_cry".to_string()),
+                DialogueVolume::Yelled,
+            ));
         }
 
         // --- A cart parked on the floor, if one fits. Footprint: 2-cell bed
@@ -415,7 +451,43 @@ async fn furnish_plaza_inner(
         }
     }
 
-    plaza_type
+    // --- Crowd: a few idle onlookers milling on the open floor of the busy
+    // social squares (markets and the stage), each facing the centre — browsing
+    // the stalls or watching the performer. Quieter squares (fountain, well,
+    // monument) stay empty of standers. Cells are interior (fully surrounded by
+    // paving), clear of structures, and not against a road entrance. ---
+    if matches!(plaza_type, PlazaType::Market | PlazaType::Stage) {
+        let mut crowd_cells: Vec<Point2D> = flat
+            .iter()
+            .copied()
+            .filter(|&c| c != centre && !used.contains(&c))
+            .filter(|&c| CARDINALS_2D.iter().all(|d| flat.contains(&(c + *d))))
+            .filter(|&c| !CARDINALS_2D.iter().any(|d| is_path(world.get_claim(c + *d).as_ref())))
+            .collect();
+        rng.shuffle(&mut crowd_cells);
+        let crowd_target = (region.area / 50).clamp(2, 5);
+        let mut crowd: Vec<Point2D> = Vec::new();
+        for &c in &crowd_cells {
+            if crowd.len() >= crowd_target as usize {
+                break;
+            }
+            if crowd.iter().any(|p| chebyshev(*p, c) < 3) {
+                continue;
+            }
+            let feet = Point3D::new(c.x, surf[&c] + 1, c.y);
+            scenes.push(AnchorScene::solo_with(
+                feet,
+                face_centre(feet),
+                SlotRole::Idle,
+                Some("browsing".to_string()),
+                DialogueVolume::Normal,
+            ));
+            used.insert(c);
+            crowd.push(c);
+        }
+    }
+
+    (plaza_type, scenes)
 }
 
 /// Unit cardinal step from `from` toward `to`, biased to the longer axis so a

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -11,7 +11,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::editor::Editor;
 use crate::generator::npc::DialogueVolume;
-use crate::generator::population::{yaw_toward, AnchorScene, AnchorSlot, SceneKind, SlotRole};
+use crate::generator::population::{
+    yaw_toward, AnchorScene, AnchorSlot, Occupant, SceneKind, SlotRole,
+};
 use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
 use crate::noise::RNG;
 
@@ -32,7 +34,7 @@ pub enum PlazaType {
     Fountain,
     /// 3×3 covered well: rim wall, water, corner posts, slab roof, hung lantern.
     Well,
-    /// Stepped plinth with a pillar and a lantern on top — a dry landmark.
+    /// Stepped plinth and a tall stone spire with a wall finial — a dry landmark.
     Monument,
     /// A raised wooden performance deck on fence legs, with back-rail and steps.
     Stage,
@@ -467,12 +469,20 @@ async fn furnish_plaza_inner(
         }
     }
 
-    // --- Crowd: a few idle onlookers milling on the open floor of the busy
-    // social squares (markets and the stage), each facing the centre — browsing
-    // the stalls or watching the performer. Quieter squares (fountain, well,
-    // monument) stay empty of standers. Cells are interior (fully surrounded by
-    // paving), clear of structures, and not against a road entrance. ---
-    if matches!(plaza_type, PlazaType::Market | PlazaType::Stage) {
+    // --- Crowd: idle folk gathered on the open floor, each facing the centre.
+    // Markets and stages draw the biggest crowds (shoppers, an audience); the
+    // quiet civic squares get a lighter scatter loitering at the well, fountain,
+    // or monument, with their own dialogue. Cells are interior (fully surrounded
+    // by paving), clear of structures, and not against a road entrance. ---
+    {
+        // Per-type character: how big the crowd is and what they're doing there.
+        let (browse_key, crowd_target) = match plaza_type {
+            PlazaType::Market => ("browsing", (region.area / 50).clamp(2, 5)),
+            PlazaType::Stage => ("browsing", (region.area / 50).clamp(2, 5)),
+            PlazaType::Fountain => ("by_the_fountain", (region.area / 70).clamp(2, 4)),
+            PlazaType::Well => ("at_the_well", (region.area / 80).clamp(1, 3)),
+            PlazaType::Monument => ("at_the_monument", (region.area / 90).clamp(1, 2)),
+        };
         let mut crowd_cells: Vec<Point2D> = flat
             .iter()
             .copied()
@@ -481,7 +491,6 @@ async fn furnish_plaza_inner(
             .filter(|&c| !CARDINALS_2D.iter().any(|d| is_path(world.get_claim(c + *d).as_ref())))
             .collect();
         rng.shuffle(&mut crowd_cells);
-        let crowd_target = (region.area / 50).clamp(2, 5);
         let mut crowd: Vec<Point2D> = Vec::new();
         for &c in &crowd_cells {
             if crowd.len() >= crowd_target as usize {
@@ -491,13 +500,22 @@ async fn furnish_plaza_inner(
                 continue;
             }
             let feet = Point3D::new(c.x, surf[&c] + 1, c.y);
-            scenes.push(AnchorScene::solo_with(
+            let mut scene = AnchorScene::solo_with(
                 feet,
                 face_centre(feet),
                 SlotRole::Idle,
-                Some("browsing".to_string()),
+                Some(browse_key.to_string()),
                 DialogueVolume::Normal,
-            ));
+            );
+            // Roughly a third of any crowd are children — kids tagging along,
+            // browsing the stalls, watching the show, or playing by the water.
+            // Marked `ChildOnly` so the plaza roster staffs them with an actual
+            // child (it mints exactly as many kids as there are such slots; see
+            // `build_roster`).
+            if rng.percent(34) {
+                scene.slots[0].occupant = Occupant::ChildOnly;
+            }
+            scenes.push(scene);
             used.insert(c);
             crowd.push(c);
         }
@@ -807,19 +825,38 @@ async fn build_fountain(editor: &Editor, c: Point2D, h: i32, theme: &Theme) {
 }
 
 /// Stepped plinth + pillar + lantern. `wide` builds a 3×3 base, else a 1×1.
+/// A tall spire: a stepped stone plinth, a slim worked-stone shaft, and a
+/// slender finial of wall blocks tapering to a point. Walls render as a thin
+/// central post, so the cap reads as a spike rather than a flat pillar — and
+/// there's no light on top. `wide` squares get a broader 3×3 base, a socle
+/// course, and a taller shaft than cramped ones.
 async fn build_monument(editor: &Editor, c: Point2D, h: i32, wide: bool, theme: &Theme) {
+    // Stepped plinth: a broad base, and (when there's room) a 1×1 accent socle
+    // the shaft rises from.
     if wide {
         for dx in -1..=1 {
             for dz in -1..=1 {
                 put(editor, c.x + dx, h, c.y + dz, theme.stone).await;
             }
         }
+        put(editor, c.x, h + 1, c.y, theme.stone_accent).await;
     } else {
         put(editor, c.x, h, c.y, theme.stone).await;
     }
-    let base = if wide { h + 1 } else { h };
-    put(editor, c.x, base, c.y, theme.stone_accent).await;
-    put(editor, c.x, base + 1, c.y, theme.stone).await;
-    put(editor, c.x, base + 2, c.y, theme.stone_accent).await;
-    put(editor, c.x, base + 3, c.y, "minecraft:lantern").await;
+
+    // Slim shaft of worked stone, tall enough to be seen across the square.
+    let shaft_base = if wide { h + 2 } else { h + 1 };
+    let shaft_height = if wide { 3 } else { 2 };
+    let shaft_top = shaft_base + shaft_height - 1;
+    for y in shaft_base..=shaft_top {
+        put(editor, c.x, y, c.y, theme.stone).await;
+    }
+
+    // Spire: an accent capital, then the shaft narrows into a slender needle of
+    // wall blocks tapering to a point (a thin post, not a full column).
+    put(editor, c.x, shaft_top + 1, c.y, theme.stone_accent).await;
+    let spire_height = 2;
+    for i in 1..=spire_height {
+        put(editor, c.x, shaft_top + 1 + i, c.y, theme.wall).await;
+    }
 }

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -7,7 +7,7 @@
 //! little greenery in the corners. The roomier types need a bigger open centre;
 //! a cramped plaza falls back to the single-cell monument.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 use crate::editor::Editor;
 use crate::generator::npc::DialogueVolume;
@@ -74,24 +74,9 @@ fn max_square_radius(cells: &HashSet<Point2D>, c: Point2D, limit: i32) -> i32 {
 /// The most-interior region cell (max distance from the perimeter), with the
 /// largest odd-square half-radius that fits there.
 fn centre_cell(region: &Region, cells: &HashSet<Point2D>) -> (Point2D, i32) {
-    let mut dist: HashMap<Point2D, i32> = HashMap::new();
-    let mut queue: VecDeque<Point2D> = VecDeque::new();
-    for &c in &region.cells {
-        if CARDINALS_2D.iter().any(|d| !cells.contains(&(c + *d))) {
-            dist.insert(c, 0);
-            queue.push_back(c);
-        }
-    }
-    while let Some(c) = queue.pop_front() {
-        let dc = dist[&c];
-        for d in CARDINALS_2D {
-            let n = c + d;
-            if cells.contains(&n) && !dist.contains_key(&n) {
-                dist.insert(n, dc + 1);
-                queue.push_back(n);
-            }
-        }
-    }
+    // Distance of each `cells` member from the perimeter; region cells outside
+    // `cells` (e.g. the stepped border) fall back to 0 and so never win.
+    let dist = edge_depth(cells);
     let centre = *region
         .cells
         .iter()

--- a/src/generator/open_space/props.rs
+++ b/src/generator/open_space/props.rs
@@ -159,7 +159,7 @@ pub(super) async fn place_tree(
         return false;
     };
     lay_soil_patch(editor, c, h).await;
-    let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y)).await;
+    let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y), rng).await;
     true
 }
 

--- a/src/generator/open_space/props.rs
+++ b/src/generator/open_space/props.rs
@@ -180,11 +180,22 @@ pub(super) async fn lay_soil_patch(editor: &Editor, c: Point2D, h: i32) {
     }
 }
 
-/// A bench (`wood` stairs) backed against a wall, seat facing `inward`.
+/// A two-wide bench (`wood` stairs) backed against a wall, seat facing `inward`.
+///
+/// A stair's solid riser sits on the side *opposite* its `facing`, so the bench
+/// faces away from the seated occupant: we face it outward (toward the wall) so
+/// the riser lands on the open side as a backrest. (Facing it `inward` puts the
+/// backrest against the wall and the seat the wrong way round.) A second stair is
+/// laid alongside, perpendicular to `inward`, so the bench is two blocks wide.
 pub(super) async fn place_bench(editor: &Editor, c: Point2D, h: i32, inward: Point2D, wood: &str) {
-    let block = string_to_block(&format!("minecraft:{}_stairs[facing={}]", wood, cardinal_facing(inward)))
+    let outward = Point2D::new(-inward.x, -inward.y);
+    let block = string_to_block(&format!("minecraft:{}_stairs[facing={}]", wood, cardinal_facing(outward)))
         .expect("bench stair block");
-    editor.place_block(&block, Point3D::new(c.x, h, c.y)).await;
+    // Extend one cell along the wall (perpendicular to inward) for a two-wide seat.
+    let along = Point2D::new(-inward.y, inward.x);
+    for cell in [c, c + along] {
+        editor.place_block(&block, Point3D::new(cell.x, h, cell.y)).await;
+    }
 }
 
 /// A planter: a `wood` base with a leafy azalea on top.

--- a/src/generator/open_space/test.rs
+++ b/src/generator/open_space/test.rs
@@ -56,6 +56,11 @@ async fn plaza_types_gallery() {
         types.len(),
     );
 
+    // NPC scenes harvested from every plot, staffed in one pass after the grid
+    // is built so the gallery shows the stage performers, market vendors, and
+    // onlookers in place.
+    let mut all_scenes: Vec<crate::generator::population::AnchorScene> = Vec::new();
+
     println!("\n=== Plaza gallery: {COPIES} of each type ===");
     for (row, &t) in types.iter().enumerate() {
         let bz = MARGIN + row as i32 * STRIDE;
@@ -79,7 +84,8 @@ async fn plaza_types_gallery() {
             // A monument fallback means the plot's terrain left too small a flat
             // plateau for that type (e.g. a 5×5 fountain on bumpy ground); flag it
             // rather than panic, so the rest of the gallery still builds.
-            let built = furnish_plaza_as(&editor, &region, &mut rng, &theme, t).await;
+            let (built, scenes) = furnish_plaza_as(&editor, &region, &mut rng, &theme, t).await;
+            all_scenes.extend(scenes);
             let c = region.centroid();
             let (wx, wz) = (origin.x + c.x, origin.z + c.y); // absolute centre for /tp
             if built == t {
@@ -91,6 +97,26 @@ async fn plaza_types_gallery() {
         println!();
     }
     println!("=== end gallery — each row above is one type; /tp to any centre ===\n");
+
+    // Flush the blocks first so the NPCs spawn into finished plazas (entities
+    // bypass the block buffer, so a stale buffer would otherwise drop them onto
+    // not-yet-placed paving).
+    editor.flush_buffer().await;
+
+    // Staff the harvested anchors: vendors at stalls, a performer on each stage,
+    // a scatter of onlookers in the crowd. Roster supplies names/dialogue/biome.
+    use crate::generator::population::{build_roster, populate_npcs, NpcData};
+    let scene_count = all_scenes.len();
+    match NpcData::load() {
+        Ok(data) => {
+            let roster = build_roster(scene_count, Culture::Desert, &data, &mut rng.derive());
+            let placed = populate_npcs(&editor, all_scenes, roster, scene_count, &data, &mut rng)
+                .await
+                .expect("populate plaza NPCs");
+            println!("Spawned {placed} plaza NPCs across the gallery");
+        }
+        Err(e) => println!("skipped NPC staffing (npcs.yaml load failed: {e})"),
+    }
 
     editor.flush_buffer().await;
 }

--- a/src/generator/open_space/test.rs
+++ b/src/generator/open_space/test.rs
@@ -105,11 +105,13 @@ async fn plaza_types_gallery() {
 
     // Staff the harvested anchors: vendors at stalls, a performer on each stage,
     // a scatter of onlookers in the crowd. Roster supplies names/dialogue/biome.
-    use crate::generator::population::{build_roster, populate_npcs, NpcData};
+    use crate::generator::population::{build_roster, populate_npcs, IdAllocator, NpcData};
     let scene_count = all_scenes.len();
     match NpcData::load() {
         Ok(data) => {
-            let roster = build_roster(scene_count, Culture::Desert, &data, &mut rng.derive());
+            let mut id_alloc = IdAllocator::new();
+            let roster =
+                build_roster(scene_count, Culture::Desert, &data, &mut id_alloc, &mut rng.derive());
             let placed = populate_npcs(&editor, all_scenes, roster, scene_count, &data, &mut rng)
                 .await
                 .expect("populate plaza NPCs");

--- a/src/generator/open_space/test.rs
+++ b/src/generator/open_space/test.rs
@@ -105,13 +105,18 @@ async fn plaza_types_gallery() {
 
     // Staff the harvested anchors: vendors at stalls, a performer on each stage,
     // a scatter of onlookers in the crowd. Roster supplies names/dialogue/biome.
-    use crate::generator::population::{build_roster, populate_npcs, IdAllocator, NpcData};
+    use crate::generator::population::{build_roster, populate_npcs, IdAllocator, NpcData, Occupant};
     let scene_count = all_scenes.len();
     match NpcData::load() {
         Ok(data) => {
             let mut id_alloc = IdAllocator::new();
+            let kids = all_scenes
+                .iter()
+                .flat_map(|s| &s.slots)
+                .filter(|sl| sl.occupant == Occupant::ChildOnly)
+                .count();
             let roster =
-                build_roster(scene_count, Culture::Desert, &data, &mut id_alloc, &mut rng.derive());
+                build_roster(scene_count, kids, Culture::Desert, &data, &mut id_alloc, &mut rng.derive());
             let placed = populate_npcs(&editor, all_scenes, roster, scene_count, &data, &mut rng)
                 .await
                 .expect("populate plaza NPCs");

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -25,12 +25,13 @@
 //! Generation runs in four passes:
 //!   1. [`build_households`] — open-shape households, sized to bed budget,
 //!      with intra-household kin (parent↔child, spouse↔spouse, sibling↔sibling)
-//!      wired reciprocally. `profession: None` everywhere.
+//!      wired reciprocally. Everyone starts a plain, unemployed villager.
 //!   2. [`link_cross_household`] — in-laws, married-out siblings, adult
 //!      children whose parents live elsewhere. All edges reciprocal.
-//!   3. [`assign_employment`] — fills `profession` for adults (children stay
-//!      None; elders mostly retire). v1 rolls random trades; future passes
-//!      will consume a workplace jobs board.
+//!   3. [`assign_employment`] — sets each adult's `look` (villager outfit) and
+//!      `employment` (the job it implies); children stay plain villagers, elders
+//!      mostly retire. v1 rolls random trades; future passes will consume a
+//!      workplace jobs board.
 //!   4. [`populate_town`] — the existing seeded + weighted anchor draw, but
 //!      the per-house pool now reads from `population.households[h].members`.
 
@@ -43,10 +44,12 @@ use crate::editor::Editor;
 use crate::generator::buildings_v2::footprint::SizeClass;
 use crate::generator::buildings_v2::Culture;
 use crate::generator::nbts::{Structure, StructureType};
-use crate::geometry::Point3D;
+use crate::geometry::{Point2D, Point3D};
 use crate::noise::RNG;
 
-use super::npc::{spawn_villager_npc, DialogueVolume, Profession, VillagerBiome};
+use super::npc::{
+    spawn_mob_npc, spawn_villager_npc, DialogueVolume, NpcLook, Profession, Staffing, VillagerBiome,
+};
 
 /// How much more a multi-person scene weighs than a solo one, per person. A
 /// two-slot scene starts at `2 * BOOST`, so conversations and tables are picked
@@ -71,6 +74,25 @@ pub enum SlotRole {
     Idle,
 }
 
+/// Which age of NPC may fill a slot. Deserialized from furniture `anchors:`
+/// specs (snake_case: `adult_only`, `any_age`, `child_only`). Defaults to
+/// `AdultOnly`: most posts are adult work (anvils, stalls, guard posts), so a
+/// slot opts *into* children. Mark domestic and social slots `any_age`, and
+/// child-led scenes (playing in the yard) `child_only`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Occupant {
+    AdultOnly,
+    AnyAge,
+    ChildOnly,
+}
+
+impl Default for Occupant {
+    fn default() -> Self {
+        Occupant::AdultOnly
+    }
+}
+
 /// One person's spot within a scene: where they stand, which way they face, and
 /// what kind of NPC belongs there.
 #[derive(Clone, Debug)]
@@ -81,13 +103,19 @@ pub struct AnchorSlot {
     /// scenes this is baked toward the other slots at emit time.
     pub facing: f32,
     pub role: SlotRole,
+    /// Which age of NPC may stand here. Most slots are `AdultOnly`; domestic and
+    /// social slots are marked `AnyAge` and play scenes `ChildOnly`, so a child
+    /// only ever spawns where a furniture/scene author allowed one.
+    pub occupant: Occupant,
     /// If true, the whole scene is skipped unless this slot can be filled.
     pub required: bool,
-    /// Force a specific profession on the spawned NPC, overriding the roster's
-    /// random one. `None` keeps the roster's profession. Used by workplace
-    /// fixtures (the smithy worker is a smith regardless of who the roster
-    /// hands us) — name and dialogue still come from the roster.
-    pub profession: Option<Profession>,
+    /// Force how the spawned NPC looks — a villager with a specific profession,
+    /// or a non-villager mob (e.g. a pillager guard) — overriding the default.
+    /// `None` derives the look from the roster NPC (a villager wearing its own
+    /// rolled profession). Either way, name and dialogue come from the roster.
+    /// Used by workplace fixtures (the smithy worker is a smith regardless of who
+    /// the roster hands us) and guard posts. See [`NpcLook`].
+    pub look: Option<NpcLook>,
     /// Context dialogue key (e.g. `tending_furnace`, `conversation`) indexing a
     /// pool in `NpcData::dialogue`. `None` falls back to generic small talk.
     /// Set from the furniture anchor that produced this slot.
@@ -110,8 +138,9 @@ impl AnchorSlot {
             pos,
             facing,
             role,
+            occupant: Occupant::AdultOnly,
             required: true,
-            profession: None,
+            look: None,
             dialogue: None,
             volume: DialogueVolume::Normal,
             y_offset: 0.0,
@@ -166,8 +195,9 @@ impl AnchorScene {
                 pos,
                 facing,
                 role,
+                occupant: Occupant::AdultOnly,
                 required: true,
-                profession: None,
+                look: None,
                 dialogue,
                 volume,
                 y_offset: 0.0,
@@ -176,17 +206,18 @@ impl AnchorScene {
     }
 
     /// A one-person workplace fixture: a single required [`SlotRole::Worker`]
-    /// with a profession bound to the workplace (smith at a smithy, etc.). Name
-    /// and dialogue still come from the roster; only the outfit is forced.
-    pub fn worker(pos: Point3D, facing: f32, profession: Profession) -> Self {
+    /// with a skin bound to the workplace (a smith look at a smithy, etc.). Name
+    /// and dialogue still come from the roster; only the look is forced.
+    pub fn worker(pos: Point3D, facing: f32, look: NpcLook) -> Self {
         AnchorScene {
             kind: SceneKind::Solo,
             slots: vec![AnchorSlot {
                 pos,
                 facing,
                 role: SlotRole::Worker,
+                occupant: Occupant::AdultOnly,
                 required: true,
-                profession: Some(profession),
+                look: Some(look),
                 dialogue: None,
                 volume: DialogueVolume::Normal,
                 y_offset: 0.0,
@@ -350,9 +381,23 @@ pub struct Npc {
     pub epithet: Option<String>,
     pub life_stage: LifeStage,
     pub biome: VillagerBiome,
-    /// `None` until [`assign_employment`] fills it (and stays `None` for
-    /// children and most elders). Spawns as the green "unemployed" robe.
-    pub profession: Option<Profession>,
+    /// How the NPC *looks* — a villager in some Minecraft profession outfit, or a
+    /// mob (a witch, a pillager). This is the costume, not the job: "is it a
+    /// villager, a witch, a weaponsmith." Residents default to a plain villager
+    /// and are dressed by [`assign_employment`]; the mob half is allowed (those
+    /// are just NPCs that look like a mob). Distinct from `employment`.
+    pub look: NpcLook,
+    /// What the NPC *does* — its literal town job ("guard", "woodcutter",
+    /// "farmer", …), or `None` when unemployed (children, retired elders,
+    /// nitwits, plain villagers). Residents get a trade label from
+    /// [`assign_employment`]; fixtures get the label their data entry declares.
+    /// Distinct from `look`: a weaponsmith-outfit villager can work as a guard.
+    pub employment: Option<String>,
+    /// Set once the NPC has been committed to a fixed spot in the world — today
+    /// only by [`bind_workers`] when a resident is drafted to a workplace — so
+    /// [`populate_town`] won't also seat them at home. Keeps the "each resident
+    /// appears exactly once" invariant without disturbing [`Population::by_id`].
+    pub placed: bool,
     pub relationships: Vec<Relationship>,
 }
 
@@ -382,6 +427,10 @@ pub struct Household {
     /// Which house this household lives in — the index used for the
     /// `home_<id>` entity tag on spawned residents.
     pub home: usize,
+    /// Footprint centre (X/Z) of this household's house — copied from its
+    /// [`HouseAnchors`] so proximity passes (work-binding, friendship) don't
+    /// need to thread the house list around.
+    pub pos: Point2D,
     /// Wealth tier derived from the building's size class at placement time.
     /// Biases [`assign_employment`] and [`pick_household_shape`].
     pub wealth: Wealth,
@@ -421,18 +470,17 @@ fn villager_biome_for(culture: Culture) -> VillagerBiome {
     }
 }
 
-/// Workplace fixture spec: how to dress and size a building's worker crew.
-/// `professions` is rolled across (so two of the same shop don't always match),
-/// `workers` is the target crew size (capped later by available stand cells).
+/// A staffed post defined in data: the job it fills and the skins it can wear.
+/// `employment` is the job label baked onto the NPC (and tallied in the jobs
+/// summary); `looks` is rolled per spawn, so a post can mix villager and mob
+/// skins. Used for guard posts. Workplaces use [`Staffing`] (this plus a crew
+/// size), declared on each building's structure JSON.
 #[derive(Debug, Clone, Deserialize)]
-pub struct WorkplaceSpec {
-    pub professions: Vec<Profession>,
-    pub workers: usize,
+pub struct Fixture {
+    pub employment: String,
+    pub looks: Vec<NpcLook>,
 }
 
-/// Key in `NpcData::workplaces` used as the fallback when a building kind has
-/// no explicit entry. Must always exist (enforced by `NpcData::validate`).
-const DEFAULT_WORKPLACE_KEY: &str = "default";
 
 /// Name + dialogue pools, loaded from `data/npcs.yaml`.
 #[derive(Debug, Clone, Deserialize)]
@@ -471,13 +519,14 @@ pub struct NpcData {
     /// exchange should stand alone, in case the scene is reduced to one person.
     #[serde(default)]
     pub exchanges: HashMap<String, Vec<Vec<String>>>,
-    /// Trade outfit for gate and tower guard fixtures.
-    pub guard_profession: Profession,
-    /// Workplace (building NBT id) → trade outfit + crew size for worker
-    /// fixtures placed at the building's footprint edge. An unknown kind falls
-    /// back to the `default` entry; the key list is validated at load against
-    /// the loaded `Structure` map (see [`NpcData::validate`]).
-    pub workplaces: HashMap<String, WorkplaceSpec>,
+    /// Gate and tower guard fixture: its `employment` job label and the `looks`
+    /// pool rolled per guard (mix villager and mob skins; repeat to weight).
+    /// `looks` must be non-empty (enforced by [`NpcData::validate`]).
+    pub guards: Fixture,
+    /// Fallback worker [`Staffing`] for buildings whose structure JSON declares
+    /// no `staffing` block of its own. Workplace staffing now lives on each
+    /// building's structure sidecar; this only covers the unstated ones.
+    pub default_staffing: Staffing,
 }
 
 impl NpcData {
@@ -501,6 +550,26 @@ impl NpcData {
         }
     }
 
+    /// Like [`line`](Self::line), but for a child it first tries a `{key}_child`
+    /// pool — so a kid at a `conversation` slot draws from `conversation_child`
+    /// when that pool exists, and otherwise falls back to the normal line. Adults
+    /// (and missing child pools) behave exactly like [`line`](Self::line).
+    pub fn line_aged(&self, key: Option<&str>, is_child: bool, rng: &mut RNG) -> String {
+        if is_child {
+            if let Some(k) = key {
+                let child_key = format!("{k}_child");
+                if let Some(pool) = self
+                    .dialogue
+                    .get(&child_key)
+                    .filter(|lines| !lines.is_empty())
+                {
+                    return rng.choose(pool).clone();
+                }
+            }
+        }
+        self.line(key, rng)
+    }
+
     /// Pick one whole exchange (an ordered list of lines) for `key` whose cast
     /// size matches `n` — an entry with exactly `n` lines, one per speaker — or
     /// `None` if the pool has no `n`-line entry. The caller hands the lines out to
@@ -516,42 +585,43 @@ impl NpcData {
         Some(rng.choose(&matching).to_vec())
     }
 
-    /// Trade outfit pool + crew size for a worker fixture at a building of
-    /// `kind`. Unknown kinds fall back to the required `default` entry. The
-    /// caller rolls a profession per worker from `spec.professions` so a
-    /// multi-worker shop isn't uniform.
-    pub fn workplace_spec(&self, kind: &str) -> &WorkplaceSpec {
-        self.workplaces
-            .get(kind)
-            .or_else(|| self.workplaces.get(DEFAULT_WORKPLACE_KEY))
-            .expect("npcs.yaml workplaces.default must exist (enforced by validate)")
+    /// The worker [`Staffing`] for a building of `kind`: its structure JSON's own
+    /// `staffing` block when present, else the town-wide `default_staffing`. The
+    /// caller rolls a skin per worker from `staffing.looks` so a multi-worker
+    /// shop isn't uniform.
+    pub fn staffing_for<'a>(
+        &'a self,
+        kind: &str,
+        structures: &'a HashMap<StructureType, Structure>,
+    ) -> &'a Staffing {
+        structures
+            .get(&StructureType(kind.to_string()))
+            .and_then(|s| s.staffing.as_ref())
+            .unwrap_or(&self.default_staffing)
     }
 
-    /// Validate the workplaces map: the `default` entry must exist; every
-    /// entry must have a non-empty `professions` list and at least one worker;
-    /// and every key other than `default` must match a loaded building NBT id
-    /// (so a typo like `copper_smleter` fails at startup instead of silently
-    /// falling through to the default).
+    /// Validate the NPC data against the loaded structures: the guard and default
+    /// staffing pools must be non-empty, and every building that declares its own
+    /// `staffing` block must have a non-empty `looks` pool and at least one
+    /// worker (so a malformed sidecar fails at startup, not silently).
     pub fn validate(&self, structures: &HashMap<StructureType, Structure>) -> anyhow::Result<()> {
-        if !self.workplaces.contains_key(DEFAULT_WORKPLACE_KEY) {
-            anyhow::bail!(
-                "npcs.yaml: workplaces is missing required `{DEFAULT_WORKPLACE_KEY}` entry",
-            );
+        if self.guards.looks.is_empty() {
+            anyhow::bail!("npcs.yaml: `guards.looks` must list at least one entry");
         }
-        for (kind, spec) in &self.workplaces {
-            if spec.professions.is_empty() {
-                anyhow::bail!("npcs.yaml: workplaces.{kind} has an empty `professions` list");
-            }
-            if spec.workers == 0 {
-                anyhow::bail!("npcs.yaml: workplaces.{kind} has `workers: 0`");
-            }
-            if kind == DEFAULT_WORKPLACE_KEY {
-                continue;
-            }
-            if !structures.contains_key(&StructureType(kind.clone())) {
-                anyhow::bail!(
-                    "npcs.yaml: workplaces.{kind} doesn't match any loaded building NBT id",
-                );
+        if self.default_staffing.looks.is_empty() {
+            anyhow::bail!("npcs.yaml: `default_staffing.looks` must list at least one entry");
+        }
+        if self.default_staffing.workers == 0 {
+            anyhow::bail!("npcs.yaml: `default_staffing.workers` must be > 0");
+        }
+        for (ty, s) in structures {
+            if let Some(staffing) = &s.staffing {
+                if staffing.looks.is_empty() {
+                    anyhow::bail!("structure {}: `staffing.looks` is empty", ty.0);
+                }
+                if staffing.workers == 0 {
+                    anyhow::bail!("structure {}: `staffing.workers` is 0", ty.0);
+                }
             }
         }
         Ok(())
@@ -848,7 +918,10 @@ fn push_member(
         epithet,
         life_stage: stage,
         biome,
-        profession: None,
+        // Plain villager until `assign_employment` dresses and employs them.
+        look: NpcLook::Villager(Profession::None),
+        employment: None,
+        placed: false,
         relationships: Vec::new(),
     });
     m_idx
@@ -1093,6 +1166,7 @@ pub fn build_households(
         pop.households.push(Household {
             surname: primary_surname,
             home: h_idx,
+            pos: house.pos,
             wealth,
             members,
         });
@@ -1289,33 +1363,27 @@ fn add_reciprocal(
 // Employment
 // ============================================================================
 
-/// Assign a `profession` to every resident. v1 rolls trades randomly from
-/// [`PROFESSIONS`]; children stay `None` (they're not employed); most elders
-/// retire (None), with 20% retaining their old trade for flavour. A later
-/// patch can swap this out for a workplace jobs board without changing the
-/// surrounding pipeline.
+/// Dress and employ every resident. Rolls a villager look-profession per member
+/// (children stay plain villagers; most elders retire to a plain robe, 20%
+/// keeping their old trade outfit for flavour; adults draw from their wealth
+/// tier), then sets `look` to that villager outfit and `employment` to the job
+/// it implies (see [`Profession::employment`] — the jobless `None`/`Nitwit`
+/// looks carry no employment). A later patch can swap the roll for a workplace
+/// jobs board without changing the surrounding pipeline.
 pub fn assign_employment(pop: &mut Population, rng: &mut RNG) {
     for h in pop.households.iter_mut() {
         let pool = professions_for(h.wealth);
         for m in h.members.iter_mut() {
-            match m.life_stage {
-                LifeStage::Child => {
-                    m.profession = None;
-                }
-                LifeStage::Elder => {
-                    // Most elders retire to `None`; 20% retain a trade — drawn
-                    // from the household's tier so a wealthy retiree keeps a
-                    // prestige outfit (the old librarian still wears the robe).
-                    m.profession = if rng.percent(20) {
-                        Some(*rng.choose(pool))
-                    } else {
-                        None
-                    };
-                }
-                LifeStage::Adult => {
-                    m.profession = Some(*rng.choose(pool));
-                }
-            }
+            let outfit = match m.life_stage {
+                LifeStage::Child => Profession::None,
+                // Most elders retire to a plain robe; 20% retain a trade — drawn
+                // from the household's tier so a wealthy retiree keeps a prestige
+                // outfit (the old librarian still wears the robe).
+                LifeStage::Elder if !rng.percent(20) => Profession::None,
+                LifeStage::Elder | LifeStage::Adult => *rng.choose(pool),
+            };
+            m.look = NpcLook::Villager(outfit);
+            m.employment = outfit.employment().map(String::from);
         }
     }
 }
@@ -1481,9 +1549,9 @@ pub fn log_population_stats(pop: &Population) {
     let mut unemployed = 0usize;
     for h in &pop.households {
         for m in &h.members {
-            match m.profession {
+            match &m.employment {
                 None => unemployed += 1,
-                Some(p) => *emp_counts.entry(format!("{:?}", p)).or_insert(0) += 1,
+                Some(e) => *emp_counts.entry(e.clone()).or_insert(0) += 1,
             }
         }
     }
@@ -1525,10 +1593,7 @@ pub fn log_sample_households(pop: &Population, n: usize) {
             h_idx, format!("\"{}\"", h.surname), h.wealth.label(), h.members.len(),
         );
         for m in &h.members {
-            let prof = m
-                .profession
-                .map(|p| format!("{:?}", p))
-                .unwrap_or_else(|| "—".to_string());
+            let job = m.employment.clone().unwrap_or_else(|| "—".to_string());
             let kin: Vec<String> = m
                 .relationships
                 .iter()
@@ -1553,7 +1618,7 @@ pub fn log_sample_households(pop: &Population, n: usize) {
                 "  {:<24} {:<6} {:<14} | {}",
                 m.display_name(),
                 format!("{:?}", m.life_stage),
-                prof,
+                job,
                 kin_str,
             );
         }
@@ -1564,22 +1629,37 @@ pub fn log_sample_households(pop: &Population, n: usize) {
 // Flat fixture roster (workplaces, plaza)
 // ============================================================================
 
-/// Generate a flat roster of `count` adult NPCs for fixture placement (plaza
-/// vendors, workplace workers, guards). Unlike household members, these are
-/// not registered in any [`Population`] — they have unique ids but no kin
-/// edges, no home, and a profession rolled up front (since fixtures are
-/// usually overridden by the scene's slot anyway).
+/// Generate a flat roster of `count` NPCs for fixture placement (plaza vendors
+/// and onlookers, workplace workers, guards), `children` of them kids and the
+/// rest working adults. Children are plain villagers with no trade — they exist
+/// to fill `ChildOnly` slots (e.g. kids in a market crowd); pass `0` for
+/// adult-only fixtures. Unlike household members, these are not registered in
+/// any [`Population`] — they have unique ids but no kin edges, no home, and a
+/// look/employment rolled up front (since fixtures usually override the look via
+/// the scene's slot anyway). Callers shuffle before placing, so the kids-first
+/// ordering here doesn't cluster them.
 pub fn build_roster(
     count: usize,
+    children: usize,
     culture: Culture,
     data: &NpcData,
     alloc: &mut IdAllocator,
     rng: &mut RNG,
 ) -> Vec<Npc> {
     let biome = villager_biome_for(culture);
+    let children = children.min(count);
     (0..count)
-        .map(|_| {
-            let stage = LifeStage::Adult;
+        .map(|i| {
+            let (stage, look, employment) = if i < children {
+                (LifeStage::Child, NpcLook::Villager(Profession::None), None)
+            } else {
+                let outfit = *rng.choose(&PROFESSIONS);
+                (
+                    LifeStage::Adult,
+                    NpcLook::Villager(outfit),
+                    outfit.employment().map(String::from),
+                )
+            };
             Npc {
                 id: alloc.next_id(),
                 first_name: roll_first_name(data, rng),
@@ -1587,7 +1667,9 @@ pub fn build_roster(
                 epithet: roll_epithet(stage, data, rng),
                 life_stage: stage,
                 biome,
-                profession: Some(*rng.choose(&PROFESSIONS)),
+                look,
+                employment,
+                placed: false,
                 relationships: Vec::new(),
             }
         })
@@ -1608,6 +1690,10 @@ pub struct HouseAnchors {
     pub scenes: Vec<AnchorScene>,
     pub population: usize,
     pub wealth: Wealth,
+    /// Footprint centre (X/Z) of this house, used by the household it seeds for
+    /// cheap proximity queries (work-binding to nearby workplaces, friendship
+    /// drafting between neighbours).
+    pub pos: Point2D,
 }
 
 /// One candidate scene in the town-wide draw, tagged with the house it belongs
@@ -1638,7 +1724,7 @@ async fn staff_scene(
     home: Option<usize>,
 ) -> anyhow::Result<usize> {
     let need = scene.required_count();
-    if need == 0 || pool.len() < need {
+    if need == 0 {
         return Ok(0);
     }
     // Draw one script sized to this scene's cast: an `n`-line exchange for `n`
@@ -1649,29 +1735,82 @@ async fn staff_scene(
         .dialogue
         .as_deref()
         .and_then(|k| data.exchange_of_len(k, scene.slots.len(), rng));
+
+    // Select an NPC per slot *before* spawning, so the scene stays atomic: a
+    // required slot that can't be matched by age drops the whole scene with
+    // nothing placed. Match age-restricted slots first so an `AnyAge` slot can't
+    // grab the only adult a later `AdultOnly` slot needs (or the only child a
+    // `ChildOnly` slot needs).
+    let mut assigned: Vec<Option<Npc>> = (0..scene.slots.len()).map(|_| None).collect();
+    let mut order: Vec<usize> = (0..scene.slots.len()).collect();
+    order.sort_by_key(|&i| {
+        let s = &scene.slots[i];
+        (matches!(s.occupant, Occupant::AnyAge) as u8, !s.required)
+    });
+    for &i in &order {
+        let slot = &scene.slots[i];
+        match take_for(pool, slot.occupant) {
+            Some(npc) => assigned[i] = Some(npc),
+            None if slot.required => {
+                // Infeasible — restore what we took and drop the scene.
+                for npc in assigned.into_iter().flatten() {
+                    pool.push(npc);
+                }
+                return Ok(0);
+            }
+            None => {} // optional slot with no acceptable NPC left → skip it
+        }
+    }
+
     let mut placed = 0usize;
     for (i, slot) in scene.slots.iter().enumerate() {
-        if !slot.required && pool.is_empty() {
-            continue; // optional slots fill only if roster remains
-        }
-        let Some(npc) = pool.pop() else { break };
-        let profession = slot
-            .profession
-            .or(npc.profession)
-            .unwrap_or(Profession::None);
+        let Some(npc) = assigned[i].take() else { continue };
+        // The slot may force a look (workplace trade, guard mob); otherwise the
+        // NPC keeps its own rolled look. Name and dialogue always come from the
+        // roster; a child draws a `{key}_child` line when the pool defines one.
+        let look = slot.look.unwrap_or(npc.look);
         let dialogue = exchange
             .as_ref()
             .and_then(|lines| lines.get(i).cloned())
-            .unwrap_or_else(|| data.line(slot.dialogue.as_deref(), rng));
+            .unwrap_or_else(|| data.line_aged(slot.dialogue.as_deref(), npc.is_child(), rng));
         let display_name = npc.display_name();
-        spawn_villager_npc(
-            editor, slot.pos, slot.facing, &display_name, &dialogue, npc.biome,
-            profession, slot.volume, home, npc.is_child(), slot.y_offset,
-        )
-        .await?;
+        match look {
+            NpcLook::Villager(profession) => {
+                spawn_villager_npc(
+                    editor, slot.pos, slot.facing, &display_name, &dialogue, npc.biome,
+                    profession, slot.volume, home, npc.is_child(), slot.y_offset,
+                )
+                .await?;
+            }
+            // The mob path is villager-free: biome/profession/home/child don't
+            // apply, but the roster still supplies the name and dialogue.
+            NpcLook::Mob(mob) => {
+                spawn_mob_npc(
+                    editor, slot.pos, slot.facing, &display_name, &dialogue, mob,
+                    slot.volume, slot.y_offset,
+                )
+                .await?;
+            }
+        }
         placed += 1;
     }
     Ok(placed)
+}
+
+/// Remove and return the last pool NPC whose age the slot's [`Occupant`] rule
+/// accepts, preferring an adult for `AnyAge` so children are left for any
+/// `ChildOnly` slots in the same scene. `None` if the pool has no acceptable
+/// NPC. Takes from the back to mirror the old `pool.pop()` draw order.
+fn take_for(pool: &mut Vec<Npc>, occupant: Occupant) -> Option<Npc> {
+    let pos = match occupant {
+        Occupant::AdultOnly => pool.iter().rposition(|n| !n.is_child()),
+        Occupant::ChildOnly => pool.iter().rposition(|n| n.is_child()),
+        Occupant::AnyAge => pool
+            .iter()
+            .rposition(|n| !n.is_child())
+            .or_else(|| pool.iter().rposition(|n| n.is_child())),
+    }?;
+    Some(pool.remove(pos))
 }
 
 /// Pick the index (into `entries`) of one of `live` weighted by its current
@@ -1753,7 +1892,12 @@ pub async fn populate_town(
     let mut pools: Vec<Vec<Npc>> = (0..num_houses)
         .map(|i| {
             if i < households.len() {
+                // Residents already committed elsewhere (bound to a workplace by
+                // `bind_workers`) are filtered out so they aren't seated twice.
                 std::mem::take(&mut households[i].members)
+                    .into_iter()
+                    .filter(|m| !m.placed)
+                    .collect()
             } else {
                 Vec::new()
             }
@@ -1848,6 +1992,156 @@ pub async fn populate_npcs(
     Ok(placed)
 }
 
+// ============================================================================
+// Employment binding — workplaces draft nearby residents
+// ============================================================================
+
+/// One worker post at a placed workplace: where the worker stands and which way
+/// they face, the building centre used for proximity scoring, the skin pool the
+/// post dresses its worker from, and the job label baked onto whoever fills it.
+/// The settlement layer's claim scan produces these (see `discover_worker_slots`)
+/// and [`bind_workers`] consumes them; posts left unfilled are handed back so the
+/// caller can backfill them with anonymous fixtures.
+pub struct WorkerSlot {
+    pub stand: Point3D,
+    pub facing: f32,
+    pub workplace: Point2D,
+    pub looks: Vec<NpcLook>,
+    pub employment: String,
+}
+
+/// Distance falloff for the work draft. A resident next door to a workplace is
+/// far likelier to staff it than one across town; exponential decay over this
+/// many blocks keeps the pull strong but never absolute.
+const WORK_PROXIMITY_SCALE: f32 = 48.0;
+/// Weight multiplier for a resident whose flavour outfit already matches the
+/// post's trade (a weaponsmith villager staffing the smithy). Mild on purpose,
+/// so proximity stays the lead term and a nearby non-specialist can still be
+/// hired — and re-dressed in the trade.
+const WORK_AFFINITY_MATCH: f32 = 3.0;
+
+/// Per-NPC base employability, independent of any particular workplace. Today
+/// every working-age adult scores the same; this is the seam where skill,
+/// trait, or age terms will multiply in later. Proximity and trade affinity are
+/// applied per-workplace at draft time (see [`draft_worker`]), not here.
+fn base_qualification(_npc: &Npc) -> f32 {
+    1.0
+}
+
+/// Proximity weight between a household's house and a workplace.
+fn work_proximity(home: Point2D, workplace: Point2D) -> f32 {
+    let dx = (home.x - workplace.x) as f32;
+    let dz = (home.y - workplace.y) as f32;
+    let dist = (dx * dx + dz * dz).sqrt();
+    (-dist / WORK_PROXIMITY_SCALE).exp()
+}
+
+/// Trade-affinity weight: a bonus when the resident's current look is one the
+/// post would hire for, else neutral.
+fn work_affinity(npc: &Npc, looks: &[NpcLook]) -> f32 {
+    if looks.iter().any(|l| *l == npc.look) {
+        WORK_AFFINITY_MATCH
+    } else {
+        1.0
+    }
+}
+
+/// Weighted pick over `(household_idx, member_idx, weight)` candidates. Mirrors
+/// [`weighted_pick`]'s tolerance of an all-zero total (returns the first).
+fn weighted_choice(cands: &[(usize, usize, f32)], rng: &mut RNG) -> Option<(usize, usize)> {
+    if cands.is_empty() {
+        return None;
+    }
+    let total: f32 = cands.iter().map(|c| c.2).sum();
+    if total <= 0.0 {
+        return cands.first().map(|c| (c.0, c.1));
+    }
+    let mut r = rng.rand_i32(100_000) as f32 / 100_000.0 * total;
+    for c in cands {
+        if r < c.2 {
+            return Some((c.0, c.1));
+        }
+        r -= c.2;
+    }
+    cands.last().map(|c| (c.0, c.1))
+}
+
+/// The pure core of the work draft: choose which unplaced working-age adult
+/// staffs a post at `workplace`, weighting each candidate by
+/// `base_qualification * proximity * affinity`. Returns the chosen member's
+/// `(household_idx, member_idx)`, or `None` if no eligible adult remains. Pure
+/// (no I/O), so the qualification model is unit-testable without a server.
+fn draft_worker(
+    households: &[Household],
+    workplace: Point2D,
+    looks: &[NpcLook],
+    rng: &mut RNG,
+) -> Option<(usize, usize)> {
+    let mut cands: Vec<(usize, usize, f32)> = Vec::new();
+    for (hi, h) in households.iter().enumerate() {
+        for (mi, m) in h.members.iter().enumerate() {
+            if m.placed || m.life_stage != LifeStage::Adult {
+                continue;
+            }
+            let w = base_qualification(m)
+                * work_proximity(h.pos, workplace)
+                * work_affinity(m, looks);
+            if w > 0.0 {
+                cands.push((hi, mi, w));
+            }
+        }
+    }
+    weighted_choice(&cands, rng)
+}
+
+/// Staff each workplace from the resident population *before* residential
+/// placement, so a resident drafted into a shop isn't also seated at home. For
+/// every [`WorkerSlot`], [`draft_worker`] picks an unplaced working-age adult
+/// (proximity-led qualification); the chosen resident is dressed in the post's
+/// trade, given its job label, marked `placed`, and spawned at the post tagged
+/// with their home. Posts with no eligible adult left (more posts than adults)
+/// are returned unfilled for the caller to backfill with anonymous fixtures.
+/// Returns `(residents_bound, unfilled_posts)`. Offline: binds nothing, hands
+/// every post back.
+pub async fn bind_workers(
+    editor: &Editor,
+    population: &mut Population,
+    slots: Vec<WorkerSlot>,
+    data: &NpcData,
+    rng: &mut RNG,
+) -> anyhow::Result<(usize, Vec<WorkerSlot>)> {
+    if editor.is_offline() {
+        return Ok((0, slots));
+    }
+    let mut bound = 0usize;
+    let mut unfilled: Vec<WorkerSlot> = Vec::new();
+    for slot in slots {
+        let Some((hi, mi)) =
+            draft_worker(&population.households, slot.workplace, &slot.looks, rng)
+        else {
+            unfilled.push(slot);
+            continue;
+        };
+        // Dress the resident in the post's trade and bake its job label, then
+        // mark them placed so `populate_town` skips them.
+        let look = *rng.choose(&slot.looks);
+        let home = population.households[hi].home;
+        {
+            let m = &mut population.households[hi].members[mi];
+            m.look = look;
+            m.employment = Some(slot.employment.clone());
+            m.placed = true;
+        }
+        // Spawn this specific resident via the shared scene path (name, dialogue,
+        // home tag) with the post's look forced.
+        let npc = population.households[hi].members[mi].clone();
+        let scene = AnchorScene::worker(slot.stand, slot.facing, look);
+        let mut one = vec![npc];
+        bound += staff_scene(editor, &scene, &mut one, data, rng, Some(home)).await?;
+    }
+    Ok((bound, unfilled))
+}
+
 /// Minecraft yaw (degrees) for an NPC at `from` looking toward `to`. Use this
 /// when emitting anchors so the NPC faces something meaningful (a door, a
 /// counter, the other half of a conversation). 0 = south, 90 = west.
@@ -1931,7 +2225,9 @@ mod tests {
             epithet: Some("the Quiet".into()),
             life_stage: LifeStage::Elder,
             biome: VillagerBiome::Plains,
-            profession: None,
+            look: NpcLook::Villager(Profession::None),
+            employment: None,
+            placed: false,
             relationships: Vec::new(),
         };
         assert_eq!(with_epithet.display_name(), "Doral the Quiet");
@@ -1939,6 +2235,55 @@ mod tests {
 
         let without = Npc { epithet: None, ..with_epithet.clone() };
         assert_eq!(without.display_name(), "Doral Carter");
+    }
+
+    /// The work draft favours nearby unplaced adults, skips placed/non-adults,
+    /// and yields `None` once the pool is exhausted.
+    #[test]
+    fn work_draft_prefers_nearby_unplaced_adults() {
+        let workplace = Point2D::new(0, 0);
+        let adult = |id: NpcId, pos: Point2D| Household {
+            surname: "X".into(),
+            home: id as usize,
+            pos,
+            wealth: Wealth::Modest,
+            members: vec![Npc {
+                id,
+                first_name: "A".into(),
+                surname: "X".into(),
+                epithet: None,
+                life_stage: LifeStage::Adult,
+                biome: VillagerBiome::Plains,
+                look: NpcLook::Villager(Profession::None),
+                employment: None,
+                placed: false,
+                relationships: Vec::new(),
+            }],
+        };
+        // House 0 sits beside the workplace; house 1 is far across town.
+        let mut households = vec![adult(0, Point2D::new(2, 0)), adult(1, Point2D::new(400, 0))];
+        let looks = [NpcLook::Villager(Profession::None)];
+        let mut rng = RNG::new(Seed(7));
+
+        let near = (0..200)
+            .filter(|_| draft_worker(&households, workplace, &looks, &mut rng) == Some((0, 0)))
+            .count();
+        assert!(near > 180, "near household should dominate, got {near}/200");
+
+        // Once the near adult is committed, the draft falls to the far one.
+        households[0].members[0].placed = true;
+        assert_eq!(draft_worker(&households, workplace, &looks, &mut rng), Some((1, 0)));
+
+        // Both committed → nothing left to draft.
+        households[1].members[0].placed = true;
+        assert_eq!(draft_worker(&households, workplace, &looks, &mut rng), None);
+
+        // A lone child is never working-age, so still nothing.
+        households[0].members[0].placed = false;
+        households[0].members[0].life_stage = LifeStage::Child;
+        households[1].members[0].placed = false;
+        households[1].members[0].life_stage = LifeStage::Child;
+        assert_eq!(draft_worker(&households, workplace, &looks, &mut rng), None);
     }
 
     /// Build a small batch of households and assert intra-household kinship is
@@ -1952,7 +2297,12 @@ mod tests {
         let mut alloc = IdAllocator::new();
         // A mix of bed budgets covering every shape branch.
         let houses: Vec<HouseAnchors> = (1..=6)
-            .map(|pop| HouseAnchors { scenes: Vec::new(), population: pop, wealth: Wealth::Modest })
+            .map(|pop| HouseAnchors {
+                scenes: Vec::new(),
+                population: pop,
+                wealth: Wealth::Modest,
+                pos: Point2D::new(pop as i32 * 16, 0),
+            })
             .collect();
         let pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
         assert_eq!(pop.households.len(), houses.len());
@@ -1996,24 +2346,40 @@ mod tests {
         }
     }
 
-    /// `assign_employment` leaves children unemployed, mostly retires elders,
-    /// and gives every adult a profession. No server.
+    /// `assign_employment` leaves children unemployed plain villagers, mostly
+    /// retires elders, and dresses every adult as a villager. No server.
     #[test]
     fn employment_pass_respects_life_stage() {
         let data = NpcData::load().expect("load npcs.yaml");
         let mut rng = RNG::new(Seed(13));
         let mut alloc = IdAllocator::new();
         let houses: Vec<HouseAnchors> = (1..=6)
-            .map(|pop| HouseAnchors { scenes: Vec::new(), population: pop, wealth: Wealth::Modest })
+            .map(|pop| HouseAnchors {
+                scenes: Vec::new(),
+                population: pop,
+                wealth: Wealth::Modest,
+                pos: Point2D::new(pop as i32 * 16, 0),
+            })
             .collect();
         let mut pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
         assign_employment(&mut pop, &mut rng);
         for h in &pop.households {
             for m in &h.members {
                 match m.life_stage {
-                    LifeStage::Child => assert!(m.profession.is_none(), "child stays unemployed"),
-                    LifeStage::Adult => assert!(m.profession.is_some(), "every adult gets a trade"),
-                    LifeStage::Elder => {} // either None (retired) or Some (kept)
+                    LifeStage::Child => {
+                        assert!(m.employment.is_none(), "child stays unemployed");
+                        assert_eq!(
+                            m.look,
+                            NpcLook::Villager(Profession::None),
+                            "child is a plain villager",
+                        );
+                    }
+                    // Adults are dressed as villagers; whether they hold a job
+                    // depends on the roll (None/Nitwit looks are unemployed).
+                    LifeStage::Adult => {
+                        assert!(matches!(m.look, NpcLook::Villager(_)), "adult is a villager");
+                    }
+                    LifeStage::Elder => {} // retired (None) or kept a trade
                 }
             }
         }
@@ -2050,7 +2416,7 @@ mod tests {
             .collect();
 
         let data = NpcData::load().expect("load npcs.yaml");
-        let roster = build_roster(count as usize, Culture::Desert, &data, &mut alloc, &mut rng);
+        let roster = build_roster(count as usize, 0, Culture::Desert, &data, &mut alloc, &mut rng);
         let placed = populate_npcs(&editor, scenes, roster, count as usize, &data, &mut rng)
             .await
             .expect("populate failed");

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -1,0 +1,600 @@
+//! NPC population: turn a town into a roster of residents, collect placement
+//! anchors emitted while the town is built, and distribute the roster across
+//! them.
+//!
+//! The placement unit is an [`AnchorScene`] — a group of [`AnchorSlot`]s filled
+//! together. v1 only emits **solo** scenes (one slot), but the model is built
+//! scene-ready so multi-person scenes (a conversation, a haggle) drop in later
+//! without reshaping the pipeline: a scene's slots carry their own baked facings
+//! (so two people face each other), the assignment fills a scene **atomically**
+//! (skipping it entirely if a `required` slot can't be staffed), and multi-slot
+//! scenes are weighted higher so the town fills with interactions first.
+//!
+//! NPCs are entities, so the whole pass is a no-op in offline/dry-run mode —
+//! only a live `cargo run` actually spawns them.
+
+use std::collections::HashMap;
+
+use serde_derive::Deserialize;
+
+use crate::data::load_yaml;
+use crate::editor::Editor;
+use crate::generator::buildings_v2::Culture;
+use crate::geometry::Point3D;
+use crate::noise::RNG;
+
+use super::npc::{spawn_villager_npc, DialogueVolume, Profession, VillagerBiome};
+
+/// How much more a multi-person scene weighs than a solo one, per person. A
+/// two-slot scene starts at `2 * BOOST`, so conversations and tables are picked
+/// well ahead of lone standers in the town-wide draw.
+const MULTI_SLOT_WEIGHT_BOOST: f32 = 3.0;
+
+/// Factor a house's remaining anchor weights are multiplied by each time one of
+/// its anchors is staffed — halving its pull on the next draw.
+const HOUSE_WEIGHT_DECAY: f32 = 0.5;
+
+/// Who may fill an anchor slot. Deserialized from furniture `anchors:` specs
+/// (snake_case: `resident`, `worker`, `idle`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlotRole {
+    /// Any town resident from the roster.
+    Resident,
+    /// A worker bound to a workplace (profession matters). Used by industrial
+    /// fixtures via [`AnchorScene::worker`], which forces the slot's profession.
+    Worker,
+    /// An idle bystander in a public space.
+    Idle,
+}
+
+/// One person's spot within a scene: where they stand, which way they face, and
+/// what kind of NPC belongs there.
+#[derive(Clone, Debug)]
+pub struct AnchorSlot {
+    /// Build-area-local feet position — must be a walkable cell.
+    pub pos: Point3D,
+    /// Yaw in degrees the NPC faces (0 = south, like vanilla). For multi-person
+    /// scenes this is baked toward the other slots at emit time.
+    pub facing: f32,
+    pub role: SlotRole,
+    /// If true, the whole scene is skipped unless this slot can be filled.
+    pub required: bool,
+    /// Force a specific profession on the spawned NPC, overriding the roster's
+    /// random one. `None` keeps the roster's profession. Used by workplace
+    /// fixtures (the smithy worker is a smith regardless of who the roster
+    /// hands us) — name and dialogue still come from the roster.
+    pub profession: Option<Profession>,
+    /// Context dialogue key (e.g. `tending_furnace`, `conversation`) indexing a
+    /// pool in `NpcData::dialogue`. `None` falls back to generic small talk.
+    /// Set from the furniture anchor that produced this slot.
+    pub dialogue: Option<String>,
+    /// How loudly this NPC's bubble reads. Interior/furniture anchors are
+    /// `Normal`; plaza criers and stage performers are `Yelled` so their line
+    /// carries across the square (see [`super::npc::DialogueVolume`]).
+    pub volume: DialogueVolume,
+}
+
+impl AnchorSlot {
+    /// A required slot with no forced profession or dialogue key — the caller
+    /// sets `facing` itself, so each slot in a multi-person scene can look
+    /// wherever it should (at a partner, a table, a focal point).
+    pub fn new(pos: Point3D, facing: f32, role: SlotRole) -> Self {
+        AnchorSlot {
+            pos,
+            facing,
+            role,
+            required: true,
+            profession: None,
+            dialogue: None,
+            volume: DialogueVolume::Normal,
+        }
+    }
+}
+
+/// What a scene depicts. Deserialized from furniture `anchors:` specs
+/// (snake_case: `solo`, `conversation`, `table`, …).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SceneKind {
+    Solo,
+    Conversation,
+    Haggle,
+    Table,
+    Mourning,
+}
+
+/// A group of slots filled as a unit.
+#[derive(Clone, Debug)]
+pub struct AnchorScene {
+    pub kind: SceneKind,
+    pub slots: Vec<AnchorSlot>,
+}
+
+impl AnchorScene {
+    /// A one-person scene — the only kind v1 emits. The slot carries no forced
+    /// profession, so it draws its trade from the roster.
+    pub fn solo(pos: Point3D, facing: f32, role: SlotRole) -> Self {
+        Self::solo_with(pos, facing, role, None, DialogueVolume::Normal)
+    }
+
+    /// A one-person scene with an explicit dialogue key and bubble volume. Used
+    /// by plaza fixtures — a market vendor hawking wares (`Yelled`) or an idle
+    /// onlooker in the crowd (`Normal`) — where the caller wants to pin the line
+    /// pool and how loudly it reads rather than take the generic defaults.
+    pub fn solo_with(
+        pos: Point3D,
+        facing: f32,
+        role: SlotRole,
+        dialogue: Option<String>,
+        volume: DialogueVolume,
+    ) -> Self {
+        AnchorScene {
+            kind: SceneKind::Solo,
+            slots: vec![AnchorSlot {
+                pos,
+                facing,
+                role,
+                required: true,
+                profession: None,
+                dialogue,
+                volume,
+            }],
+        }
+    }
+
+    /// A one-person workplace fixture: a single required [`SlotRole::Worker`]
+    /// with a profession bound to the workplace (smith at a smithy, etc.). Name
+    /// and dialogue still come from the roster; only the outfit is forced.
+    pub fn worker(pos: Point3D, facing: f32, profession: Profession) -> Self {
+        AnchorScene {
+            kind: SceneKind::Solo,
+            slots: vec![AnchorSlot {
+                pos,
+                facing,
+                role: SlotRole::Worker,
+                required: true,
+                profession: Some(profession),
+                dialogue: None,
+                volume: DialogueVolume::Normal,
+            }],
+        }
+    }
+
+    /// A multi-person scene assembled from pre-built slots. Each slot already
+    /// carries its own position, rotation, and role, so the caller decides where
+    /// everyone looks (e.g. two conversers facing each other, a table facing
+    /// inward). Slots default to `required`, so the scene is skipped unless all
+    /// of them can be staffed.
+    pub fn group(kind: SceneKind, slots: Vec<AnchorSlot>) -> Self {
+        AnchorScene { kind, slots }
+    }
+
+    /// Base selection weight for the town-wide draw. Multi-person scenes are
+    /// boosted so a town fills with interactions before lone standers. This is
+    /// the *starting* weight; [`populate_town`] halves a house's live weights
+    /// each time one of its anchors is staffed, so the crowd spreads off filled
+    /// houses onto emptier ones.
+    pub fn base_weight(&self) -> f32 {
+        match self.slots.len() {
+            0 | 1 => 1.0,
+            n => n as f32 * MULTI_SLOT_WEIGHT_BOOST,
+        }
+    }
+
+    /// Total person-slots in the scene (used to size the roster/budget so every
+    /// slot — not just every scene — can be staffed).
+    pub fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// How many slots must be staffed for the scene to be placed at all.
+    fn required_count(&self) -> usize {
+        self.slots.iter().filter(|s| s.required).count()
+    }
+}
+
+/// A resolved NPC identity, ready to spawn. Dialogue isn't baked here — it's
+/// chosen per placement from the slot's context key (see [`NpcData::line`]).
+#[derive(Clone, Debug)]
+pub struct Npc {
+    pub name: String,
+    pub biome: VillagerBiome,
+    pub profession: Profession,
+}
+
+/// The villager skin variant that matches a town's culture.
+fn villager_biome_for(culture: Culture) -> VillagerBiome {
+    match culture {
+        Culture::Desert => VillagerBiome::Desert,
+        Culture::Japanese => VillagerBiome::Taiga,
+        Culture::Medieval => VillagerBiome::Plains,
+    }
+}
+
+/// Name + dialogue pools, loaded from `data/npcs.yaml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NpcData {
+    pub first_names: Vec<String>,
+    pub epithets: Vec<String>,
+    /// Generic fallback lines, used when a slot has no dialogue key (or the key
+    /// isn't in `dialogue`).
+    pub small_talk: Vec<String>,
+    /// Context-keyed dialogue pools (e.g. `tending_furnace`, `conversation`,
+    /// `crafting`). A key can be shared by several furniture items. Missing
+    /// keys fall back to `small_talk`.
+    #[serde(default)]
+    pub dialogue: HashMap<String, Vec<String>>,
+    /// Multi-person exchanges, keyed like `dialogue` but each entry is a whole
+    /// back-and-forth: its lines are handed out positionally to a scene's slots
+    /// (line 0 → first speaker, line 1 → their reply, …) so the pair reads as
+    /// one conversation instead of two random lines. The first line of each
+    /// exchange should stand alone, in case the scene is reduced to one person.
+    #[serde(default)]
+    pub exchanges: HashMap<String, Vec<Vec<String>>>,
+}
+
+impl NpcData {
+    /// Load the pools from `data/npcs.yaml`.
+    pub fn load() -> anyhow::Result<Self> {
+        load_yaml("npcs.yaml")
+    }
+
+    /// Pick a dialogue line for a slot. Uses the context pool named by `key` if
+    /// it exists and is non-empty; otherwise falls back to generic `small_talk`
+    /// (and to "..." only if every pool is empty).
+    pub fn line(&self, key: Option<&str>, rng: &mut RNG) -> String {
+        let pool = key
+            .and_then(|k| self.dialogue.get(k))
+            .filter(|lines| !lines.is_empty())
+            .unwrap_or(&self.small_talk);
+        if pool.is_empty() {
+            "...".to_string()
+        } else {
+            rng.choose(pool).clone()
+        }
+    }
+
+    /// Pick one whole exchange (an ordered list of lines) for `key`, or `None`
+    /// if there's no exchange pool for it. The caller hands the lines out to a
+    /// scene's slots in order so the conversation reads as a single back-and-
+    /// forth.
+    pub fn exchange(&self, key: &str, rng: &mut RNG) -> Option<Vec<String>> {
+        self.exchanges
+            .get(key)
+            .filter(|pool| !pool.is_empty())
+            .map(|pool| rng.choose(pool).clone())
+    }
+}
+
+/// Professions a random resident may take (v1 — no workplace binding yet). These
+/// stay in code rather than YAML since they're enum-bound; the duplicate
+/// `Farmer` skews the roll toward common trades.
+const PROFESSIONS: [Profession; 10] = [
+    Profession::Farmer,
+    Profession::Farmer,
+    Profession::None,
+    Profession::Librarian,
+    Profession::Cleric,
+    Profession::Fisherman,
+    Profession::Shepherd,
+    Profession::Mason,
+    Profession::Butcher,
+    Profession::Nitwit,
+];
+
+/// Generate a roster of `count` residents for a town of `culture`, drawing names
+/// and dialogue from `data`.
+pub fn build_roster(count: usize, culture: Culture, data: &NpcData, rng: &mut RNG) -> Vec<Npc> {
+    let biome = villager_biome_for(culture);
+    (0..count)
+        .map(|_| {
+            let mut name = rng.choose(&data.first_names).clone();
+            if !data.epithets.is_empty() && rng.percent(35) {
+                name.push(' ');
+                name.push_str(rng.choose(&data.epithets).as_str());
+            }
+            let profession = *rng.choose(&PROFESSIONS);
+            Npc { name, biome, profession }
+        })
+        .collect()
+}
+
+/// One house's harvested anchor scenes plus the population budget its beds
+/// imply. `population` is the count of anchors the town-wide draw aims to staff
+/// for this house — derived by the caller from sleeping capacity (see
+/// `POPULATION_PER_BED` in `settlement`), so a double bed counts for two.
+pub struct HouseAnchors {
+    pub scenes: Vec<AnchorScene>,
+    pub population: usize,
+}
+
+/// One candidate scene in the town-wide draw, tagged with the house it belongs
+/// to so a placement can damp the rest of that house's anchors.
+struct Entry {
+    house: usize,
+    scene: AnchorScene,
+    weight: f32,
+    used: bool,
+}
+
+/// Spawn the NPCs for one scene from `pool`, returning how many were placed.
+///
+/// Atomic: if `pool` can't cover the scene's `required` slots, nothing is
+/// spawned and `0` is returned. Multi-person scenes draw one shared exchange
+/// (keyed by the first slot's dialogue key) and hand its lines out in slot
+/// order, so a pair reads as one back-and-forth; solo scenes fall back to a
+/// per-slot line. A slot may force a profession (workplace fixtures); otherwise
+/// the NPC keeps the roster's random trade. `home`, when set, tags every NPC in
+/// the scene with the house they belong to (see [`spawn_villager_npc`]).
+async fn staff_scene(
+    editor: &Editor,
+    scene: &AnchorScene,
+    pool: &mut Vec<Npc>,
+    data: &NpcData,
+    rng: &mut RNG,
+    home: Option<usize>,
+) -> anyhow::Result<usize> {
+    let need = scene.required_count();
+    if need == 0 || pool.len() < need {
+        return Ok(0);
+    }
+    let exchange = if scene.slots.len() >= 2 {
+        scene.slots[0].dialogue.as_deref().and_then(|k| data.exchange(k, rng))
+    } else {
+        None
+    };
+    let mut placed = 0usize;
+    for (i, slot) in scene.slots.iter().enumerate() {
+        if !slot.required && pool.is_empty() {
+            continue; // optional slots fill only if roster remains
+        }
+        let Some(npc) = pool.pop() else { break };
+        let profession = slot.profession.unwrap_or(npc.profession);
+        let dialogue = exchange
+            .as_ref()
+            .and_then(|lines| lines.get(i).cloned())
+            .unwrap_or_else(|| data.line(slot.dialogue.as_deref(), rng));
+        spawn_villager_npc(
+            editor, slot.pos, slot.facing, &npc.name, &dialogue, npc.biome, profession, slot.volume,
+            home,
+        )
+        .await?;
+        placed += 1;
+    }
+    Ok(placed)
+}
+
+/// Pick the index (into `entries`) of one of `live` weighted by its current
+/// `weight`, or `None` if `live` is empty. Tolerates an all-zero total (returns
+/// the first live entry) so repeated halving can't trip an empty-weight panic.
+fn weighted_pick(entries: &[Entry], live: &[usize], rng: &mut RNG) -> Option<usize> {
+    if live.is_empty() {
+        return None;
+    }
+    let total: f32 = live.iter().map(|&i| entries[i].weight).sum();
+    if total <= 0.0 {
+        return live.first().copied();
+    }
+    let mut r = rng.rand_i32(100_000) as f32 / 100_000.0 * total;
+    for &i in live {
+        if r < entries[i].weight {
+            return Some(i);
+        }
+        r -= entries[i].weight;
+    }
+    live.last().copied()
+}
+
+/// Halve the live (unused) anchor weights of one house, so its pull on the next
+/// town-wide draw drops after each resident placed there.
+fn decay_house(entries: &mut [Entry], house: usize) {
+    for e in entries.iter_mut() {
+        if e.house == house && !e.used {
+            e.weight *= HOUSE_WEIGHT_DECAY;
+        }
+    }
+}
+
+/// Populate a whole town from per-house anchors, sizing the crowd to beds.
+///
+/// The budget is `Σ max(1, beds)` over all houses. A seed pass staffs one anchor
+/// in every house that has any (so each populated house gets at least one
+/// resident), then a town-wide weighted draw fills the rest: anchors are picked
+/// in proportion to their current weight (multi-person scenes weigh more), and
+/// each placement halves the rest of that house's weights so the crowd flows off
+/// filled houses onto emptier ones. Returns the number of NPCs spawned. No-op
+/// (returns 0) in offline mode.
+pub async fn populate_town(
+    editor: &Editor,
+    houses: Vec<HouseAnchors>,
+    culture: Culture,
+    data: &NpcData,
+    rng: &mut RNG,
+) -> anyhow::Result<usize> {
+    if editor.is_offline() {
+        return Ok(0);
+    }
+
+    let budget: usize = houses.iter().map(|h| h.population).sum();
+    if budget == 0 {
+        return Ok(0);
+    }
+
+    // Flatten houses into weighted entries, remembering each scene's house.
+    let mut entries: Vec<Entry> = Vec::new();
+    for (house, h) in houses.into_iter().enumerate() {
+        for scene in h.scenes {
+            let weight = scene.base_weight();
+            entries.push(Entry { house, scene, weight, used: false });
+        }
+    }
+    if entries.is_empty() {
+        return Ok(0);
+    }
+    let num_houses = entries.iter().map(|e| e.house).max().map_or(0, |m| m + 1);
+
+    // Roster: names/professions for up to two NPCs per staffed anchor (v1's max
+    // slot count). Drained from the back as scenes are staffed.
+    let mut pool = build_roster((budget * 2).max(1), culture, data, &mut rng.derive());
+
+    let mut placed_anchors = 0usize;
+    let mut placed_npcs = 0usize;
+
+    // Seed pass: one anchor per house that has any, before the town-wide draw.
+    for house in 0..num_houses {
+        if pool.is_empty() || placed_anchors >= budget {
+            break;
+        }
+        let live: Vec<usize> = entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.house == house && !e.used)
+            .map(|(i, _)| i)
+            .collect();
+        let Some(idx) = weighted_pick(&entries, &live, rng) else { continue };
+        let n = staff_scene(editor, &entries[idx].scene, &mut pool, data, rng, Some(house)).await?;
+        entries[idx].used = true;
+        if n > 0 {
+            placed_npcs += n;
+            placed_anchors += 1;
+            decay_house(&mut entries, house);
+        }
+    }
+
+    // Town-wide draw for the remaining budget.
+    while placed_anchors < budget && !pool.is_empty() {
+        let live: Vec<usize> = entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| !e.used)
+            .map(|(i, _)| i)
+            .collect();
+        let Some(idx) = weighted_pick(&entries, &live, rng) else { break };
+        let house = entries[idx].house;
+        let n = staff_scene(editor, &entries[idx].scene, &mut pool, data, rng, Some(house)).await?;
+        entries[idx].used = true;
+        if n > 0 {
+            placed_npcs += n;
+            placed_anchors += 1;
+            decay_house(&mut entries, house);
+        }
+    }
+
+    Ok(placed_npcs)
+}
+
+/// Distribute `roster` across a flat list of `scenes`, spawning up to `budget`
+/// NPCs. Higher-weight (multi-person) scenes are tried first. Used for fixtures
+/// like industrial workers, where every scene should be staffed. Returns the
+/// number of NPCs spawned. No-op (returns 0) in offline mode.
+pub async fn populate_npcs(
+    editor: &Editor,
+    mut scenes: Vec<AnchorScene>,
+    mut roster: Vec<Npc>,
+    budget: usize,
+    data: &NpcData,
+    rng: &mut RNG,
+) -> anyhow::Result<usize> {
+    if editor.is_offline() {
+        return Ok(0);
+    }
+
+    // Shuffle for "somewhat random" placement, then prefer multi-person scenes
+    // (stable sort keeps the shuffle as a tiebreak within equal weights).
+    rng.shuffle(&mut scenes);
+    rng.shuffle(&mut roster);
+    scenes.sort_by(|a, b| {
+        b.base_weight().partial_cmp(&a.base_weight()).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut pool = roster; // drained from the back as we place
+    let mut placed = 0usize;
+    for scene in &scenes {
+        if placed >= budget || pool.is_empty() {
+            break;
+        }
+        // Workplace/plaza fixtures aren't house residents, so they carry no home.
+        placed += staff_scene(editor, scene, &mut pool, data, rng, None).await?;
+    }
+    Ok(placed)
+}
+
+/// Minecraft yaw (degrees) for an NPC at `from` looking toward `to`. Use this
+/// when emitting anchors so the NPC faces something meaningful (a door, a
+/// counter, the other half of a conversation). 0 = south, 90 = west.
+pub fn yaw_toward(from: Point3D, to: Point3D) -> f32 {
+    let dx = (to.x - from.x) as f32;
+    let dz = (to.z - from.z) as f32;
+    if dx == 0.0 && dz == 0.0 {
+        return 0.0;
+    }
+    (-dx).atan2(dz).to_degrees()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::{Editor, World};
+    use crate::geometry::{Point2D, Point3D};
+    use crate::http_mod::GDMCHTTPProvider;
+    use crate::noise::{Seed, RNG};
+    use crate::util::init_logger;
+
+    /// `npcs.yaml` parses and the context dialogue pools resolve. No server.
+    #[test]
+    fn npc_dialogue_pools_resolve() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        let mut rng = RNG::new(Seed(1));
+        // A known context key returns a line from its own pool, not small_talk.
+        let cooking = &data.dialogue["cooking"];
+        assert!(!cooking.is_empty(), "cooking pool should have lines");
+        let line = data.line(Some("cooking"), &mut rng);
+        assert!(cooking.contains(&line), "context line must come from the keyed pool");
+        // An unknown key falls back to generic small talk.
+        let fallback = data.line(Some("no_such_key"), &mut rng);
+        assert!(data.small_talk.contains(&fallback), "missing key falls back to small_talk");
+        // No key at all also falls back.
+        let none = data.line(None, &mut rng);
+        assert!(data.small_talk.contains(&none));
+    }
+
+    /// Build a small roster and place it along a row of solo anchors across the
+    /// middle of the build area, so the variety (names, professions, dialogue)
+    /// can be eyeballed in-game. Needs a live server.
+    /// Run with: `cargo test populate_demo -- --nocapture`.
+    #[tokio::test]
+    async fn populate_demo() {
+        init_logger();
+
+        let provider = GDMCHTTPProvider::new();
+        let build_area = provider.get_build_area().await.expect("Failed to get build area");
+        let world = World::new(&provider).await.expect("Failed to create world");
+        let editor = Editor::new(build_area, world);
+        let mut rng = RNG::new(Seed(42));
+
+        let size = editor.world().world_rect_2d().size;
+        let cz = size.y / 2;
+        let start_x = size.x / 2 - 6;
+
+        // A line of 6 solo anchors, each facing south (toward an approaching
+        // player), spaced 3 apart.
+        let count = 6;
+        let scenes: Vec<AnchorScene> = (0..count)
+            .map(|i| {
+                let c = Point2D::new(start_x + i * 3, cz);
+                let y = editor.world().get_ocean_floor_height_at(c);
+                AnchorScene::solo(Point3D::new(c.x, y, c.y), 0.0, SlotRole::Resident)
+            })
+            .collect();
+
+        let data = NpcData::load().expect("load npcs.yaml");
+        let roster = build_roster(count as usize, Culture::Desert, &data, &mut rng);
+        let placed = populate_npcs(&editor, scenes, roster, count as usize, &data, &mut rng)
+            .await
+            .expect("populate failed");
+
+        println!("Placed {} NPCs in a demo row at z={}", placed, cz);
+        assert!(placed > 0);
+    }
+}

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -73,6 +73,9 @@ pub struct AnchorSlot {
     /// `Normal`; plaza criers and stage performers are `Yelled` so their line
     /// carries across the square (see [`super::npc::DialogueVolume`]).
     pub volume: DialogueVolume,
+    /// Fractional blocks to raise the spawned NPC's feet — e.g. `0.5` to stand on
+    /// a slab top (a tower battlement). `0.0` for normal full-block ground.
+    pub y_offset: f32,
 }
 
 impl AnchorSlot {
@@ -88,6 +91,7 @@ impl AnchorSlot {
             profession: None,
             dialogue: None,
             volume: DialogueVolume::Normal,
+            y_offset: 0.0,
         }
     }
 }
@@ -102,6 +106,10 @@ pub enum SceneKind {
     Haggle,
     Table,
     Mourning,
+    /// A troupe on a plaza stage — a solo act, duet, or trio. The stage rolls the
+    /// cast size and `staff_scene` draws a `performing` script with that many
+    /// lines (see [`NpcData::exchange_of_len`]).
+    Performance,
 }
 
 /// A group of slots filled as a unit.
@@ -139,6 +147,7 @@ impl AnchorScene {
                 profession: None,
                 dialogue,
                 volume,
+                y_offset: 0.0,
             }],
         }
     }
@@ -157,6 +166,7 @@ impl AnchorScene {
                 profession: Some(profession),
                 dialogue: None,
                 volume: DialogueVolume::Normal,
+                y_offset: 0.0,
             }],
         }
     }
@@ -201,6 +211,9 @@ pub struct Npc {
     pub name: String,
     pub biome: VillagerBiome,
     pub profession: Profession,
+    /// A baby villager. Children keep a roster profession for naming/dialogue but
+    /// spawn as a baby (see [`spawn_villager_npc`]).
+    pub is_child: bool,
 }
 
 /// The villager skin variant that matches a town's culture.
@@ -255,15 +268,19 @@ impl NpcData {
         }
     }
 
-    /// Pick one whole exchange (an ordered list of lines) for `key`, or `None`
-    /// if there's no exchange pool for it. The caller hands the lines out to a
-    /// scene's slots in order so the conversation reads as a single back-and-
-    /// forth.
-    pub fn exchange(&self, key: &str, rng: &mut RNG) -> Option<Vec<String>> {
-        self.exchanges
-            .get(key)
-            .filter(|pool| !pool.is_empty())
-            .map(|pool| rng.choose(pool).clone())
+    /// Pick one whole exchange (an ordered list of lines) for `key` whose cast
+    /// size matches `n` — an entry with exactly `n` lines, one per speaker — or
+    /// `None` if the pool has no `n`-line entry. The caller hands the lines out to
+    /// a scene's slots in order so the group reads as one exchange. Selecting by
+    /// length lets a single key (e.g. `performing`) hold solos, duets, and trios
+    /// side by side, and a fixed-size scene draw the script that fits its cast.
+    pub fn exchange_of_len(&self, key: &str, n: usize, rng: &mut RNG) -> Option<Vec<String>> {
+        let pool = self.exchanges.get(key)?;
+        let matching: Vec<&Vec<String>> = pool.iter().filter(|e| e.len() == n).collect();
+        if matching.is_empty() {
+            return None;
+        }
+        Some(rng.choose(&matching).to_vec())
     }
 }
 
@@ -295,7 +312,9 @@ pub fn build_roster(count: usize, culture: Culture, data: &NpcData, rng: &mut RN
                 name.push_str(rng.choose(&data.epithets).as_str());
             }
             let profession = *rng.choose(&PROFESSIONS);
-            Npc { name, biome, profession }
+            // Children aren't decided here yet — residents default to adults; the
+            // caller flips `is_child` (and the spawner's `child`) when it wants one.
+            Npc { name, biome, profession, is_child: false }
         })
         .collect()
 }
@@ -339,11 +358,14 @@ async fn staff_scene(
     if need == 0 || pool.len() < need {
         return Ok(0);
     }
-    let exchange = if scene.slots.len() >= 2 {
-        scene.slots[0].dialogue.as_deref().and_then(|k| data.exchange(k, rng))
-    } else {
-        None
-    };
+    // Draw one script sized to this scene's cast: an `n`-line exchange for `n`
+    // slots, so a duet gets two lines and a trio three (see `exchange_of_len`).
+    // `need >= 1` here (the early return covers all-optional scenes), so slot 0
+    // exists. Keys with no matching-length entry fall back to per-slot `line`s.
+    let exchange = scene.slots[0]
+        .dialogue
+        .as_deref()
+        .and_then(|k| data.exchange_of_len(k, scene.slots.len(), rng));
     let mut placed = 0usize;
     for (i, slot) in scene.slots.iter().enumerate() {
         if !slot.required && pool.is_empty() {
@@ -357,7 +379,7 @@ async fn staff_scene(
             .unwrap_or_else(|| data.line(slot.dialogue.as_deref(), rng));
         spawn_villager_npc(
             editor, slot.pos, slot.facing, &npc.name, &dialogue, npc.biome, profession, slot.volume,
-            home,
+            home, npc.is_child, slot.y_offset,
         )
         .await?;
         placed += 1;
@@ -557,6 +579,25 @@ mod tests {
         // No key at all also falls back.
         let none = data.line(None, &mut rng);
         assert!(data.small_talk.contains(&none));
+    }
+
+    /// `exchange_of_len` returns only entries with the requested line count, so a
+    /// fixed-size stage scene draws a script that fits its cast. No server.
+    #[test]
+    fn exchange_matches_cast_size() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        let mut rng = RNG::new(Seed(7));
+        // The `performing` pool has solos, duets, and trios; each draw has exactly
+        // the requested number of lines.
+        for n in 1..=3 {
+            let script = data
+                .exchange_of_len("performing", n, &mut rng)
+                .unwrap_or_else(|| panic!("performing pool should have a {n}-line entry"));
+            assert_eq!(script.len(), n, "drew a {}-line script for cast {n}", script.len());
+        }
+        // No 9-line performance exists, and an unknown key has no exchanges at all.
+        assert!(data.exchange_of_len("performing", 9, &mut rng).is_none());
+        assert!(data.exchange_of_len("no_such_key", 2, &mut rng).is_none());
     }
 
     /// Build a small roster and place it along a row of solo anchors across the

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -1,6 +1,5 @@
-//! NPC population: turn a town into a roster of residents, collect placement
-//! anchors emitted while the town is built, and distribute the roster across
-//! them.
+//! NPC population: turn a town into households of NPCs with kinship, then
+//! distribute them across placement anchors emitted while the town was built.
 //!
 //! The placement unit is an [`AnchorScene`] — a group of [`AnchorSlot`]s filled
 //! together. v1 only emits **solo** scenes (one slot), but the model is built
@@ -12,6 +11,28 @@
 //!
 //! NPCs are entities, so the whole pass is a no-op in offline/dry-run mode —
 //! only a live `cargo run` actually spawns them.
+//!
+//! ## Household model
+//!
+//! Residents are generated as [`Household`]s (per house, sized to bed budget),
+//! not as a flat roster. Each [`Npc`] carries: a town-wide unique [`NpcId`],
+//! first name + surname (always stored), optional epithet, three-bucket
+//! [`LifeStage`] (Child/Adult/Elder), and a `Vec<Relationship>` whose targets
+//! reference any NPC in town by [`NpcId`] — relationships freely cross
+//! household boundaries (in-laws, siblings who moved across town, an adult
+//! child who inherited a neighbour's plot).
+//!
+//! Generation runs in four passes:
+//!   1. [`build_households`] — open-shape households, sized to bed budget,
+//!      with intra-household kin (parent↔child, spouse↔spouse, sibling↔sibling)
+//!      wired reciprocally. `profession: None` everywhere.
+//!   2. [`link_cross_household`] — in-laws, married-out siblings, adult
+//!      children whose parents live elsewhere. All edges reciprocal.
+//!   3. [`assign_employment`] — fills `profession` for adults (children stay
+//!      None; elders mostly retire). v1 rolls random trades; future passes
+//!      will consume a workplace jobs board.
+//!   4. [`populate_town`] — the existing seeded + weighted anchor draw, but
+//!      the per-house pool now reads from `population.households[h].members`.
 
 use std::collections::HashMap;
 
@@ -19,7 +40,9 @@ use serde_derive::Deserialize;
 
 use crate::data::load_yaml;
 use crate::editor::Editor;
+use crate::generator::buildings_v2::footprint::SizeClass;
 use crate::generator::buildings_v2::Culture;
+use crate::generator::nbts::{Structure, StructureType};
 use crate::geometry::Point3D;
 use crate::noise::RNG;
 
@@ -204,16 +227,189 @@ impl AnchorScene {
     }
 }
 
+// ============================================================================
+// NPC data model
+// ============================================================================
+
+/// Town-wide unique identifier for an NPC. Relationships reference this so an
+/// edge can freely cross household boundaries — a sibling who moved across
+/// town, in-laws from another family, the smith's adult son living next door.
+/// Allocated by [`IdAllocator`].
+pub type NpcId = u32;
+
+/// Hands out fresh [`NpcId`]s. One allocator threads through the whole town's
+/// generation (residents, workplace fixtures, guards) so every NPC has a
+/// unique id regardless of which subsystem spawned it.
+#[derive(Debug)]
+pub struct IdAllocator {
+    next: u32,
+}
+
+impl Default for IdAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdAllocator {
+    pub fn new() -> Self {
+        // Start at 1 so id 0 can stay a sentinel if anything needs one.
+        IdAllocator { next: 1 }
+    }
+
+    pub fn next_id(&mut self) -> NpcId {
+        let id = self.next;
+        self.next += 1;
+        id
+    }
+}
+
+/// Three-bucket age model. Minecraft only renders adult-vs-baby visually, so
+/// `Elder` is flavour (epithets, retired trade) but still spawns as an adult
+/// villager — `Child` is the only stage that maps to the baby model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LifeStage {
+    Child,
+    Adult,
+    Elder,
+}
+
+/// A household's wealth tier, derived from the building's [`SizeClass`] at
+/// placement time. Drives downstream skew in employment (wealthy households
+/// favour prestige trades; poor favour subsistence) and household shape
+/// (wealthy households more often house servants/lodgers and multigen
+/// elders; poor lean solo / sibling / lodger). Ordered Poor < … < Elite so
+/// callers can compare with `>=`/`<` when expressing thresholds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Wealth {
+    /// Cottage tier — rural / outskirts / subsistence.
+    Poor,
+    /// Standard town house — the majority of the population.
+    Modest,
+    /// Hall tier — a craftsman or notable family with means.
+    Wealthy,
+    /// Manor tier — the elite, capped at 1–2 per town.
+    Elite,
+}
+
+impl Wealth {
+    /// Map a [`SizeClass`] to the wealth tier of the household that lives
+    /// there. The only wealth signal currently flowing into population
+    /// generation, so the mapping is 1:1.
+    pub fn from_size_class(sc: SizeClass) -> Self {
+        match sc {
+            SizeClass::Cottage => Wealth::Poor,
+            SizeClass::House => Wealth::Modest,
+            SizeClass::Hall => Wealth::Wealthy,
+            SizeClass::Manor => Wealth::Elite,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Wealth::Poor => "Poor",
+            Wealth::Modest => "Modest",
+            Wealth::Wealthy => "Wealthy",
+            Wealth::Elite => "Elite",
+        }
+    }
+}
+
+/// Kinship between two NPCs. Designed open: new variants (grandparent, in-law,
+/// lodger) can land without reshaping the data model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelationshipKind {
+    Spouse,
+    Parent,
+    Child,
+    Sibling,
+}
+
+/// One directed edge in the kinship graph. Both directions are stored on the
+/// respective NPCs as a reciprocal pair (Parent on Alice, Child on Bob).
+#[derive(Clone, Debug)]
+pub struct Relationship {
+    pub kind: RelationshipKind,
+    /// Whom the edge points at — by town-wide id, so the target may live in any
+    /// household (including none — fixtures aren't registered in
+    /// [`Population::by_id`], so kin edges only target residents).
+    pub to: NpcId,
+}
+
 /// A resolved NPC identity, ready to spawn. Dialogue isn't baked here — it's
 /// chosen per placement from the slot's context key (see [`NpcData::line`]).
 #[derive(Clone, Debug)]
 pub struct Npc {
-    pub name: String,
+    pub id: NpcId,
+    pub first_name: String,
+    pub surname: String,
+    /// Flavour add-on ("the Quiet", "Stonefoot"). When present, the displayed
+    /// name tag uses `first epithet` instead of `first surname` — but the
+    /// surname is *still stored* so kin/household lookups stay intact.
+    /// Rolled heavily toward elders; rare on adults; almost never on children.
+    pub epithet: Option<String>,
+    pub life_stage: LifeStage,
     pub biome: VillagerBiome,
-    pub profession: Profession,
-    /// A baby villager. Children keep a roster profession for naming/dialogue but
-    /// spawn as a baby (see [`spawn_villager_npc`]).
-    pub is_child: bool,
+    /// `None` until [`assign_employment`] fills it (and stays `None` for
+    /// children and most elders). Spawns as the green "unemployed" robe.
+    pub profession: Option<Profession>,
+    pub relationships: Vec<Relationship>,
+}
+
+impl Npc {
+    /// The name tag shown above the NPC in-game. Epithets replace the surname
+    /// in the displayed form; the surname is still stored on the struct.
+    pub fn display_name(&self) -> String {
+        match &self.epithet {
+            Some(e) => format!("{} {}", self.first_name, e),
+            None => format!("{} {}", self.first_name, self.surname),
+        }
+    }
+
+    pub fn is_child(&self) -> bool {
+        matches!(self.life_stage, LifeStage::Child)
+    }
+}
+
+/// One family unit living in a single house. Members usually share `surname`,
+/// but a married-in spouse who kept their name or an unrelated lodger keeps
+/// their own — `Npc.surname` is the source of truth per-member.
+#[derive(Clone, Debug)]
+pub struct Household {
+    /// The household's primary surname (usually the head's). Members may carry
+    /// a different one.
+    pub surname: String,
+    /// Which house this household lives in — the index used for the
+    /// `home_<id>` entity tag on spawned residents.
+    pub home: usize,
+    /// Wealth tier derived from the building's size class at placement time.
+    /// Biases [`assign_employment`] and [`pick_household_shape`].
+    pub wealth: Wealth,
+    pub members: Vec<Npc>,
+}
+
+/// The whole town's NPC population: households plus a flat id→location index
+/// so cross-household passes (and the employment pass) can resolve an
+/// [`NpcId`] in O(1).
+#[derive(Debug, Default)]
+pub struct Population {
+    pub households: Vec<Household>,
+    /// `id → (household_idx, member_idx)`. Only household members are
+    /// registered here; anonymous fixtures (workplace workers, guards) get an
+    /// id from the same allocator but aren't kin-resolvable.
+    pub by_id: HashMap<NpcId, (usize, usize)>,
+}
+
+impl Population {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a member by id. `None` for fixture ids (not registered).
+    pub fn get(&self, id: NpcId) -> Option<&Npc> {
+        let &(h, m) = self.by_id.get(&id)?;
+        Some(&self.households[h].members[m])
+    }
 }
 
 /// The villager skin variant that matches a town's culture.
@@ -225,10 +421,40 @@ fn villager_biome_for(culture: Culture) -> VillagerBiome {
     }
 }
 
+/// Workplace fixture spec: how to dress and size a building's worker crew.
+/// `professions` is rolled across (so two of the same shop don't always match),
+/// `workers` is the target crew size (capped later by available stand cells).
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkplaceSpec {
+    pub professions: Vec<Profession>,
+    pub workers: usize,
+}
+
+/// Key in `NpcData::workplaces` used as the fallback when a building kind has
+/// no explicit entry. Must always exist (enforced by `NpcData::validate`).
+const DEFAULT_WORKPLACE_KEY: &str = "default";
+
 /// Name + dialogue pools, loaded from `data/npcs.yaml`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NpcData {
-    pub first_names: Vec<String>,
+    /// Consonant-ending stems that open a generated first name (Ael, Cor,
+    /// Hild, Theod, …). Combined with [`Self::first_name_suffixes`] in
+    /// [`roll_first_name`] to mint first names — Aelric, Coran, Hilda,
+    /// Theodwyn. Keeping prefixes consonant-terminal avoids awkward double
+    /// vowels when paired with a vowel-initial suffix.
+    pub first_name_prefixes: Vec<String>,
+    /// Endings appended to a [`Self::first_name_prefixes`] stem (-a, -ric,
+    /// -wyn, …). See [`roll_first_name`].
+    pub first_name_suffixes: Vec<String>,
+    /// Capitalized noun-like roots that lead a generated surname (Ash, Oak,
+    /// Stone, Hawk, Under, …). Combined with [`Self::surname_suffixes`] in
+    /// [`roll_surname`] to mint family names — Ashwood, Stonebrook, Hawkridge.
+    /// The two pools together give ~prefix*suffix possible surnames, so
+    /// collisions across a town of ~100 residents stay rare.
+    pub surname_prefixes: Vec<String>,
+    /// Lowercase place-name endings that close a generated surname (-wood,
+    /// -ford, -ridge, -ham, …). See [`Self::surname_prefixes`].
+    pub surname_suffixes: Vec<String>,
     pub epithets: Vec<String>,
     /// Generic fallback lines, used when a slot has no dialogue key (or the key
     /// isn't in `dialogue`).
@@ -245,6 +471,13 @@ pub struct NpcData {
     /// exchange should stand alone, in case the scene is reduced to one person.
     #[serde(default)]
     pub exchanges: HashMap<String, Vec<Vec<String>>>,
+    /// Trade outfit for gate and tower guard fixtures.
+    pub guard_profession: Profession,
+    /// Workplace (building NBT id) → trade outfit + crew size for worker
+    /// fixtures placed at the building's footprint edge. An unknown kind falls
+    /// back to the `default` entry; the key list is validated at load against
+    /// the loaded `Structure` map (see [`NpcData::validate`]).
+    pub workplaces: HashMap<String, WorkplaceSpec>,
 }
 
 impl NpcData {
@@ -282,11 +515,53 @@ impl NpcData {
         }
         Some(rng.choose(&matching).to_vec())
     }
+
+    /// Trade outfit pool + crew size for a worker fixture at a building of
+    /// `kind`. Unknown kinds fall back to the required `default` entry. The
+    /// caller rolls a profession per worker from `spec.professions` so a
+    /// multi-worker shop isn't uniform.
+    pub fn workplace_spec(&self, kind: &str) -> &WorkplaceSpec {
+        self.workplaces
+            .get(kind)
+            .or_else(|| self.workplaces.get(DEFAULT_WORKPLACE_KEY))
+            .expect("npcs.yaml workplaces.default must exist (enforced by validate)")
+    }
+
+    /// Validate the workplaces map: the `default` entry must exist; every
+    /// entry must have a non-empty `professions` list and at least one worker;
+    /// and every key other than `default` must match a loaded building NBT id
+    /// (so a typo like `copper_smleter` fails at startup instead of silently
+    /// falling through to the default).
+    pub fn validate(&self, structures: &HashMap<StructureType, Structure>) -> anyhow::Result<()> {
+        if !self.workplaces.contains_key(DEFAULT_WORKPLACE_KEY) {
+            anyhow::bail!(
+                "npcs.yaml: workplaces is missing required `{DEFAULT_WORKPLACE_KEY}` entry",
+            );
+        }
+        for (kind, spec) in &self.workplaces {
+            if spec.professions.is_empty() {
+                anyhow::bail!("npcs.yaml: workplaces.{kind} has an empty `professions` list");
+            }
+            if spec.workers == 0 {
+                anyhow::bail!("npcs.yaml: workplaces.{kind} has `workers: 0`");
+            }
+            if kind == DEFAULT_WORKPLACE_KEY {
+                continue;
+            }
+            if !structures.contains_key(&StructureType(kind.clone())) {
+                anyhow::bail!(
+                    "npcs.yaml: workplaces.{kind} doesn't match any loaded building NBT id",
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
-/// Professions a random resident may take (v1 — no workplace binding yet). These
-/// stay in code rather than YAML since they're enum-bound; the duplicate
-/// `Farmer` skews the roll toward common trades.
+/// Professions an adult resident may take. Stays in code (not YAML) since it's
+/// enum-bound. Used by [`build_roster`] for anonymous fixture NPCs (workplace
+/// workers, plaza vendors) where wealth has no meaning; residents draw from
+/// the wealth-tiered pools below instead. Duplicates skew toward common trades.
 const PROFESSIONS: [Profession; 10] = [
     Profession::Farmer,
     Profession::Farmer,
@@ -300,32 +575,1039 @@ const PROFESSIONS: [Profession; 10] = [
     Profession::Nitwit,
 ];
 
-/// Generate a roster of `count` residents for a town of `culture`, drawing names
-/// and dialogue from `data`.
-pub fn build_roster(count: usize, culture: Culture, data: &NpcData, rng: &mut RNG) -> Vec<Npc> {
+/// Wealth-tiered profession pools, used by [`assign_employment`] so each
+/// household's adults read as plausible for their station. Same enum-bound
+/// rationale as [`PROFESSIONS`]; duplicates skew the roll within each tier.
+const PROFESSIONS_POOR: &[Profession] = &[
+    Profession::Farmer,
+    Profession::Farmer,
+    Profession::Farmer,
+    Profession::Shepherd,
+    Profession::Shepherd,
+    Profession::Fisherman,
+    Profession::None,
+    Profession::None,
+    Profession::Nitwit,
+    Profession::Nitwit,
+];
+
+const PROFESSIONS_MODEST: &[Profession] = &[
+    Profession::Farmer,
+    Profession::Farmer,
+    Profession::Shepherd,
+    Profession::Fisherman,
+    Profession::Mason,
+    Profession::Butcher,
+    Profession::Fletcher,
+    Profession::Leatherworker,
+    Profession::None,
+    Profession::Nitwit,
+];
+
+const PROFESSIONS_WEALTHY: &[Profession] = &[
+    Profession::Mason,
+    Profession::Mason,
+    Profession::Butcher,
+    Profession::Leatherworker,
+    Profession::Toolsmith,
+    Profession::Weaponsmith,
+    Profession::Armorer,
+    Profession::Cleric,
+    Profession::Librarian,
+    Profession::Cartographer,
+];
+
+const PROFESSIONS_ELITE: &[Profession] = &[
+    Profession::Cleric,
+    Profession::Cleric,
+    Profession::Librarian,
+    Profession::Librarian,
+    Profession::Cartographer,
+    Profession::Cartographer,
+    Profession::Armorer,
+    Profession::Toolsmith,
+];
+
+fn professions_for(wealth: Wealth) -> &'static [Profession] {
+    match wealth {
+        Wealth::Poor => PROFESSIONS_POOR,
+        Wealth::Modest => PROFESSIONS_MODEST,
+        Wealth::Wealthy => PROFESSIONS_WEALTHY,
+        Wealth::Elite => PROFESSIONS_ELITE,
+    }
+}
+
+// ============================================================================
+// Name + epithet rolls
+// ============================================================================
+
+/// Mint a first name by combining a random stem prefix with a random suffix —
+/// "Cor" + "an" → "Coran", "Hild" + "a" → "Hilda", "Theod" + "ric" →
+/// "Theodric". Falls back to `"Stranger"` if either pool is empty (so a
+/// partial yaml doesn't panic).
+fn roll_first_name(data: &NpcData, rng: &mut RNG) -> String {
+    if data.first_name_prefixes.is_empty() || data.first_name_suffixes.is_empty() {
+        return "Stranger".to_string();
+    }
+    let prefix = rng.choose(&data.first_name_prefixes);
+    let suffix = rng.choose(&data.first_name_suffixes);
+    format!("{}{}", prefix, suffix)
+}
+
+/// Mint a family name by combining a random prefix with a random suffix —
+/// "Ash" + "wood" → "Ashwood", "Under" + "hill" → "Underhill". Falls back to
+/// `"Townsfolk"` if either pool is empty (so a partial yaml doesn't panic).
+fn roll_surname(data: &NpcData, rng: &mut RNG) -> String {
+    if data.surname_prefixes.is_empty() || data.surname_suffixes.is_empty() {
+        return "Townsfolk".to_string();
+    }
+    let prefix = rng.choose(&data.surname_prefixes);
+    let suffix = rng.choose(&data.surname_suffixes);
+    format!("{}{}", prefix, suffix)
+}
+
+/// Roll an epithet for a member of `stage`, weighted toward elders. Elders
+/// almost always pick one up; adults rarely; children effectively never.
+fn roll_epithet(stage: LifeStage, data: &NpcData, rng: &mut RNG) -> Option<String> {
+    if data.epithets.is_empty() {
+        return None;
+    }
+    let chance = match stage {
+        LifeStage::Elder => 60,
+        LifeStage::Adult => 8,
+        LifeStage::Child => 0,
+    };
+    if chance > 0 && rng.percent(chance) {
+        Some(rng.choose(&data.epithets).clone())
+    } else {
+        None
+    }
+}
+
+// ============================================================================
+// Household construction (intra-household kin)
+// ============================================================================
+
+/// Shapes a household may take, sized by bed budget. Picked once per house and
+/// expanded into members + intra-household relationships by [`expand_shape`].
+#[derive(Debug, Clone, Copy)]
+enum HouseholdShape {
+    /// Lone adult.
+    SoloAdult,
+    /// Lone elder ("the old hermit on the hill").
+    SoloElder,
+    /// Two adults, married.
+    Couple,
+    /// Single parent + N children.
+    SingleParent(u8),
+    /// Couple + N children.
+    CoupleWithKids(u8),
+    /// Couple + one elder (typically a parent of one spouse).
+    CoupleWithElder,
+    /// Couple + N children + one elder.
+    CoupleWithKidsAndElder(u8),
+    /// N adult siblings sharing a roof (no parents present).
+    AdultSiblings(u8),
+    /// N unrelated adults sharing a roof.
+    Lodgers(u8),
+    /// An elder living with an adult child.
+    ElderWithAdultChild,
+}
+
+/// Roll a household shape sized to `budget`, biased by `wealth`:
+/// * **Poor** — more solo elders, sibling clusters, and lodgers; fewer
+///   intact couples (precarious life expectancy / migration).
+/// * **Modest** — the baseline distribution (nuclear-heavy).
+/// * **Wealthy** — couples stay intact; more multigen (elders cared for in
+///   the household); more lodgers (semantically, live-in servants).
+/// * **Elite** — heavy lodgers (household staff) on top of a strong couple +
+///   multigen core.
+fn pick_household_shape(budget: usize, wealth: Wealth, rng: &mut RNG) -> HouseholdShape {
+    use HouseholdShape::*;
+    match budget {
+        0 | 1 => {
+            // Solo. Poor see more lonely elders; wealthier are likelier to be
+            // an adult living alone (a junior heir, an unmarried scholar).
+            let elder_chance = match wealth {
+                Wealth::Poor => 55,
+                Wealth::Modest => 35,
+                Wealth::Wealthy | Wealth::Elite => 25,
+            };
+            if rng.percent(elder_chance) { SoloElder } else { SoloAdult }
+        }
+        2 => {
+            let r = rng.rand_i32(100);
+            match wealth {
+                Wealth::Poor => {
+                    // Couples fragile; single-parent and sibling/lodger shares lift.
+                    if r < 35 { Couple }
+                    else if r < 60 { SingleParent(1) }
+                    else if r < 75 { AdultSiblings(2) }
+                    else if r < 92 { Lodgers(2) }
+                    else { ElderWithAdultChild }
+                }
+                Wealth::Modest => {
+                    if r < 55 { Couple }
+                    else if r < 75 { SingleParent(1) }
+                    else if r < 85 { AdultSiblings(2) }
+                    else if r < 95 { Lodgers(2) }
+                    else { ElderWithAdultChild }
+                }
+                Wealth::Wealthy => {
+                    // Strong couples; some lodgers (a maid + cook).
+                    if r < 60 { Couple }
+                    else if r < 70 { SingleParent(1) }
+                    else if r < 75 { AdultSiblings(2) }
+                    else if r < 95 { Lodgers(2) }
+                    else { ElderWithAdultChild }
+                }
+                Wealth::Elite => {
+                    // Many lodgers (household staff) even at small head counts.
+                    if r < 50 { Couple }
+                    else if r < 55 { SingleParent(1) }
+                    else if r < 58 { AdultSiblings(2) }
+                    else if r < 95 { Lodgers(2) }
+                    else { ElderWithAdultChild }
+                }
+            }
+        }
+        3 => {
+            let r = rng.rand_i32(100);
+            match wealth {
+                Wealth::Poor => {
+                    if r < 35 { CoupleWithKids(1) }
+                    else if r < 60 { SingleParent(2) }
+                    else if r < 70 { CoupleWithElder }
+                    else if r < 85 { AdultSiblings(3) }
+                    else { Lodgers(3) }
+                }
+                Wealth::Modest => {
+                    if r < 50 { CoupleWithKids(1) }
+                    else if r < 70 { SingleParent(2) }
+                    else if r < 82 { CoupleWithElder }
+                    else if r < 92 { AdultSiblings(3) }
+                    else { Lodgers(3) }
+                }
+                Wealth::Wealthy => {
+                    // More multigen (CoupleWithElder), some staff (Lodgers).
+                    if r < 45 { CoupleWithKids(1) }
+                    else if r < 55 { SingleParent(2) }
+                    else if r < 80 { CoupleWithElder }
+                    else if r < 85 { AdultSiblings(3) }
+                    else { Lodgers(3) }
+                }
+                Wealth::Elite => {
+                    if r < 35 { CoupleWithKids(1) }
+                    else if r < 40 { SingleParent(2) }
+                    else if r < 65 { CoupleWithElder }
+                    else if r < 68 { AdultSiblings(3) }
+                    else { Lodgers(3) } // ~32% staff
+                }
+            }
+        }
+        n => {
+            // 4+ beds. Big houses are where wealth most differentiates:
+            // wealthier households much more likely to host elders alongside kids.
+            let kids = (n.saturating_sub(2)) as u8;
+            let multigen_chance = match wealth {
+                Wealth::Poor => 15,
+                Wealth::Modest => 30,
+                Wealth::Wealthy => 55,
+                Wealth::Elite => 65,
+            };
+            if rng.percent(multigen_chance) && kids >= 1 {
+                CoupleWithKidsAndElder(kids.saturating_sub(1).max(1))
+            } else {
+                CoupleWithKids(kids.max(1))
+            }
+        }
+    }
+}
+
+/// Append a member to `members` and register it in `by_id`, returning its
+/// in-household index. Id is freshly allocated; relationships start empty.
+#[allow(clippy::too_many_arguments)]
+fn push_member(
+    h_idx: usize,
+    members: &mut Vec<Npc>,
+    by_id: &mut HashMap<NpcId, (usize, usize)>,
+    alloc: &mut IdAllocator,
+    first_name: String,
+    surname: String,
+    epithet: Option<String>,
+    stage: LifeStage,
+    biome: VillagerBiome,
+) -> usize {
+    let m_idx = members.len();
+    let id = alloc.next_id();
+    by_id.insert(id, (h_idx, m_idx));
+    members.push(Npc {
+        id,
+        first_name,
+        surname,
+        epithet,
+        life_stage: stage,
+        biome,
+        profession: None,
+        relationships: Vec::new(),
+    });
+    m_idx
+}
+
+/// Wire a reciprocal relationship pair: `a` gets a `forward` edge to `b`, and
+/// `b` gets a `back` edge to `a`. (Spouse↔Spouse, Parent→Child + Child→Parent,
+/// Sibling↔Sibling.) Both members must already be in `members`.
+fn link_pair(
+    members: &mut [Npc],
+    a: usize,
+    b: usize,
+    forward: RelationshipKind,
+    back: RelationshipKind,
+) {
+    let id_a = members[a].id;
+    let id_b = members[b].id;
+    members[a].relationships.push(Relationship { kind: forward, to: id_b });
+    members[b].relationships.push(Relationship { kind: back, to: id_a });
+}
+
+/// Realize one shape into `members`, returning when done. Surname goes to the
+/// "primary line"; lodgers and a couple's married-in spouse pick a different
+/// one from the pool so the household isn't uniformly one name.
+#[allow(clippy::too_many_arguments)]
+fn expand_shape(
+    shape: HouseholdShape,
+    h_idx: usize,
+    members: &mut Vec<Npc>,
+    by_id: &mut HashMap<NpcId, (usize, usize)>,
+    alloc: &mut IdAllocator,
+    primary_surname: &str,
+    data: &NpcData,
+    biome: VillagerBiome,
+    rng: &mut RNG,
+) {
+    // Pick a surname distinct from `primary_surname` if the pool allows; falls
+    // back to the primary if every roll matches (small surname pool).
+    let alt_surname = |rng: &mut RNG| -> String {
+        for _ in 0..6 {
+            let s = roll_surname(data, rng);
+            if s != primary_surname {
+                return s;
+            }
+        }
+        primary_surname.to_string()
+    };
+
+    match shape {
+        HouseholdShape::SoloAdult => {
+            let stage = LifeStage::Adult;
+            push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(stage, data, rng), stage, biome);
+        }
+        HouseholdShape::SoloElder => {
+            let stage = LifeStage::Elder;
+            push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(stage, data, rng), stage, biome);
+        }
+        HouseholdShape::Couple => {
+            // Spouse A keeps the household surname; spouse B has a chance to
+            // have married in from another family (different surname).
+            let married_in = rng.percent(40);
+            let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
+            let stage = LifeStage::Adult;
+            let a = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(stage, data, rng), stage, biome);
+            let b = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), sn_b,
+                roll_epithet(stage, data, rng), stage, biome);
+            link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
+        }
+        HouseholdShape::SingleParent(n_kids) => {
+            let parent = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            let mut kid_idxs = Vec::with_capacity(n_kids as usize);
+            for _ in 0..n_kids {
+                let k = push_member(h_idx, members, by_id, alloc,
+                    roll_first_name(data, rng), primary_surname.to_string(),
+                    None, LifeStage::Child, biome);
+                link_pair(members, parent, k, RelationshipKind::Child, RelationshipKind::Parent);
+                kid_idxs.push(k);
+            }
+            link_siblings(members, &kid_idxs);
+        }
+        HouseholdShape::CoupleWithKids(n_kids) => {
+            let married_in = rng.percent(40);
+            let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
+            let a = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            let b = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), sn_b,
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
+            // Kids take the primary surname (the family name).
+            let mut kid_idxs = Vec::with_capacity(n_kids as usize);
+            for _ in 0..n_kids {
+                let k = push_member(h_idx, members, by_id, alloc,
+                    roll_first_name(data, rng), primary_surname.to_string(),
+                    None, LifeStage::Child, biome);
+                link_pair(members, a, k, RelationshipKind::Child, RelationshipKind::Parent);
+                link_pair(members, b, k, RelationshipKind::Child, RelationshipKind::Parent);
+                kid_idxs.push(k);
+            }
+            link_siblings(members, &kid_idxs);
+        }
+        HouseholdShape::CoupleWithElder => {
+            let married_in = rng.percent(40);
+            let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
+            let a = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            let b = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), sn_b,
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
+            // Elder is a parent of whichever spouse shares the family name.
+            let elder = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
+            link_pair(members, elder, a, RelationshipKind::Child, RelationshipKind::Parent);
+        }
+        HouseholdShape::CoupleWithKidsAndElder(n_kids) => {
+            let married_in = rng.percent(40);
+            let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
+            let a = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            let b = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), sn_b,
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
+            let elder = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
+            link_pair(members, elder, a, RelationshipKind::Child, RelationshipKind::Parent);
+            let mut kid_idxs = Vec::with_capacity(n_kids as usize);
+            for _ in 0..n_kids {
+                let k = push_member(h_idx, members, by_id, alloc,
+                    roll_first_name(data, rng), primary_surname.to_string(),
+                    None, LifeStage::Child, biome);
+                link_pair(members, a, k, RelationshipKind::Child, RelationshipKind::Parent);
+                link_pair(members, b, k, RelationshipKind::Child, RelationshipKind::Parent);
+                // Elder is also a grandparent — not modeled with its own
+                // RelationshipKind yet, but the Parent→Spouse→Child chain
+                // already encodes it via traversal.
+                kid_idxs.push(k);
+            }
+            link_siblings(members, &kid_idxs);
+        }
+        HouseholdShape::AdultSiblings(n) => {
+            let mut idxs = Vec::with_capacity(n as usize);
+            for _ in 0..n {
+                let i = push_member(h_idx, members, by_id, alloc,
+                    roll_first_name(data, rng), primary_surname.to_string(),
+                    roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+                idxs.push(i);
+            }
+            link_siblings(members, &idxs);
+        }
+        HouseholdShape::Lodgers(n) => {
+            // Unrelated adults sharing rent. First keeps primary surname; rest
+            // get distinct ones so the household reads as "the Hollins house,
+            // plus two boarders".
+            for k in 0..n {
+                let sn = if k == 0 {
+                    primary_surname.to_string()
+                } else {
+                    alt_surname(rng)
+                };
+                push_member(h_idx, members, by_id, alloc,
+                    roll_first_name(data, rng), sn,
+                    roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            }
+        }
+        HouseholdShape::ElderWithAdultChild => {
+            let elder = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
+            let child = push_member(h_idx, members, by_id, alloc,
+                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
+            link_pair(members, elder, child, RelationshipKind::Child, RelationshipKind::Parent);
+        }
+    }
+}
+
+/// Link every pair in `idxs` as siblings (reciprocal). Idempotent on an empty
+/// or single-element slice.
+fn link_siblings(members: &mut [Npc], idxs: &[usize]) {
+    for i in 0..idxs.len() {
+        for j in (i + 1)..idxs.len() {
+            link_pair(members, idxs[i], idxs[j], RelationshipKind::Sibling, RelationshipKind::Sibling);
+        }
+    }
+}
+
+/// Build a [`Population`] for the whole town: one [`Household`] per house,
+/// sized to that house's bed budget. Intra-household kin (parent/child, spouse,
+/// sibling) are wired reciprocally; cross-household links come later in
+/// [`link_cross_household`]. Professions are left `None` for the
+/// [`assign_employment`] pass.
+pub fn build_households(
+    houses: &[HouseAnchors],
+    culture: Culture,
+    data: &NpcData,
+    alloc: &mut IdAllocator,
+    rng: &mut RNG,
+) -> Population {
+    let biome = villager_biome_for(culture);
+    let mut pop = Population::new();
+    // Every household's primary surname is unique within the town: each draw
+    // re-rolls until it hits a combination not yet used. With ~prefixes *
+    // suffixes ≈ 900 combos against ~50 households, this terminates in 1-2
+    // tries per house on average; the cap below is defensive in case the
+    // pool is ever shrunk below the household count.
+    let mut used_surnames: std::collections::HashSet<String> =
+        std::collections::HashSet::with_capacity(houses.len());
+    const SURNAME_MAX_TRIES: usize = 64;
+    for (h_idx, house) in houses.iter().enumerate() {
+        let budget = house.population.max(1);
+        let wealth = house.wealth;
+        let mut primary_surname = roll_surname(data, rng);
+        for _ in 0..SURNAME_MAX_TRIES {
+            if !used_surnames.contains(&primary_surname) {
+                break;
+            }
+            primary_surname = roll_surname(data, rng);
+        }
+        used_surnames.insert(primary_surname.clone());
+        let mut members: Vec<Npc> = Vec::new();
+        let shape = pick_household_shape(budget, wealth, rng);
+        expand_shape(
+            shape, h_idx, &mut members, &mut pop.by_id, alloc,
+            &primary_surname, data, biome, rng,
+        );
+        pop.households.push(Household {
+            surname: primary_surname,
+            home: h_idx,
+            wealth,
+            members,
+        });
+    }
+    pop
+}
+
+// ============================================================================
+// Cross-household linking
+// ============================================================================
+
+/// Attach reciprocal kinship across household boundaries. Three opportunistic
+/// passes — all probabilistic, all reciprocal:
+///   * **in-laws**: for each married couple, ~30% one spouse gets a "birth
+///     family" elsewhere (Parent edges from 1-2 adults of that house; Sibling
+///     edges to any of *their* children);
+///   * **adult siblings across town**: ~15% of adults with no sibling yet gain
+///     one from another household;
+///   * **adult-child elsewhere**: ~20% of adults with no Parent edge yet get
+///     a parent (or two) in another household — the multigen pattern where
+///     grown children live separately but kin is recorded.
+pub fn link_cross_household(pop: &mut Population, rng: &mut RNG) {
+    if pop.households.len() < 2 {
+        return;
+    }
+
+    // ---- Pass A: in-laws ----
+    let spouse_pairs: Vec<(NpcId, NpcId)> = collect_spouse_pairs(pop);
+    for (a_id, b_id) in spouse_pairs {
+        if !rng.percent(30) {
+            continue;
+        }
+        let in_law = if rng.percent(50) { a_id } else { b_id };
+        let in_law_house = pop.by_id.get(&in_law).map(|&(h, _)| h);
+        let candidate_houses: Vec<usize> = (0..pop.households.len())
+            .filter(|&i| Some(i) != in_law_house)
+            .filter(|&i| {
+                pop.households[i]
+                    .members
+                    .iter()
+                    .any(|m| matches!(m.life_stage, LifeStage::Adult | LifeStage::Elder))
+            })
+            .collect();
+        if candidate_houses.is_empty() {
+            continue;
+        }
+        let other_h = *rng.choose(&candidate_houses);
+        let other_adults: Vec<NpcId> = pop.households[other_h]
+            .members
+            .iter()
+            .filter(|m| matches!(m.life_stage, LifeStage::Adult | LifeStage::Elder))
+            .map(|m| m.id)
+            .collect();
+        let n_parents = if other_adults.len() >= 2 && rng.percent(70) { 2 } else { 1 };
+        let parents: Vec<NpcId> = other_adults.iter().copied().take(n_parents).collect();
+        for &pid in &parents {
+            add_reciprocal(pop, pid, in_law, RelationshipKind::Child, RelationshipKind::Parent);
+        }
+        // Siblings: any other resident of `other_h` who already has a Parent
+        // edge to one of these in-law parents reads as a sibling-in-law to the
+        // newcomer.
+        let siblings: Vec<NpcId> = pop.households[other_h]
+            .members
+            .iter()
+            .filter(|m| m.id != in_law)
+            .filter(|m| {
+                m.relationships.iter().any(|r| {
+                    r.kind == RelationshipKind::Parent && parents.contains(&r.to)
+                })
+            })
+            .map(|m| m.id)
+            .collect();
+        for sib in siblings {
+            add_reciprocal(pop, sib, in_law, RelationshipKind::Sibling, RelationshipKind::Sibling);
+        }
+    }
+
+    // ---- Pass B: adult siblings across town ----
+    let solo_adults: Vec<NpcId> = collect_adults_without(pop, RelationshipKind::Sibling);
+    for a_id in solo_adults {
+        if !rng.percent(15) {
+            continue;
+        }
+        let cur_h = pop.by_id.get(&a_id).map(|&(h, _)| h);
+        let mut candidates: Vec<NpcId> = Vec::new();
+        for (i, h) in pop.households.iter().enumerate() {
+            if Some(i) == cur_h {
+                continue;
+            }
+            for m in &h.members {
+                if matches!(m.life_stage, LifeStage::Adult)
+                    && m.id != a_id
+                    && !m.relationships.iter().any(|r| r.kind == RelationshipKind::Sibling)
+                {
+                    candidates.push(m.id);
+                }
+            }
+        }
+        if candidates.is_empty() {
+            continue;
+        }
+        let b_id = *rng.choose(&candidates);
+        add_reciprocal(pop, a_id, b_id, RelationshipKind::Sibling, RelationshipKind::Sibling);
+    }
+
+    // ---- Pass C: adult children whose parents live elsewhere ----
+    let parentless_adults: Vec<NpcId> = collect_adults_without(pop, RelationshipKind::Parent);
+    for a_id in parentless_adults {
+        if !rng.percent(20) {
+            continue;
+        }
+        let cur_h = pop.by_id.get(&a_id).map(|&(h, _)| h);
+        let mut candidate_houses: Vec<usize> = Vec::new();
+        for (i, h) in pop.households.iter().enumerate() {
+            if Some(i) == cur_h {
+                continue;
+            }
+            if h.members.iter().any(|m| {
+                matches!(m.life_stage, LifeStage::Elder | LifeStage::Adult)
+            }) {
+                candidate_houses.push(i);
+            }
+        }
+        if candidate_houses.is_empty() {
+            continue;
+        }
+        let other_h = *rng.choose(&candidate_houses);
+        let parent_pool: Vec<NpcId> = pop.households[other_h]
+            .members
+            .iter()
+            .filter(|m| matches!(m.life_stage, LifeStage::Elder | LifeStage::Adult))
+            .map(|m| m.id)
+            .collect();
+        let n_parents = if parent_pool.len() >= 2 && rng.percent(60) { 2 } else { 1 };
+        for &pid in parent_pool.iter().take(n_parents) {
+            add_reciprocal(pop, pid, a_id, RelationshipKind::Child, RelationshipKind::Parent);
+        }
+    }
+}
+
+fn collect_spouse_pairs(pop: &Population) -> Vec<(NpcId, NpcId)> {
+    let mut out = Vec::new();
+    for h in &pop.households {
+        for m in &h.members {
+            for r in &m.relationships {
+                // Emit each pair once: lower id is the canonical "left".
+                if r.kind == RelationshipKind::Spouse && m.id < r.to {
+                    out.push((m.id, r.to));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_adults_without(pop: &Population, kind: RelationshipKind) -> Vec<NpcId> {
+    let mut out = Vec::new();
+    for h in &pop.households {
+        for m in &h.members {
+            if matches!(m.life_stage, LifeStage::Adult)
+                && !m.relationships.iter().any(|r| r.kind == kind)
+            {
+                out.push(m.id);
+            }
+        }
+    }
+    out
+}
+
+/// Add a reciprocal edge pair across the town. Either id may be a fixture
+/// (not registered in `by_id`) — in that case the missing end is skipped, and
+/// the relationship lands one-sided. Fixtures don't currently appear here, but
+/// the guard keeps the function safe if they ever do.
+fn add_reciprocal(
+    pop: &mut Population,
+    from: NpcId,
+    to: NpcId,
+    forward: RelationshipKind,
+    back: RelationshipKind,
+) {
+    if let Some(&(h, m)) = pop.by_id.get(&from) {
+        pop.households[h].members[m]
+            .relationships
+            .push(Relationship { kind: forward, to });
+    }
+    if let Some(&(h, m)) = pop.by_id.get(&to) {
+        pop.households[h].members[m]
+            .relationships
+            .push(Relationship { kind: back, to: from });
+    }
+}
+
+// ============================================================================
+// Employment
+// ============================================================================
+
+/// Assign a `profession` to every resident. v1 rolls trades randomly from
+/// [`PROFESSIONS`]; children stay `None` (they're not employed); most elders
+/// retire (None), with 20% retaining their old trade for flavour. A later
+/// patch can swap this out for a workplace jobs board without changing the
+/// surrounding pipeline.
+pub fn assign_employment(pop: &mut Population, rng: &mut RNG) {
+    for h in pop.households.iter_mut() {
+        let pool = professions_for(h.wealth);
+        for m in h.members.iter_mut() {
+            match m.life_stage {
+                LifeStage::Child => {
+                    m.profession = None;
+                }
+                LifeStage::Elder => {
+                    // Most elders retire to `None`; 20% retain a trade — drawn
+                    // from the household's tier so a wealthy retiree keeps a
+                    // prestige outfit (the old librarian still wears the robe).
+                    m.profession = if rng.percent(20) {
+                        Some(*rng.choose(pool))
+                    } else {
+                        None
+                    };
+                }
+                LifeStage::Adult => {
+                    m.profession = Some(*rng.choose(pool));
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Diagnostics
+// ============================================================================
+
+/// Print a town-wide population breakdown: household counts, life-stage mix,
+/// kin-edge counts (with cross-household share), surname diversity, and
+/// employment distribution. Emits via `println!` so it lands in the same
+/// console stream as the rest of the pipeline summaries. Cheap — a few passes
+/// over members.
+pub fn log_population_stats(pop: &Population) {
+    if pop.households.is_empty() {
+        println!("=== POPULATION STATS: empty (no households) ===");
+        return;
+    }
+
+    let n_households = pop.households.len();
+    let total_residents: usize = pop.households.iter().map(|h| h.members.len()).sum();
+    let pct = |n: usize| -> f32 {
+        if total_residents == 0 {
+            0.0
+        } else {
+            100.0 * n as f32 / total_residents as f32
+        }
+    };
+
+    // Life-stage breakdown.
+    let mut children = 0usize;
+    let mut adults = 0usize;
+    let mut elders = 0usize;
+    for h in &pop.households {
+        for m in &h.members {
+            match m.life_stage {
+                LifeStage::Child => children += 1,
+                LifeStage::Adult => adults += 1,
+                LifeStage::Elder => elders += 1,
+            }
+        }
+    }
+
+    println!("=== POPULATION STATS ===");
+    println!(
+        "Households: {} | Total residents: {} | Avg household size: {:.2}",
+        n_households,
+        total_residents,
+        total_residents as f32 / n_households as f32,
+    );
+    println!("Life stages:");
+    println!("  Children: {:>4} ({:5.1}%)", children, pct(children));
+    println!("  Adults:   {:>4} ({:5.1}%)", adults, pct(adults));
+    println!("  Elders:   {:>4} ({:5.1}%)", elders, pct(elders));
+
+    // Wealth tier distribution across households.
+    let mut wealth_counts = [0usize; 4]; // Poor, Modest, Wealthy, Elite
+    for h in &pop.households {
+        let idx = match h.wealth {
+            Wealth::Poor => 0,
+            Wealth::Modest => 1,
+            Wealth::Wealthy => 2,
+            Wealth::Elite => 3,
+        };
+        wealth_counts[idx] += 1;
+    }
+    println!("Wealth tiers (households):");
+    for (label, n) in ["Poor", "Modest", "Wealthy", "Elite"].iter().zip(wealth_counts.iter()) {
+        let pct_h = 100.0 * *n as f32 / n_households as f32;
+        println!("  {:<8} {:>3} ({:5.1}%)", label, n, pct_h);
+    }
+
+    // Household size distribution.
+    let mut size_dist: HashMap<usize, usize> = HashMap::new();
+    for h in &pop.households {
+        *size_dist.entry(h.members.len()).or_insert(0) += 1;
+    }
+    let mut sizes: Vec<usize> = size_dist.keys().copied().collect();
+    sizes.sort_unstable();
+    println!("Household size distribution:");
+    for s in sizes {
+        let n = size_dist[&s];
+        let pct_h = 100.0 * n as f32 / n_households as f32;
+        println!("  {} members: {:>3} houses ({:5.1}%)", s, n, pct_h);
+    }
+
+    // Kin edges (each undirected edge counted once: Spouse/Sibling use id<to,
+    // Parent edges are unique by direction since Child is the back-edge).
+    let mut spouse_edges = 0usize;
+    let mut sibling_edges = 0usize;
+    let mut parent_edges = 0usize;
+    let mut cross_spouse = 0usize;
+    let mut cross_sibling = 0usize;
+    let mut cross_parent = 0usize;
+    let house_of = |id: NpcId| -> Option<usize> { pop.by_id.get(&id).map(|&(h, _)| h) };
+    for h in &pop.households {
+        for m in &h.members {
+            let src_h = house_of(m.id);
+            for r in &m.relationships {
+                let dst_h = house_of(r.to);
+                let cross = src_h.is_some() && dst_h.is_some() && src_h != dst_h;
+                match r.kind {
+                    RelationshipKind::Spouse if m.id < r.to => {
+                        spouse_edges += 1;
+                        if cross {
+                            cross_spouse += 1;
+                        }
+                    }
+                    RelationshipKind::Sibling if m.id < r.to => {
+                        sibling_edges += 1;
+                        if cross {
+                            cross_sibling += 1;
+                        }
+                    }
+                    RelationshipKind::Parent => {
+                        parent_edges += 1;
+                        if cross {
+                            cross_parent += 1;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    let total_edges = spouse_edges + sibling_edges + parent_edges;
+    let cross_edges = cross_spouse + cross_sibling + cross_parent;
+    println!("Kin edges (undirected): {}", total_edges);
+    println!("  Spouse:  {:>4} (cross-household: {})", spouse_edges, cross_spouse);
+    println!("  Parent:  {:>4} (cross-household: {})", parent_edges, cross_parent);
+    println!("  Sibling: {:>4} (cross-household: {})", sibling_edges, cross_sibling);
+    if total_edges > 0 {
+        println!(
+            "  Cross-household share: {}/{} ({:.1}%)",
+            cross_edges, total_edges,
+            100.0 * cross_edges as f32 / total_edges as f32,
+        );
+    }
+    if total_residents > 0 {
+        println!(
+            "  Avg edges/person: {:.2}",
+            (total_edges * 2) as f32 / total_residents as f32,
+        );
+    }
+
+    // Surname diversity (top 5 by count).
+    let mut surname_counts: HashMap<String, usize> = HashMap::new();
+    for h in &pop.households {
+        for m in &h.members {
+            *surname_counts.entry(m.surname.clone()).or_insert(0) += 1;
+        }
+    }
+    let mut sn: Vec<(String, usize)> = surname_counts.into_iter().collect();
+    sn.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    println!("Surnames: {} distinct across {} residents", sn.len(), total_residents);
+    let top: Vec<String> = sn.iter().take(5).map(|(s, c)| format!("{} ({})", s, c)).collect();
+    if !top.is_empty() {
+        println!("  Most common: {}", top.join(", "));
+    }
+
+    // Employment breakdown (full sorted by count).
+    let mut emp_counts: HashMap<String, usize> = HashMap::new();
+    let mut unemployed = 0usize;
+    for h in &pop.households {
+        for m in &h.members {
+            match m.profession {
+                None => unemployed += 1,
+                Some(p) => *emp_counts.entry(format!("{:?}", p)).or_insert(0) += 1,
+            }
+        }
+    }
+    let mut emp: Vec<(String, usize)> = emp_counts.into_iter().collect();
+    emp.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    println!("Employment:");
+    println!("  {:<14} {:>4} ({:5.1}%)", "Unemployed", unemployed, pct(unemployed));
+    for (k, c) in &emp {
+        println!("  {:<14} {:>4} ({:5.1}%)", k, c, pct(*c));
+    }
+    let unemp_children_share = if children > 0 {
+        100.0 * children.min(unemployed) as f32 / unemployed as f32
+    } else {
+        0.0
+    };
+    println!(
+        "  (Children account for {:.0}% of unemployed; rest is elders + adult nitwits/None)",
+        unemp_children_share,
+    );
+}
+
+/// Print a handful of sample households in detail (members + their kin links
+/// by name). Picks `n` households spaced through the list so the sample
+/// spans small, medium, and large families rather than the first `n`.
+pub fn log_sample_households(pop: &Population, n: usize) {
+    if pop.households.is_empty() || n == 0 {
+        return;
+    }
+    println!("=== SAMPLE HOUSEHOLDS ({} of {}) ===", n.min(pop.households.len()), pop.households.len());
+    let n = n.min(pop.households.len());
+    let step = (pop.households.len() / n).max(1);
+    let look_name = |id: NpcId| -> String {
+        pop.get(id).map(|m| m.display_name()).unwrap_or_else(|| format!("npc#{}", id))
+    };
+    for h_idx in (0..pop.households.len()).step_by(step).take(n) {
+        let h = &pop.households[h_idx];
+        println!(
+            "House #{:<3} {:<14} [{:<7}] ({} members):",
+            h_idx, format!("\"{}\"", h.surname), h.wealth.label(), h.members.len(),
+        );
+        for m in &h.members {
+            let prof = m
+                .profession
+                .map(|p| format!("{:?}", p))
+                .unwrap_or_else(|| "—".to_string());
+            let kin: Vec<String> = m
+                .relationships
+                .iter()
+                .map(|r| {
+                    let kind = format!("{:?}", r.kind).to_lowercase();
+                    // Mark cross-household kin so the sample shows them.
+                    let dst_h = pop.by_id.get(&r.to).map(|&(h, _)| h);
+                    let mark = if dst_h.is_some() && dst_h != Some(h_idx) {
+                        " (cross)"
+                    } else {
+                        ""
+                    };
+                    format!("{}: {}{}", kind, look_name(r.to), mark)
+                })
+                .collect();
+            let kin_str = if kin.is_empty() {
+                "—".to_string()
+            } else {
+                kin.join(", ")
+            };
+            println!(
+                "  {:<24} {:<6} {:<14} | {}",
+                m.display_name(),
+                format!("{:?}", m.life_stage),
+                prof,
+                kin_str,
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Flat fixture roster (workplaces, plaza)
+// ============================================================================
+
+/// Generate a flat roster of `count` adult NPCs for fixture placement (plaza
+/// vendors, workplace workers, guards). Unlike household members, these are
+/// not registered in any [`Population`] — they have unique ids but no kin
+/// edges, no home, and a profession rolled up front (since fixtures are
+/// usually overridden by the scene's slot anyway).
+pub fn build_roster(
+    count: usize,
+    culture: Culture,
+    data: &NpcData,
+    alloc: &mut IdAllocator,
+    rng: &mut RNG,
+) -> Vec<Npc> {
     let biome = villager_biome_for(culture);
     (0..count)
         .map(|_| {
-            let mut name = rng.choose(&data.first_names).clone();
-            if !data.epithets.is_empty() && rng.percent(35) {
-                name.push(' ');
-                name.push_str(rng.choose(&data.epithets).as_str());
+            let stage = LifeStage::Adult;
+            Npc {
+                id: alloc.next_id(),
+                first_name: roll_first_name(data, rng),
+                surname: roll_surname(data, rng),
+                epithet: roll_epithet(stage, data, rng),
+                life_stage: stage,
+                biome,
+                profession: Some(*rng.choose(&PROFESSIONS)),
+                relationships: Vec::new(),
             }
-            let profession = *rng.choose(&PROFESSIONS);
-            // Children aren't decided here yet — residents default to adults; the
-            // caller flips `is_child` (and the spawner's `child`) when it wants one.
-            Npc { name, biome, profession, is_child: false }
         })
         .collect()
 }
+
+// ============================================================================
+// Placement
+// ============================================================================
 
 /// One house's harvested anchor scenes plus the population budget its beds
 /// imply. `population` is the count of anchors the town-wide draw aims to staff
 /// for this house — derived by the caller from sleeping capacity (see
 /// `POPULATION_PER_BED` in `settlement`), so a double bed counts for two.
+/// `wealth` is the building's SizeClass mapped through
+/// [`Wealth::from_size_class`] and drives household-shape and employment skew.
 pub struct HouseAnchors {
     pub scenes: Vec<AnchorScene>,
     pub population: usize,
+    pub wealth: Wealth,
 }
 
 /// One candidate scene in the town-wide draw, tagged with the house it belongs
@@ -344,8 +1626,9 @@ struct Entry {
 /// (keyed by the first slot's dialogue key) and hand its lines out in slot
 /// order, so a pair reads as one back-and-forth; solo scenes fall back to a
 /// per-slot line. A slot may force a profession (workplace fixtures); otherwise
-/// the NPC keeps the roster's random trade. `home`, when set, tags every NPC in
-/// the scene with the house they belong to (see [`spawn_villager_npc`]).
+/// the NPC's own profession is used (defaulting to [`Profession::None`] for
+/// children and unemployed residents). `home`, when set, tags every NPC in the
+/// scene with the house they belong to (see [`spawn_villager_npc`]).
 async fn staff_scene(
     editor: &Editor,
     scene: &AnchorScene,
@@ -372,14 +1655,18 @@ async fn staff_scene(
             continue; // optional slots fill only if roster remains
         }
         let Some(npc) = pool.pop() else { break };
-        let profession = slot.profession.unwrap_or(npc.profession);
+        let profession = slot
+            .profession
+            .or(npc.profession)
+            .unwrap_or(Profession::None);
         let dialogue = exchange
             .as_ref()
             .and_then(|lines| lines.get(i).cloned())
             .unwrap_or_else(|| data.line(slot.dialogue.as_deref(), rng));
+        let display_name = npc.display_name();
         spawn_villager_npc(
-            editor, slot.pos, slot.facing, &npc.name, &dialogue, npc.biome, profession, slot.volume,
-            home, npc.is_child, slot.y_offset,
+            editor, slot.pos, slot.facing, &display_name, &dialogue, npc.biome,
+            profession, slot.volume, home, npc.is_child(), slot.y_offset,
         )
         .await?;
         placed += 1;
@@ -418,19 +1705,22 @@ fn decay_house(entries: &mut [Entry], house: usize) {
     }
 }
 
-/// Populate a whole town from per-house anchors, sizing the crowd to beds.
+/// Populate a whole town: per-house anchors paired with the pre-built
+/// [`Population`].
 ///
-/// The budget is `Σ max(1, beds)` over all houses. A seed pass staffs one anchor
-/// in every house that has any (so each populated house gets at least one
-/// resident), then a town-wide weighted draw fills the rest: anchors are picked
-/// in proportion to their current weight (multi-person scenes weigh more), and
-/// each placement halves the rest of that house's weights so the crowd flows off
-/// filled houses onto emptier ones. Returns the number of NPCs spawned. No-op
-/// (returns 0) in offline mode.
+/// `houses` and `population.households` must be parallel (same length, same
+/// ordering by house index). For each house, the candidate NPC pool is its
+/// household's members. A seed pass staffs one anchor in every house that has
+/// any (so each populated house gets at least one resident), then a town-wide
+/// weighted draw fills the rest: anchors are picked in proportion to their
+/// current weight (multi-person scenes weigh more), and each placement halves
+/// the rest of that house's weights so the crowd flows off filled houses onto
+/// emptier ones. Returns the number of NPCs spawned. No-op (returns 0) in
+/// offline mode.
 pub async fn populate_town(
     editor: &Editor,
     houses: Vec<HouseAnchors>,
-    culture: Culture,
+    population: Population,
     data: &NpcData,
     rng: &mut RNG,
 ) -> anyhow::Result<usize> {
@@ -456,17 +1746,27 @@ pub async fn populate_town(
     }
     let num_houses = entries.iter().map(|e| e.house).max().map_or(0, |m| m + 1);
 
-    // Roster: names/professions for up to two NPCs per staffed anchor (v1's max
-    // slot count). Drained from the back as scenes are staffed.
-    let mut pool = build_roster((budget * 2).max(1), culture, data, &mut rng.derive());
+    // Per-house NPC pools, taken from the population. A house with no household
+    // entry (shouldn't happen if parallel) ends up with an empty pool — its
+    // anchors will simply skip.
+    let mut households = population.households;
+    let mut pools: Vec<Vec<Npc>> = (0..num_houses)
+        .map(|i| {
+            if i < households.len() {
+                std::mem::take(&mut households[i].members)
+            } else {
+                Vec::new()
+            }
+        })
+        .collect();
 
     let mut placed_anchors = 0usize;
     let mut placed_npcs = 0usize;
 
     // Seed pass: one anchor per house that has any, before the town-wide draw.
     for house in 0..num_houses {
-        if pool.is_empty() || placed_anchors >= budget {
-            break;
+        if pools[house].is_empty() || placed_anchors >= budget {
+            continue;
         }
         let live: Vec<usize> = entries
             .iter()
@@ -474,8 +1774,11 @@ pub async fn populate_town(
             .filter(|(_, e)| e.house == house && !e.used)
             .map(|(i, _)| i)
             .collect();
-        let Some(idx) = weighted_pick(&entries, &live, rng) else { continue };
-        let n = staff_scene(editor, &entries[idx].scene, &mut pool, data, rng, Some(house)).await?;
+        let Some(idx) = weighted_pick(&entries, &live, rng) else {
+            continue;
+        };
+        let n = staff_scene(editor, &entries[idx].scene, &mut pools[house], data, rng, Some(house))
+            .await?;
         entries[idx].used = true;
         if n > 0 {
             placed_npcs += n;
@@ -485,16 +1788,19 @@ pub async fn populate_town(
     }
 
     // Town-wide draw for the remaining budget.
-    while placed_anchors < budget && !pool.is_empty() {
+    while placed_anchors < budget && pools.iter().any(|p| !p.is_empty()) {
         let live: Vec<usize> = entries
             .iter()
             .enumerate()
-            .filter(|(_, e)| !e.used)
+            .filter(|(_, e)| !e.used && !pools[e.house].is_empty())
             .map(|(i, _)| i)
             .collect();
-        let Some(idx) = weighted_pick(&entries, &live, rng) else { break };
+        let Some(idx) = weighted_pick(&entries, &live, rng) else {
+            break;
+        };
         let house = entries[idx].house;
-        let n = staff_scene(editor, &entries[idx].scene, &mut pool, data, rng, Some(house)).await?;
+        let n = staff_scene(editor, &entries[idx].scene, &mut pools[house], data, rng, Some(house))
+            .await?;
         entries[idx].used = true;
         if n > 0 {
             placed_npcs += n;
@@ -563,10 +1869,24 @@ mod tests {
     use crate::noise::{Seed, RNG};
     use crate::util::init_logger;
 
-    /// `npcs.yaml` parses and the context dialogue pools resolve. No server.
+    /// `npcs.yaml` parses (including the surname prefix/suffix pools) and
+    /// `roll_surname` produces a non-empty concatenation. No server.
     #[test]
     fn npc_dialogue_pools_resolve() {
         let data = NpcData::load().expect("load npcs.yaml");
+        assert!(!data.surname_prefixes.is_empty(), "surname_prefixes must be non-empty");
+        assert!(!data.surname_suffixes.is_empty(), "surname_suffixes must be non-empty");
+        // The combined surname is the literal prefix+suffix concat (no separator).
+        let mut sn_rng = RNG::new(Seed(123));
+        let sn = roll_surname(&data, &mut sn_rng);
+        assert!(
+            data.surname_prefixes.iter().any(|p| sn.starts_with(p)),
+            "generated surname '{sn}' should start with one of the prefixes",
+        );
+        assert!(
+            data.surname_suffixes.iter().any(|s| sn.ends_with(s)),
+            "generated surname '{sn}' should end with one of the suffixes",
+        );
         let mut rng = RNG::new(Seed(1));
         // A known context key returns a line from its own pool, not small_talk.
         let cooking = &data.dialogue["cooking"];
@@ -600,6 +1920,105 @@ mod tests {
         assert!(data.exchange_of_len("no_such_key", 2, &mut rng).is_none());
     }
 
+    /// `display_name` renders epithet-or-surname per spec, but `surname` is
+    /// always stored regardless.
+    #[test]
+    fn display_name_picks_epithet_over_surname() {
+        let with_epithet = Npc {
+            id: 1,
+            first_name: "Doral".into(),
+            surname: "Carter".into(),
+            epithet: Some("the Quiet".into()),
+            life_stage: LifeStage::Elder,
+            biome: VillagerBiome::Plains,
+            profession: None,
+            relationships: Vec::new(),
+        };
+        assert_eq!(with_epithet.display_name(), "Doral the Quiet");
+        assert_eq!(with_epithet.surname, "Carter"); // still stored
+
+        let without = Npc { epithet: None, ..with_epithet.clone() };
+        assert_eq!(without.display_name(), "Doral Carter");
+    }
+
+    /// Build a small batch of households and assert intra-household kinship is
+    /// reciprocal (every Parent has a matching Child, every Spouse is mutual,
+    /// every Sibling is mutual) and member counts hit each bed budget. No
+    /// server.
+    #[test]
+    fn intra_household_kin_is_reciprocal() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        let mut rng = RNG::new(Seed(11));
+        let mut alloc = IdAllocator::new();
+        // A mix of bed budgets covering every shape branch.
+        let houses: Vec<HouseAnchors> = (1..=6)
+            .map(|pop| HouseAnchors { scenes: Vec::new(), population: pop, wealth: Wealth::Modest })
+            .collect();
+        let pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
+        assert_eq!(pop.households.len(), houses.len());
+
+        // Every household's primary surname is unique within the town.
+        let mut seen = std::collections::HashSet::new();
+        for h in &pop.households {
+            assert!(
+                seen.insert(h.surname.clone()),
+                "duplicate primary surname '{}' across households",
+                h.surname,
+            );
+        }
+
+        // Every member is registered in by_id and the lookup round-trips.
+        for (h_idx, h) in pop.households.iter().enumerate() {
+            for (m_idx, m) in h.members.iter().enumerate() {
+                let entry = pop.by_id.get(&m.id).expect("member registered in by_id");
+                assert_eq!(*entry, (h_idx, m_idx));
+            }
+            assert!(!h.members.is_empty(), "every household has at least one member");
+        }
+
+        // Every edge has a reciprocal counterpart.
+        for h in &pop.households {
+            for m in &h.members {
+                for r in &m.relationships {
+                    let target = pop.get(r.to).expect("relationship target exists");
+                    let expected_back = match r.kind {
+                        RelationshipKind::Spouse => RelationshipKind::Spouse,
+                        RelationshipKind::Sibling => RelationshipKind::Sibling,
+                        RelationshipKind::Parent => RelationshipKind::Child,
+                        RelationshipKind::Child => RelationshipKind::Parent,
+                    };
+                    assert!(
+                        target.relationships.iter().any(|tr| tr.kind == expected_back && tr.to == m.id),
+                        "missing reciprocal {:?} from {} back to {}", expected_back, target.id, m.id,
+                    );
+                }
+            }
+        }
+    }
+
+    /// `assign_employment` leaves children unemployed, mostly retires elders,
+    /// and gives every adult a profession. No server.
+    #[test]
+    fn employment_pass_respects_life_stage() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        let mut rng = RNG::new(Seed(13));
+        let mut alloc = IdAllocator::new();
+        let houses: Vec<HouseAnchors> = (1..=6)
+            .map(|pop| HouseAnchors { scenes: Vec::new(), population: pop, wealth: Wealth::Modest })
+            .collect();
+        let mut pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
+        assign_employment(&mut pop, &mut rng);
+        for h in &pop.households {
+            for m in &h.members {
+                match m.life_stage {
+                    LifeStage::Child => assert!(m.profession.is_none(), "child stays unemployed"),
+                    LifeStage::Adult => assert!(m.profession.is_some(), "every adult gets a trade"),
+                    LifeStage::Elder => {} // either None (retired) or Some (kept)
+                }
+            }
+        }
+    }
+
     /// Build a small roster and place it along a row of solo anchors across the
     /// middle of the build area, so the variety (names, professions, dialogue)
     /// can be eyeballed in-game. Needs a live server.
@@ -613,6 +2032,7 @@ mod tests {
         let world = World::new(&provider).await.expect("Failed to create world");
         let editor = Editor::new(build_area, world);
         let mut rng = RNG::new(Seed(42));
+        let mut alloc = IdAllocator::new();
 
         let size = editor.world().world_rect_2d().size;
         let cz = size.y / 2;
@@ -630,7 +2050,7 @@ mod tests {
             .collect();
 
         let data = NpcData::load().expect("load npcs.yaml");
-        let roster = build_roster(count as usize, Culture::Desert, &data, &mut rng);
+        let roster = build_roster(count as usize, Culture::Desert, &data, &mut alloc, &mut rng);
         let placed = populate_npcs(&editor, scenes, roster, count as usize, &data, &mut rng)
             .await
             .expect("populate failed");

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -523,6 +523,12 @@ pub struct NpcData {
     /// pool rolled per guard (mix villager and mob skins; repeat to weight).
     /// `looks` must be non-empty (enforced by [`NpcData::validate`]).
     pub guards: Fixture,
+    /// Market-stall vendor fixture — the skin pool and job label for the trader
+    /// hawking wares behind a plaza stall. `looks` must be non-empty.
+    pub vendors: Fixture,
+    /// Stage performer fixture — the skin pool and job label for a troupe member
+    /// up on a plaza stage. `looks` must be non-empty.
+    pub performers: Fixture,
     /// Fallback worker [`Staffing`] for buildings whose structure JSON declares
     /// no `staffing` block of its own. Workplace staffing now lives on each
     /// building's structure sidecar; this only covers the unstated ones.
@@ -607,6 +613,12 @@ impl NpcData {
     pub fn validate(&self, structures: &HashMap<StructureType, Structure>) -> anyhow::Result<()> {
         if self.guards.looks.is_empty() {
             anyhow::bail!("npcs.yaml: `guards.looks` must list at least one entry");
+        }
+        if self.vendors.looks.is_empty() {
+            anyhow::bail!("npcs.yaml: `vendors.looks` must list at least one entry");
+        }
+        if self.performers.looks.is_empty() {
+            anyhow::bail!("npcs.yaml: `performers.looks` must list at least one entry");
         }
         if self.default_staffing.looks.is_empty() {
             anyhow::bail!("npcs.yaml: `default_staffing.looks` must list at least one entry");

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -241,52 +241,12 @@ pub async fn generate_town(
     let urban_industrial_count = editor.world().structures.len() - n_before;
 
     // ---- Rural buildings ----
-    // Outside the wall, the resource chain assigns each rural super-parcel a
-    // gathering/processing building from its biome resources (a farm, mine,
-    // sawmill, ranch, ...). Resolve the assignments, place one building per
-    // assigned parcel, and paint its production area (fields, pasture, spoil).
-    // These sit in their own parcels — independent of the urban road network and
-    // not barriers for it — and each placement flattens its own footprint and
-    // clears its yard, so the pass is self-contained. Their `Structure` claim ids
-    // follow the urban ones, so the worker-staffing pass below picks them up too.
-    let n_rural_before = editor.world().structures.len();
-    {
-        use crate::generator::districts::DistrictID;
-        use crate::generator::placement::place_rural_building;
-        use crate::generator::resource_chain::paint_production_area;
-
-        let rural_ids: Vec<DistrictID> = editor.world().districts.iter()
-            .filter(|(_, sd)| sd.data.parcel_type == ParcelType::Rural)
-            .map(|(id, _)| *id)
-            .collect();
-        let rural_analysis: HashMap<DistrictID, _> = rural_ids.iter()
-            .filter_map(|id| editor.world().district_analysis_data.get(id).map(|a| (*id, a.clone())))
-            .collect();
-        let result = data.resource_registry.resolve_for_parcels(&rural_analysis, &mut rng);
-
-        // One placement per assigned rural parcel (assignments are keyed by
-        // DistrictID); sort for deterministic order.
-        let mut sd_ids: Vec<DistrictID> = result.parcel_assignments.keys().cloned().collect();
-        sd_ids.sort_by_key(|id| id.0);
-        for sd_id in &sd_ids {
-            let assignment = &result.parcel_assignments[sd_id];
-            let Some(district) = editor.world().districts.get(sd_id).cloned() else { continue };
-            let structure_type = crate::generator::nbts::StructureType(assignment.building.clone());
-            let Some(structure) = data.structures.get(&structure_type).cloned() else {
-                log::warn!("no structure for rural building '{}'", assignment.building);
-                continue;
-            };
-            match place_rural_building(&district, &structure, &mut rng, editor, &data).await {
-                Ok(()) => {
-                    if let Some(painter) = &assignment.production_painter {
-                        paint_production_area(&district, painter, &data, editor, &mut rng).await;
-                    }
-                }
-                Err(e) => log::warn!("rural placement failed for '{}': {}", assignment.building, e),
-            }
-        }
-    }
-    let rural_building_count = editor.world().structures.len() - n_rural_before;
+    // The rural resource-chain pass above already placed each gathering/
+    // processing building (farm, mine, sawmill, ranch, ...) in its own parcel and
+    // painted its production area. Their `Structure` claim ids follow the urban
+    // ones, so the worker-staffing pass below picks them up alongside the urban
+    // shops.
+    let rural_building_count = placed_rural.len();
     let rural_parcel_count = editor.world().districts.values()
         .filter(|sd| sd.data.parcel_type == ParcelType::Rural)
         .count();

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::data::Loadable;
 use crate::editor::Editor;
 use crate::generator::data::LoadedData;
-use crate::generator::districts::{build_wall, generate_parcels, ParcelType, WallType};
+use crate::generator::districts::{build_wall, generate_parcels, ParcelType, TowerSkin, WallType};
 use crate::generator::materials::{Material, MaterialId, Placer};
 use crate::generator::nbts::Structure;
 use crate::generator::paths::{build_paths_merged, build_road_network, build_rural_road_network, find_blocks, Path, PathPriority, RuralBuilding};
@@ -94,9 +94,10 @@ pub async fn generate_town(
             p
         }
     });
+    let tower_skin = tower_palette.as_ref().map(|p| TowerSkin { data: &data, palette: p });
     build_wall(
         &editor.world().get_urban_points(), editor, &mut rng2,
-        &mut placer, &wall_material, &structures, WallType::Standard, tower_palette.as_ref(),
+        &mut placer, &wall_material, &structures, WallType::Standard, tower_skin.as_ref(),
     ).await;
     drop(placer);
 

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -238,6 +238,62 @@ pub async fn generate_town(
         "Placed {} / {} industrial buildings",
         editor.world().structures.len() - n_before, ind_counts.values().sum::<u32>(),
     );
+    let urban_industrial_count = editor.world().structures.len() - n_before;
+
+    // ---- Rural buildings ----
+    // Outside the wall, the resource chain assigns each rural super-parcel a
+    // gathering/processing building from its biome resources (a farm, mine,
+    // sawmill, ranch, ...). Resolve the assignments, place one building per
+    // assigned parcel, and paint its production area (fields, pasture, spoil).
+    // These sit in their own parcels — independent of the urban road network and
+    // not barriers for it — and each placement flattens its own footprint and
+    // clears its yard, so the pass is self-contained. Their `Structure` claim ids
+    // follow the urban ones, so the worker-staffing pass below picks them up too.
+    let n_rural_before = editor.world().structures.len();
+    {
+        use crate::generator::districts::DistrictID;
+        use crate::generator::placement::place_rural_building;
+        use crate::generator::resource_chain::paint_production_area;
+
+        let rural_ids: Vec<DistrictID> = editor.world().districts.iter()
+            .filter(|(_, sd)| sd.data.parcel_type == ParcelType::Rural)
+            .map(|(id, _)| *id)
+            .collect();
+        let rural_analysis: HashMap<DistrictID, _> = rural_ids.iter()
+            .filter_map(|id| editor.world().district_analysis_data.get(id).map(|a| (*id, a.clone())))
+            .collect();
+        let result = data.resource_registry.resolve_for_parcels(&rural_analysis, &mut rng);
+
+        // One placement per assigned rural parcel (assignments are keyed by
+        // DistrictID); sort for deterministic order.
+        let mut sd_ids: Vec<DistrictID> = result.parcel_assignments.keys().cloned().collect();
+        sd_ids.sort_by_key(|id| id.0);
+        for sd_id in &sd_ids {
+            let assignment = &result.parcel_assignments[sd_id];
+            let Some(district) = editor.world().districts.get(sd_id).cloned() else { continue };
+            let structure_type = crate::generator::nbts::StructureType(assignment.building.clone());
+            let Some(structure) = data.structures.get(&structure_type).cloned() else {
+                log::warn!("no structure for rural building '{}'", assignment.building);
+                continue;
+            };
+            match place_rural_building(&district, &structure, &mut rng, editor, &data).await {
+                Ok(()) => {
+                    if let Some(painter) = &assignment.production_painter {
+                        paint_production_area(&district, painter, &data, editor, &mut rng).await;
+                    }
+                }
+                Err(e) => log::warn!("rural placement failed for '{}': {}", assignment.building, e),
+            }
+        }
+    }
+    let rural_building_count = editor.world().structures.len() - n_rural_before;
+    let rural_parcel_count = editor.world().districts.values()
+        .filter(|sd| sd.data.parcel_type == ParcelType::Rural)
+        .count();
+    println!(
+        "Placed {} rural buildings across {} rural parcels",
+        rural_building_count, rural_parcel_count,
+    );
 
     // Footprints → a `blocked` barrier (footprint + margin) and one node per
     // building for the network to connect.
@@ -817,6 +873,24 @@ pub async fn generate_town(
         );
     }
 
+    // Count plaza employment for the jobs summary: a stall is any scene with a
+    // `Worker` slot (market vendors), a stage is a `Performance` scene, and its
+    // performer slots are the per-stage cast. Onlookers/browsers aren't jobs.
+    let (market_stall_count, stage_count, performer_slot_count) = {
+        use crate::generator::population::{SceneKind, SlotRole};
+        let stalls = plaza_scenes.iter()
+            .filter(|s| s.slots.iter().any(|sl| sl.role == SlotRole::Worker))
+            .count();
+        let stages = plaza_scenes.iter()
+            .filter(|s| s.kind == SceneKind::Performance)
+            .count();
+        let performers: usize = plaza_scenes.iter()
+            .filter(|s| s.kind == SceneKind::Performance)
+            .map(|s| s.slots.len())
+            .sum();
+        (stalls, stages, performers)
+    };
+
     // ---- Plaza fixtures: staff every harvested plaza scene ----
     // Stage performers, market vendors, and onlookers are fixtures like the
     // industrial workers below — always placed, independent of the resident bed
@@ -862,40 +936,75 @@ pub async fn generate_town(
         }
     }
 
-    // ---- Industrial worker fixtures ----
-    // Staff every industrial shop with exactly one worker NPC standing just
-    // outside it, facing the workshop, wearing the trade outfit that matches its
-    // type (a smith at the smithy, a shepherd at the weaver, ...). These are
-    // fixtures: always placed, independent of the resident budget above. The NBT
-    // interiors are opaque, so the worker stands on a clear ground cell at the
-    // footprint edge — never inside, never on a road or another building.
+    // ---- Worker fixtures: staff every workplace ----
+    // Stand a small crew of worker NPCs just outside each placed building (urban
+    // processing shop or rural gather building), facing it, wearing the trade
+    // outfit that matches its type. These are fixtures: always placed, independent
+    // of the resident budget above. The NBT interiors are opaque, so workers stand
+    // on clear ground cells at the footprint edge — never inside, never on a road
+    // or another building. A workplace can employ several hands (see `workers_for`).
     {
         use crate::generator::npc::Profession;
-        use crate::generator::population::{build_roster, populate_npcs, AnchorScene, NpcData};
+        use crate::generator::population::{
+            build_roster, populate_npcs, AnchorScene, AnchorSlot, NpcData, SceneKind, SlotRole,
+        };
 
-        // type name -> trade outfit. smithy/carpenter roll across a small set so
-        // shops of the same kind don't all wear the identical profession.
+        // Building type -> trade outfit. Shops with a set roll across it so two of
+        // the same kind don't always match. Covers urban processing shops and rural
+        // gather buildings; the default keeps any unmapped workplace staffed.
         let mut worker_rng = rng.derive();
         let profession_for = |kind: &str, rng: &mut RNG| -> Option<Profession> {
             Some(match kind {
-                "smithy" => *rng.choose(&[
-                    Profession::Weaponsmith, Profession::Toolsmith, Profession::Armorer,
-                ]),
-                "mill" => Profession::Farmer,
-                "bakery" => Profession::Butcher, // no baker profession; closest food trade
-                "carpenter" => *rng.choose(&[Profession::Fletcher, Profession::Mason]),
+                // — urban processing shops —
+                "smithy" | "smelter" => {
+                    *rng.choose(&[Profession::Weaponsmith, Profession::Toolsmith, Profession::Armorer])
+                }
+                "mill" | "sawmill" | "sugar_mill" | "paper_mill_wood" | "paper_mill_sugar" => {
+                    Profession::Farmer
+                }
+                "bakery" | "confectionery" | "butcher" => Profession::Butcher,
+                "carpenter" | "woodcutter_hut" => {
+                    *rng.choose(&[Profession::Fletcher, Profession::Mason])
+                }
                 "tannery" => Profession::Leatherworker,
-                "weaver" => Profession::Shepherd,
-                _ => return None,
+                "weaver" | "tailor" => Profession::Shepherd,
+                "scriptorium" => Profession::Librarian,
+                "brewery" | "chandlery" | "apiary" => Profession::Farmer,
+                // — rural gather buildings —
+                "farm" | "sugar_plantation" => Profession::Farmer,
+                "ranch" | "shepherds_hut" => Profession::Shepherd,
+                "iron_mine" | "coal_mine" | "charcoal_burner" => Profession::Mason,
+                // sensible default so every placed workplace gets a worker
+                _ => Profession::Farmer,
             })
         };
 
-        // Re-scan the claim map: industrial buildings are the only `Structure`
-        // claims (wall towers claim `Wall`), and claims persist, so this recovers
-        // each building's footprint + type without threading state out of the
-        // early industrial phase. Group cells by instance id.
+        // How many hands a workplace employs, capped later by available stand
+        // cells. Big farms field a full crew; processing shops a standard crew;
+        // small gather huts/mines a pair.
+        let workers_for = |kind: &str| -> usize {
+            match kind {
+                "farm" | "ranch" | "sugar_plantation" => 4,
+                "iron_mine" | "coal_mine" | "charcoal_burner" | "woodcutter_hut"
+                | "shepherds_hut" | "apiary" => 2,
+                // processing shops and anything unmapped run a standard crew
+                _ => 3,
+            }
+        };
+
+        // Re-scan the claim map: placed buildings are the only `Structure` claims
+        // (wall towers claim `Wall`), and claims persist, so this recovers each
+        // building's footprint + type without threading state out of the placement
+        // phases. Scan the urban area *and* every rural parcel so rural gather
+        // buildings get staffed alongside urban shops. Group cells by instance id.
+        let mut scan_cells: Vec<Point2D> = urban.iter().copied().collect();
+        for sd in editor.world().districts.values() {
+            if sd.data.parcel_type == ParcelType::Rural {
+                scan_cells.extend(sd.data.points_2d.iter().copied());
+            }
+        }
         let mut footprints: HashMap<u32, (String, Vec<Point2D>)> = HashMap::new();
-        for &p in &urban {
+        for &p in &scan_cells {
             if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
                 footprints
                     .entry(id.id)
@@ -925,16 +1034,17 @@ pub async fn generate_town(
         ids.sort_unstable();
 
         let mut worker_scenes: Vec<AnchorScene> = Vec::new();
+        // Tally placed workers by trade for the employment-by-job breakdown.
+        let mut worker_by_prof: HashMap<String, usize> = HashMap::new();
         for id in ids {
             let (kind, cells) = &footprints[&id];
-            let Some(profession) = profession_for(kind, &mut worker_rng) else { continue };
             let cell_set: HashSet<Point2D> = cells.iter().copied().collect();
             let centroid =
                 cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
 
             // Candidate stand cells: cardinally adjacent to the footprint, outside
-            // it, in bounds, and clear. Sort for determinism, then prefer a cell
-            // that borders a road so the worker reads as standing at the street.
+            // it, in bounds, and clear. Road-bordering cells sort first (so workers
+            // read as standing at the street), then deterministic order.
             let mut candidates: Vec<Point2D> = Vec::new();
             let mut seen: HashSet<Point2D> = HashSet::new();
             for &fc in cells {
@@ -948,24 +1058,82 @@ pub async fn generate_town(
                     }
                 }
             }
-            candidates.sort_unstable_by_key(|c| (c.x, c.y));
-            let stand = candidates
-                .iter()
-                .find(|c| road_side(**c))
-                .or_else(|| candidates.first())
-                .copied();
-            let Some(stand) = stand else {
-                log::warn!("no clear stand cell for industrial '{}' (id {})", kind, id);
-                continue;
-            };
+            candidates.sort_unstable_by_key(|c| (!road_side(*c), c.x, c.y));
 
-            // Stand on the ground at the cell; face the footprint centroid.
-            let y = editor.world().get_ocean_floor_height_at(stand);
-            let stand3 = Point3D::new(stand.x, y, stand.y);
-            let centre3 = Point3D::new(centroid.x, y, centroid.y);
-            let facing = crate::generator::population::yaw_toward(stand3, centre3);
-            worker_scenes.push(AnchorScene::worker(stand3, facing, profession));
+            // Staff up to `workers_for` hands on distinct stand cells, each with a
+            // freshly rolled trade so a multi-worker shop isn't uniform.
+            let want = workers_for(kind).min(candidates.len());
+            if want == 0 {
+                log::warn!("no clear stand cell for building '{}' (id {})", kind, id);
+                continue;
+            }
+            for &stand in candidates.iter().take(want) {
+                let Some(profession) = profession_for(kind, &mut worker_rng) else { continue };
+                // Stand on the ground at the cell; face the footprint centroid.
+                let y = editor.world().get_ocean_floor_height_at(stand);
+                let stand3 = Point3D::new(stand.x, y, stand.y);
+                let centre3 = Point3D::new(centroid.x, y, centroid.y);
+                let facing = crate::generator::population::yaw_toward(stand3, centre3);
+                worker_scenes.push(AnchorScene::worker(stand3, facing, profession));
+                *worker_by_prof.entry(format!("{:?}", profession)).or_insert(0) += 1;
+            }
         }
+
+        let industrial_job_slots = worker_scenes.len();
+        let workplace_count = footprints.len();
+
+        // ---- Guard posts: gates + wall towers ----
+        // Gates get 1–2 guards each; each tower has a 10% chance of 2 guards and a
+        // 20% chance of 1 (else none). Guards are Armorer-skinned fixtures with
+        // their own dialogue, watching the approaches.
+        let guard_scene = |feet: Point3D, facing: f32| -> AnchorScene {
+            let mut slot = AnchorSlot::new(feet, facing, SlotRole::Worker);
+            slot.profession = Some(Profession::Armorer);
+            slot.dialogue = Some("guarding".to_string());
+            AnchorScene::group(SceneKind::Solo, vec![slot])
+        };
+        let town_centre = {
+            let n = urban.len().max(1) as i32;
+            urban.iter().fold(Point2D::ZERO, |a, &p| a + p) / n
+        };
+        // Gates: one guard a couple cells inside the opening; when a gate gets a
+        // second, it stands the same distance outside — a guard on each side of
+        // the gate. Both face the opening.
+        for (gate_point, dir) in editor.world().gate_locations.clone() {
+            let base = gate_point.drop_y();
+            let fwd: Point2D = dir.into();
+            // One cell to each side of the gate centre — in the opening, not the
+            // wall a couple cells away.
+            let inside = Point2D::new(base.x - fwd.x, base.y - fwd.y);
+            let outside = Point2D::new(base.x + fwd.x, base.y + fwd.y);
+            let stands: Vec<Point2D> = if worker_rng.percent(50) {
+                vec![inside, outside]
+            } else {
+                vec![inside]
+            };
+            for s in stands {
+                let y = editor.world().get_ocean_floor_height_at(s);
+                let feet = Point3D::new(s.x, y, s.y);
+                let facing =
+                    crate::generator::population::yaw_toward(feet, Point3D::new(base.x, y, base.y));
+                worker_scenes.push(guard_scene(feet, facing));
+            }
+        }
+        // Towers: weighted small chance of 1–2 guards on the walkway beside each.
+        for posts in editor.world().tower_guard_posts.clone() {
+            let roll = worker_rng.rand_i32(100);
+            let n: usize = if roll < 10 { 2 } else if roll < 30 { 1 } else { 0 };
+            for feet in posts.into_iter().take(n) {
+                let facing = crate::generator::population::yaw_toward(
+                    Point3D::new(town_centre.x, feet.y, town_centre.y),
+                    feet,
+                );
+                let mut scene = guard_scene(feet, facing);
+                scene.slots[0].y_offset = 0.5; // stand on the battlement slab, not sunk in it
+                worker_scenes.push(scene);
+            }
+        }
+        let guard_count = worker_scenes.len() - industrial_job_slots;
 
         if !worker_scenes.is_empty() {
             match NpcData::load() {
@@ -976,12 +1144,51 @@ pub async fn generate_town(
                         build_roster(worker_scenes.len(), culture, &npc_data, &mut rng.derive());
                     let budget = worker_scenes.len();
                     match populate_npcs(editor, worker_scenes, worker_roster, budget, &npc_data, &mut rng).await {
-                        Ok(staffed) => println!("Staffed {} industrial workers", staffed),
-                        Err(e) => log::warn!("industrial staffing failed: {}", e),
+                        Ok(staffed) => println!(
+                            "Staffed {} fixture NPCs ({} workers across {} workplaces + {} guards)",
+                            staffed, industrial_job_slots, workplace_count, guard_count,
+                        ),
+                        Err(e) => log::warn!("worker/guard staffing failed: {}", e),
                     }
                 }
                 Err(e) => log::warn!("could not load npcs.yaml for staffing: {}", e),
             }
+        }
+
+        // ---- Jobs summary ----
+        let total_industrial = urban_industrial_count + rural_building_count;
+        let approx_jobs =
+            industrial_job_slots + guard_count + market_stall_count + performer_slot_count;
+        println!("=== JOBS SUMMARY ===");
+        println!(
+            "Industrial/resource buildings: {} ({} urban + {} rural)",
+            total_industrial, urban_industrial_count, rural_building_count,
+        );
+        println!("Workers: {}", industrial_job_slots);
+        println!("Guards: {} (gates + towers)", guard_count);
+        println!("Market stalls: {}", market_stall_count);
+        println!("Stages: {} ({} performer slots)", stage_count, performer_slot_count);
+        println!(
+            "Approx jobs available: {} (workers {} + guards {} + vendors {} + performers {})",
+            approx_jobs, industrial_job_slots, guard_count, market_stall_count, performer_slot_count,
+        );
+
+        // Employment by job: building trades (sorted by count), then the
+        // non-building roles (guards, vendors, performers).
+        println!("--- Employment by job ---");
+        let mut by_job: Vec<(String, usize)> = worker_by_prof.into_iter().collect();
+        if guard_count > 0 {
+            by_job.push(("Guard".to_string(), guard_count));
+        }
+        if market_stall_count > 0 {
+            by_job.push(("Vendor".to_string(), market_stall_count));
+        }
+        if performer_slot_count > 0 {
+            by_job.push(("Performer".to_string(), performer_slot_count));
+        }
+        by_job.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        for (job, count) in &by_job {
+            println!("  {:<14} {}", job, count);
         }
     }
 

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -803,6 +803,7 @@ pub async fn generate_town(
                                 scenes: output.npc_anchors,
                                 population,
                                 wealth: crate::generator::population::Wealth::from_size_class(size_class),
+                                pos: output.footprint.bounds().midpoint(),
                             });
                             // Mark every rect in the footprint (core + wings)
                             // as used so subsequent placements on this lot
@@ -1020,15 +1021,31 @@ pub async fn generate_town(
     // and bubble volume (criers/performers yell), so we just hand them a roster
     // and staff them all. Live-only: no-op offline.
     if !plaza_scenes.is_empty() {
-        use crate::generator::population::{build_roster, populate_npcs};
+        use crate::generator::population::{build_roster, populate_npcs, Occupant};
         let npc_data = &data.npc_data;
         let budget = plaza_scenes.len();
-        let roster = build_roster(budget, culture, npc_data, &mut id_alloc, &mut rng.derive());
+        // Some market/stage onlookers are kid slots; mint exactly that many
+        // children in the roster so those scenes can be staffed (rest adults).
+        let kids = plaza_scenes
+            .iter()
+            .flat_map(|s| &s.slots)
+            .filter(|sl| sl.occupant == Occupant::ChildOnly)
+            .count();
+        let roster = build_roster(budget, kids, culture, npc_data, &mut id_alloc, &mut rng.derive());
         match populate_npcs(editor, plaza_scenes, roster, budget, npc_data, &mut rng).await {
             Ok(staffed) => println!("Staffed {} plaza NPCs", staffed),
             Err(e) => log::warn!("plaza staffing failed: {e}"),
         }
     }
+
+    // Worker binding runs inside the population pass below (before residential
+    // placement). These outlive that scope so the worker-fixture block can
+    // backfill the posts binding couldn't fill from residents, and the jobs
+    // summary can report the full per-trade tally.
+    let mut workplace_backfill: Vec<crate::generator::population::WorkerSlot> = Vec::new();
+    let mut bound_worker_count = 0usize;
+    let mut workplace_count = 0usize;
+    let mut worker_by_job: HashMap<String, usize> = HashMap::new();
 
     // ---- Population: size the resident crowd to beds, scatter it town-wide ----
     // Each house's budget is max(1, beds); the town total is their sum.
@@ -1066,6 +1083,31 @@ pub async fn generate_town(
         log_population_stats(&population);
         log_sample_households(&population, 8);
 
+        // Bind residents to workplaces before seating anyone at home. The draft
+        // weights each unplaced adult by qualification (proximity-led) and spawns
+        // the winner at the post; posts with no taker left fall through to
+        // anonymous fixtures (`workplace_backfill`). Bound workers are marked
+        // `placed`, so `populate_town` skips them — each resident appears once.
+        // Every post (resident-filled or not) is tallied by trade for the summary.
+        use crate::generator::population::bind_workers;
+        let (work_slots, n_workplaces) = discover_worker_slots(editor, &data);
+        workplace_count = n_workplaces;
+        for s in &work_slots {
+            *worker_by_job.entry(s.employment.clone()).or_insert(0) += 1;
+        }
+        match bind_workers(editor, &mut population, work_slots, npc_data, &mut rng.derive()).await {
+            Ok((bound, unfilled)) => {
+                println!(
+                    "Bound {} residents to workplaces; {} posts need fixtures",
+                    bound,
+                    unfilled.len(),
+                );
+                bound_worker_count = bound;
+                workplace_backfill = unfilled;
+            }
+            Err(e) => log::warn!("worker binding failed: {e}"),
+        }
+
         match populate_town(editor, town_anchors, population, npc_data, &mut rng).await {
             Ok(placed) => println!("Populated {} NPCs", placed),
             Err(e) => log::warn!("NPC population failed: {e}"),
@@ -1085,113 +1127,36 @@ pub async fn generate_town(
             build_roster, populate_npcs, AnchorScene, AnchorSlot, SceneKind, SlotRole,
         };
 
-        // Building type -> trade outfit. Looked up in `data/npcs.yaml` via
-        // `workplace_spec`: each entry carries a `professions` list (rolled
-        // across so two of the same kind don't always match) and a `workers`
-        // count. Unknown kinds fall back to the `default` entry.
+        // Workplace posts that binding couldn't fill from residents get an
+        // anonymous fixture: a fresh skin rolled from the post's pool, standing
+        // where binding would have seated the resident. (Residents bound to
+        // workplaces were already spawned in the population pass above; the claim
+        // scan + stand-cell geometry now lives in `discover_worker_slots`.)
         let npc_data = &data.npc_data;
         let mut worker_rng = rng.derive();
 
-        // Re-scan the claim map: placed buildings are the only `Structure` claims
-        // (wall towers claim `Wall`), and claims persist, so this recovers each
-        // building's footprint + type without threading state out of the placement
-        // phases. Scan the urban area *and* every rural parcel so rural gather
-        // buildings get staffed alongside urban shops. Group cells by instance id.
-        let mut scan_cells: Vec<Point2D> = urban.iter().copied().collect();
-        for sd in editor.world().districts.values() {
-            if sd.data.parcel_type == ParcelType::Rural {
-                scan_cells.extend(sd.data.points_2d.iter().copied());
-            }
-        }
-        let mut footprints: HashMap<u32, (String, Vec<Point2D>)> = HashMap::new();
-        for &p in &scan_cells {
-            if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
-                footprints
-                    .entry(id.id)
-                    .or_insert_with(|| (id.structure_type.0.clone(), Vec::new()))
-                    .1
-                    .push(p);
-            }
-        }
-
-        // A cell is a usable stand spot only if nothing else claims it — not a
-        // road, wall, or another building. `get_claim` returns `None` only out
-        // of bounds, so an in-bounds open cell reads as `BuildClaim::None`.
-        let is_clear = |c: Point2D| {
-            matches!(
-                editor.world().get_claim(c),
-                Some(BuildClaim::None) | Some(BuildClaim::Nature)
-            )
-        };
-        let road_side = |c: Point2D| {
-            crate::geometry::CARDINALS_2D
-                .iter()
-                .any(|&d| matches!(editor.world().get_claim(c + d), Some(BuildClaim::Path(_))))
-        };
-
-        // Deterministic order over buildings (HashMap iteration isn't stable).
-        let mut ids: Vec<u32> = footprints.keys().copied().collect();
-        ids.sort_unstable();
-
         let mut worker_scenes: Vec<AnchorScene> = Vec::new();
-        // Tally placed workers by trade for the employment-by-job breakdown.
-        let mut worker_by_prof: HashMap<String, usize> = HashMap::new();
-        for id in ids {
-            let (kind, cells) = &footprints[&id];
-            let cell_set: HashSet<Point2D> = cells.iter().copied().collect();
-            let centroid =
-                cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
-
-            // Candidate stand cells: cardinally adjacent to the footprint, outside
-            // it, in bounds, and clear. Road-bordering cells sort first (so workers
-            // read as standing at the street), then deterministic order.
-            let mut candidates: Vec<Point2D> = Vec::new();
-            let mut seen: HashSet<Point2D> = HashSet::new();
-            for &fc in cells {
-                for d in crate::geometry::CARDINALS_2D {
-                    let c = fc + d;
-                    if cell_set.contains(&c) || !editor.world().is_in_bounds_2d(c) || !is_clear(c) {
-                        continue;
-                    }
-                    if seen.insert(c) {
-                        candidates.push(c);
-                    }
-                }
-            }
-            candidates.sort_unstable_by_key(|c| (!road_side(*c), c.x, c.y));
-
-            // Staff up to the per-kind crew size on distinct stand cells, each
-            // with a freshly rolled trade so a multi-worker shop isn't uniform.
-            let spec = npc_data.workplace_spec(kind);
-            let want = spec.workers.min(candidates.len());
-            if want == 0 {
-                log::warn!("no clear stand cell for building '{}' (id {})", kind, id);
-                continue;
-            }
-            for &stand in candidates.iter().take(want) {
-                let profession = *worker_rng.choose(&spec.professions);
-                // Stand on the ground at the cell; face the footprint centroid.
-                let y = editor.world().get_ocean_floor_height_at(stand);
-                let stand3 = Point3D::new(stand.x, y, stand.y);
-                let centre3 = Point3D::new(centroid.x, y, centroid.y);
-                let facing = crate::generator::population::yaw_toward(stand3, centre3);
-                worker_scenes.push(AnchorScene::worker(stand3, facing, profession));
-                *worker_by_prof.entry(format!("{:?}", profession)).or_insert(0) += 1;
-            }
+        for slot in &workplace_backfill {
+            let look = *worker_rng.choose(&slot.looks);
+            worker_scenes.push(AnchorScene::worker(slot.stand, slot.facing, look));
         }
 
-        let industrial_job_slots = worker_scenes.len();
-        let workplace_count = footprints.len();
+        // Total worker posts = residents bound in the population pass + the
+        // anonymous backfill scenes just built; guards are appended below.
+        let backfill_slots = worker_scenes.len();
+        let industrial_job_slots = bound_worker_count + backfill_slots;
 
         // ---- Guard posts: gates + wall towers ----
         // Gates get 1–2 guards each; each tower has a 10% chance of 2 guards and a
-        // 20% chance of 1 (else none). Guards wear the trade outfit set by
-        // `guard_profession` in `data/npcs.yaml` (default Armorer) and carry
-        // their own `guarding` dialogue, watching the approaches.
-        let guard_profession = npc_data.guard_profession;
-        let guard_scene = |feet: Point3D, facing: f32| -> AnchorScene {
+        // 20% chance of 1 (else none). Guards carry their own `guarding` dialogue,
+        // watching the approaches. Each guard's appearance is rolled from the
+        // guards fixture's `looks` pool (villager professions and/or mobs like
+        // pillagers), so a post can mix both.
+        use crate::generator::npc::NpcLook;
+        let guard_looks = &npc_data.guards.looks;
+        let guard_scene = |feet: Point3D, facing: f32, look: NpcLook| -> AnchorScene {
             let mut slot = AnchorSlot::new(feet, facing, SlotRole::Worker);
-            slot.profession = Some(guard_profession);
+            slot.look = Some(look);
             slot.dialogue = Some("guarding".to_string());
             AnchorScene::group(SceneKind::Solo, vec![slot])
         };
@@ -1219,7 +1184,8 @@ pub async fn generate_town(
                 let feet = Point3D::new(s.x, y, s.y);
                 let facing =
                     crate::generator::population::yaw_toward(feet, Point3D::new(base.x, y, base.y));
-                let mut scene = guard_scene(feet, facing);
+                let look = *worker_rng.choose(guard_looks);
+                let mut scene = guard_scene(feet, facing, look);
                 // Gates often sit on a slabbed threshold (sandstone slabs on a
                 // desert gateway, stair-and-slab approach on a stone one). When
                 // the block beneath the guard's feet is a slab, lift them half
@@ -1243,24 +1209,25 @@ pub async fn generate_town(
                     Point3D::new(town_centre.x, feet.y, town_centre.y),
                     feet,
                 );
-                let mut scene = guard_scene(feet, facing);
+                let look = *worker_rng.choose(guard_looks);
+                let mut scene = guard_scene(feet, facing, look);
                 scene.slots[0].y_offset = 0.5; // stand on the battlement slab, not sunk in it
                 worker_scenes.push(scene);
             }
         }
-        let guard_count = worker_scenes.len() - industrial_job_slots;
+        let guard_count = worker_scenes.len() - backfill_slots;
 
         if !worker_scenes.is_empty() {
             // Roster supplies names/dialogue/biome; each scene's slot
             // overrides the profession, so the roll here is incidental.
             let worker_roster = build_roster(
-                worker_scenes.len(), culture, npc_data, &mut id_alloc, &mut rng.derive(),
+                worker_scenes.len(), 0, culture, npc_data, &mut id_alloc, &mut rng.derive(),
             );
             let budget = worker_scenes.len();
             match populate_npcs(editor, worker_scenes, worker_roster, budget, npc_data, &mut rng).await {
                 Ok(staffed) => println!(
-                    "Staffed {} fixture NPCs ({} workers across {} workplaces + {} guards)",
-                    staffed, industrial_job_slots, workplace_count, guard_count,
+                    "Staffed {} fixture NPCs ({} backfill workers + {} guards); {} of {} posts across {} workplaces filled by residents",
+                    staffed, backfill_slots, guard_count, bound_worker_count, industrial_job_slots, workplace_count,
                 ),
                 Err(e) => log::warn!("worker/guard staffing failed: {}", e),
             }
@@ -1287,15 +1254,15 @@ pub async fn generate_town(
         // Employment by job: building trades (sorted by count), then the
         // non-building roles (guards, vendors, performers).
         println!("--- Employment by job ---");
-        let mut by_job: Vec<(String, usize)> = worker_by_prof.into_iter().collect();
+        let mut by_job: Vec<(String, usize)> = worker_by_job.into_iter().collect();
         if guard_count > 0 {
-            by_job.push(("Guard".to_string(), guard_count));
+            by_job.push((npc_data.guards.employment.clone(), guard_count));
         }
         if market_stall_count > 0 {
-            by_job.push(("Vendor".to_string(), market_stall_count));
+            by_job.push(("vendor".to_string(), market_stall_count));
         }
         if performer_slot_count > 0 {
-            by_job.push(("Performer".to_string(), performer_slot_count));
+            by_job.push(("performer".to_string(), performer_slot_count));
         }
         by_job.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
         for (job, count) in &by_job {
@@ -1322,4 +1289,109 @@ pub async fn generate_town(
     }
 
     editor.flush_buffer().await;
+}
+
+/// Scan the claim map for every placed workplace (urban shop or rural gather
+/// building) and produce one [`WorkerSlot`](crate::generator::population::WorkerSlot)
+/// per crew position: a clear stand cell at the footprint edge facing the
+/// building, the building centre for proximity scoring, and the post's skin pool
+/// + job label from `staffing_for`. Returns the slots plus the number of distinct
+/// workplaces that yielded any. This is the geometry half of worker staffing;
+/// who fills each post is decided by
+/// [`bind_workers`](crate::generator::population::bind_workers).
+fn discover_worker_slots(
+    editor: &Editor,
+    data: &LoadedData,
+) -> (Vec<crate::generator::population::WorkerSlot>, usize) {
+    use crate::generator::population::{yaw_toward, WorkerSlot};
+    use crate::generator::BuildClaim;
+    let npc_data = &data.npc_data;
+
+    // Placed buildings are the only `Structure` claims (wall towers claim
+    // `Wall`), and claims persist, so this recovers each building's footprint +
+    // type without threading placement state out. Scan the urban area *and*
+    // every rural parcel so rural gather buildings get staffed too.
+    let mut scan_cells: Vec<Point2D> = editor.world().get_urban_points().into_iter().collect();
+    for sd in editor.world().districts.values() {
+        if sd.data.parcel_type == ParcelType::Rural {
+            scan_cells.extend(sd.data.points_2d.iter().copied());
+        }
+    }
+    let mut footprints: HashMap<u32, (String, Vec<Point2D>)> = HashMap::new();
+    for &p in &scan_cells {
+        if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
+            footprints
+                .entry(id.id)
+                .or_insert_with(|| (id.structure_type.0.clone(), Vec::new()))
+                .1
+                .push(p);
+        }
+    }
+
+    // A usable stand spot is an in-bounds open cell — not a road, wall, or
+    // building. Road-bordering cells sort first so workers read as street-side.
+    let is_clear = |c: Point2D| {
+        matches!(
+            editor.world().get_claim(c),
+            Some(BuildClaim::None) | Some(BuildClaim::Nature)
+        )
+    };
+    let road_side = |c: Point2D| {
+        crate::geometry::CARDINALS_2D
+            .iter()
+            .any(|&d| matches!(editor.world().get_claim(c + d), Some(BuildClaim::Path(_))))
+    };
+
+    // Deterministic order over buildings (HashMap iteration isn't stable).
+    let mut ids: Vec<u32> = footprints.keys().copied().collect();
+    ids.sort_unstable();
+
+    let mut slots: Vec<WorkerSlot> = Vec::new();
+    let mut workplaces = 0usize;
+    for id in ids {
+        let (kind, cells) = &footprints[&id];
+        let cell_set: HashSet<Point2D> = cells.iter().copied().collect();
+        let centroid =
+            cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
+
+        let mut candidates: Vec<Point2D> = Vec::new();
+        let mut seen: HashSet<Point2D> = HashSet::new();
+        for &fc in cells {
+            for d in crate::geometry::CARDINALS_2D {
+                let c = fc + d;
+                if cell_set.contains(&c) || !editor.world().is_in_bounds_2d(c) || !is_clear(c) {
+                    continue;
+                }
+                if seen.insert(c) {
+                    candidates.push(c);
+                }
+            }
+        }
+        candidates.sort_unstable_by_key(|c| (!road_side(*c), c.x, c.y));
+
+        // Staffing comes from the building's own structure JSON (its `staffing`
+        // block), falling back to the town-wide default.
+        let staffing = npc_data.staffing_for(kind, &data.structures);
+        let want = staffing.workers.min(candidates.len());
+        if want == 0 {
+            log::warn!("no clear stand cell for building '{}' (id {})", kind, id);
+            continue;
+        }
+        workplaces += 1;
+        for &stand in candidates.iter().take(want) {
+            // Stand on the ground at the cell; face the footprint centroid.
+            let y = editor.world().get_ocean_floor_height_at(stand);
+            let stand3 = Point3D::new(stand.x, y, stand.y);
+            let centre3 = Point3D::new(centroid.x, y, centroid.y);
+            let facing = yaw_toward(stand3, centre3);
+            slots.push(WorkerSlot {
+                stand: stand3,
+                facing,
+                workplace: centroid,
+                looks: staffing.looks.clone(),
+                employment: staffing.employment.clone(),
+            });
+        }
+    }
+    (slots, workplaces)
 }

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -588,18 +588,71 @@ pub async fn generate_town(
     }
     // Densest tier first; size pool per tier (houses on the main roads,
     // cottages on the back lanes).
-    // House + Hall on every tier for now (district wealth will refine this
-    // later). Slots that can't fit a Hall's wider frontage just skip.
-    let tiers: [(&HashSet<Point2D>, &[SizeClass]); 3] = [
-        (&arterial_band, &[SizeClass::House, SizeClass::Hall]),
-        (&collector_band, &[SizeClass::House, SizeClass::Hall]),
-        (&alley_band, &[SizeClass::House, SizeClass::Hall]),
-    ];
+    // House + Hall on every tier. Manor is no longer opportunistic — it's
+    // seeded in a deliberate pre-pass: pick MANOR_CAP arterial-eligible lots
+    // up front and process them first with their arterial tier forced to
+    // Manor-only. Lots without an arterial frontage long enough for a Manor
+    // are ineligible. If a chosen Manor build fails we just continue (no
+    // fallback to House/Hall on that slice); the lot still gets its other
+    // tiers placed normally below.
+    const MANOR_CAP: usize = 2;
+    let mut manors_placed = 0usize;
+    let manor_min_front = *SizeClass::Manor.front_width_range().start();
+    // Manors prefer arterial frontage, but fall back to collector if no lot
+    // touches an arterial with enough cells (common — arterials run through
+    // the urban core but lots are bounded by collectors). `manor_tier_idx`
+    // names which tier hosts the Manor pool inside the main loop (0 = arterial,
+    // 1 = collector). Alley never hosts Manors.
+    let eligible_for_band = |band: &HashSet<Point2D>| -> Vec<usize> {
+        sub_blocks
+            .iter()
+            .enumerate()
+            .filter(|(_, lot)| !lot.is_empty())
+            .filter(|(_, lot)| {
+                frontage_from_roads(lot, band)
+                    .iter()
+                    .any(|f| (f.cells.len() as i32) >= manor_min_front)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    };
+    let arterial_eligible = eligible_for_band(&arterial_band);
+    let (eligible, manor_tier_idx, manor_tier_label): (Vec<usize>, usize, &str) =
+        if !arterial_eligible.is_empty() {
+            (arterial_eligible, 0, "arterial")
+        } else {
+            (eligible_for_band(&collector_band), 1, "collector (arterial empty)")
+        };
+    let manor_lots: HashSet<usize> = {
+        let mut pool = eligible.clone();
+        rng.derive().shuffle(&mut pool);
+        pool.into_iter().take(MANOR_CAP).collect()
+    };
+    println!(
+        "Manor pre-pass: {} {}-eligible lots, chose {} to host Manors",
+        eligible.len(),
+        manor_tier_label,
+        manor_lots.len(),
+    );
+    // Iterate manor-lots first (in shuffled order), then everything else in
+    // natural sub_block order. "Before the rest of the houses" is enforced
+    // by the iteration order alone — no separate code path.
+    let lot_order: Vec<usize> = manor_lots
+        .iter()
+        .copied()
+        .chain((0..sub_blocks.len()).filter(|i| !manor_lots.contains(i)))
+        .collect();
 
     let mut total_buildings = 0usize;
     // Per-house NPC anchors + bed-derived population budget, gathered from every
     // house and fed to the town-wide population pass once the town is built.
     let mut town_anchors: Vec<crate::generator::population::HouseAnchors> = Vec::new();
+    // Houses placed per SizeClass — used to size the wealth distribution
+    // (Cottage/House = common, Hall = wealthy craftsman, Manor = elite).
+    let mut size_counts: HashMap<String, usize> = HashMap::new();
+    // Footprint rect-count distribution (1 = single-rect / no wings, 2 = one
+    // wing, 3+ = multi-wing L/T/U shapes). Reads how often wings actually land.
+    let mut rect_count_dist: HashMap<usize, usize> = HashMap::new();
     let mut tier_cells = [0usize; 3];   // frontage cells found per tier
     let mut tier_placed = [0usize; 3];  // houses placed per tier
     let mut tier_fail = [0usize; 3];    // build_house failures per tier
@@ -612,11 +665,33 @@ pub async fn generate_town(
     // the road and each house front, which we pave into a forecourt so the
     // unavoidable set-back on a diagonal reads as a shoulder, not bare grass.
     let mut tier_verge: [HashSet<Point2D>; 2] = Default::default();
-    for lot in &sub_blocks {
+    for lot_idx in lot_order {
+        let lot = &sub_blocks[lot_idx];
         if lot.is_empty() { continue; }
         let Some(mut plot) = plot_from_block(lot) else { continue; };
 
-        for (ti, (band, pool)) in tiers.iter().enumerate() {
+        // On a chosen manor-lot, the manor's tier (arterial when arterials
+        // had eligible frontages; otherwise collector) gets a Manor-only
+        // pool until the cap is reached. Other tiers — and other lots —
+        // stay House+Hall. Alley never hosts Manors.
+        let is_manor_lot = manor_lots.contains(&lot_idx) && manors_placed < MANOR_CAP;
+        let arterial_pool: &[SizeClass] = if is_manor_lot && manor_tier_idx == 0 {
+            &[SizeClass::Manor]
+        } else {
+            &[SizeClass::House, SizeClass::Hall]
+        };
+        let collector_pool: &[SizeClass] = if is_manor_lot && manor_tier_idx == 1 {
+            &[SizeClass::Manor]
+        } else {
+            &[SizeClass::House, SizeClass::Hall]
+        };
+        let tiers_local: [(&HashSet<Point2D>, &[SizeClass]); 3] = [
+            (&arterial_band, arterial_pool),
+            (&collector_band, collector_pool),
+            (&alley_band, &[SizeClass::House, SizeClass::Hall]),
+        ];
+
+        'tier_loop: for (ti, (band, pool)) in tiers_local.iter().enumerate() {
             let min_front = pool.iter().map(|s| *s.front_width_range().start()).min().unwrap_or(0);
             for frontage in frontage_from_roads(lot, band) {
                 tier_cells[ti] += frontage.cells.len();
@@ -652,6 +727,10 @@ pub async fn generate_town(
                         tier_unfit[ti] += 1; cursor += 1; continue;
                     };
                     let rect = rect_from_frontage(chain_slice, frontage.outward, depth);
+                    // The frontage rect becomes the core; try to grow wings
+                    // into the lot's remaining usable cells (away from the
+                    // road). Square_bias = 0 here matches the live town gen —
+                    // domes on wings haven't been wired through yet.
 
                     // Desert keeps a uniform sandstone palette; other cultures
                     // roll wood/stone/roof variants per house for variety.
@@ -660,8 +739,13 @@ pub async fn generate_town(
                         _ => roll_palette(&mut rng, &base_palette, &data, &wood_ids, &stone_ids, &roof_ids),
                     };
                     let roof_style = roof_styles[rng.rand_i32_range(0, roof_styles.len() as i32) as usize];
-                    let plot_bounds = synthetic_plot_bounds(&rect, frontage.outward);
-                    let footprint = Footprint::from_rect(rect);
+                    let footprint = crate::generator::buildings_v2::footprint::generate::generate_footprint_from_core(
+                        &mut rng, &plot, rect, frontage.outward, &size_class, culture.square_bias(),
+                    );
+                    // Door scoring needs the full footprint bounds, not just
+                    // the core rect, so a wing extending rearward doesn't
+                    // misreport the back wall's distance to the plot edge.
+                    let plot_bounds = synthetic_plot_bounds(&footprint.bounds(), frontage.outward);
                     // Align the main door with the road it faces: pin the floor
                     // (= door sill) to the height of the *nearest* road cell to
                     // this frontage. Probe outward from every frontage cell and
@@ -718,10 +802,21 @@ pub async fn generate_town(
                             town_anchors.push(crate::generator::population::HouseAnchors {
                                 scenes: output.npc_anchors,
                                 population,
+                                wealth: crate::generator::population::Wealth::from_size_class(size_class),
                             });
-                            plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
+                            // Mark every rect in the footprint (core + wings)
+                            // as used so subsequent placements on this lot
+                            // can't overlap the wing cells.
+                            for r in output.footprint.rects() {
+                                plot.mark_rect_used(r, SIDE_BUFFER_CELLS);
+                            }
+                            *rect_count_dist.entry(output.footprint.rects().len()).or_insert(0) += 1;
                             total_buildings += 1;
                             tier_placed[ti] += 1;
+                            *size_counts.entry(format!("{:?}", size_class)).or_insert(0) += 1;
+                            if size_class == SizeClass::Manor {
+                                manors_placed += 1;
+                            }
                             // Record the verge: from each frontage cell, walk
                             // into the block (−outward) until we reach the
                             // house. On a straight slice this is just the
@@ -740,6 +835,14 @@ pub async fn generate_town(
                                     }
                                 }
                             }
+                            // A Manor closes out its lot's manor-tier: skip any
+                            // remaining frontages/cursors here so we don't tile
+                            // additional Manors along the same chain. Other
+                            // tiers (collector/alley) of the lot still process
+                            // normally below.
+                            if size_class == SizeClass::Manor {
+                                continue 'tier_loop;
+                            }
                             cursor += fw + SIDE_BUFFER_CELLS;
                         }
                         Err(msg) => {
@@ -753,6 +856,20 @@ pub async fn generate_town(
         }
     }
     println!("Placed {} buildings across {} lots", total_buildings, sub_blocks.len());
+    {
+        let order = ["Cottage", "House", "Hall", "Manor"];
+        let parts: Vec<String> = order
+            .iter()
+            .map(|k| format!("{}: {}", k, size_counts.get(*k).copied().unwrap_or(0)))
+            .collect();
+        println!("Size class breakdown — {}", parts.join("  "));
+    }
+    {
+        let mut rcounts: Vec<(usize, usize)> = rect_count_dist.iter().map(|(&k, &v)| (k, v)).collect();
+        rcounts.sort_unstable_by_key(|&(k, _)| k);
+        let parts: Vec<String> = rcounts.iter().map(|(k, v)| format!("{} rect: {}", k, v)).collect();
+        println!("Footprint shape — {}", parts.join("  "));
+    }
     println!(
         "Per-tier [frontage cells / placed / failed] — arterial: {}/{}/{}  collector: {}/{}/{}  subdivider: {}/{}/{}",
         tier_cells[0], tier_placed[0], tier_fail[0],
@@ -891,6 +1008,11 @@ pub async fn generate_town(
         (stalls, stages, performers)
     };
 
+    // Town-wide NPC id allocator. Shared across every staffing call below
+    // (plaza fixtures, residents, workplace workers, guards) so every NPC has
+    // a unique id and kin relationships can reference any of them.
+    let mut id_alloc = crate::generator::population::IdAllocator::new();
+
     // ---- Plaza fixtures: staff every harvested plaza scene ----
     // Stage performers, market vendors, and onlookers are fixtures like the
     // industrial workers below — always placed, independent of the resident bed
@@ -898,27 +1020,28 @@ pub async fn generate_town(
     // and bubble volume (criers/performers yell), so we just hand them a roster
     // and staff them all. Live-only: no-op offline.
     if !plaza_scenes.is_empty() {
-        use crate::generator::population::{build_roster, populate_npcs, NpcData};
-        match NpcData::load() {
-            Ok(npc_data) => {
-                let budget = plaza_scenes.len();
-                let roster = build_roster(budget, culture, &npc_data, &mut rng.derive());
-                match populate_npcs(editor, plaza_scenes, roster, budget, &npc_data, &mut rng).await {
-                    Ok(staffed) => println!("Staffed {} plaza NPCs", staffed),
-                    Err(e) => log::warn!("plaza staffing failed: {e}"),
-                }
-            }
-            Err(e) => log::warn!("could not load npcs.yaml for plaza staffing: {e}"),
+        use crate::generator::population::{build_roster, populate_npcs};
+        let npc_data = &data.npc_data;
+        let budget = plaza_scenes.len();
+        let roster = build_roster(budget, culture, npc_data, &mut id_alloc, &mut rng.derive());
+        match populate_npcs(editor, plaza_scenes, roster, budget, npc_data, &mut rng).await {
+            Ok(staffed) => println!("Staffed {} plaza NPCs", staffed),
+            Err(e) => log::warn!("plaza staffing failed: {e}"),
         }
     }
 
     // ---- Population: size the resident crowd to beds, scatter it town-wide ----
-    // Each house's budget is max(1, beds); the town total is their sum. The
-    // town-wide draw seeds one resident per house, then fills the rest weighted
-    // by anchor weight, halving a house's weights each time it gains a resident
-    // so the crowd spreads instead of clustering. Live-only: no-op offline.
+    // Each house's budget is max(1, beds); the town total is their sum.
+    // Residents come from generated households (kin reciprocally wired, then
+    // cross-household links, then employment), and the town-wide draw seeds
+    // one resident per house, then fills the rest weighted by anchor weight,
+    // halving a house's weights each time it gains a resident so the crowd
+    // spreads instead of clustering. Live-only: no-op offline.
     {
-        use crate::generator::population::{populate_town, NpcData};
+        use crate::generator::population::{
+            assign_employment, build_households, link_cross_household,
+            log_population_stats, log_sample_households, populate_town,
+        };
         let budget: usize = town_anchors.iter().map(|h| h.population).sum();
         let candidate_anchors: usize = town_anchors.iter().map(|h| h.scenes.len()).sum();
         println!(
@@ -927,12 +1050,25 @@ pub async fn generate_town(
             town_anchors.len(),
             candidate_anchors,
         );
-        match NpcData::load() {
-            Ok(data) => match populate_town(editor, town_anchors, culture, &data, &mut rng).await {
-                Ok(placed) => println!("Populated {} NPCs", placed),
-                Err(e) => log::warn!("NPC population failed: {e}"),
-            },
-            Err(e) => log::warn!("failed to load npcs.yaml; skipping NPC population: {e}"),
+        let npc_data = &data.npc_data;
+        // Four passes: shape households per house, link kin across town,
+        // assign professions, place at anchors. Each pass derives its own
+        // RNG so reordering or inserting a future pass doesn't shift
+        // downstream rolls.
+        let mut population = build_households(
+            &town_anchors, culture, npc_data, &mut id_alloc, &mut rng.derive(),
+        );
+        link_cross_household(&mut population, &mut rng.derive());
+        assign_employment(&mut population, &mut rng.derive());
+
+        // Diagnostics: stats + a handful of sampled households so the kin graph
+        // is legible in the console without needing a debugger.
+        log_population_stats(&population);
+        log_sample_households(&population, 8);
+
+        match populate_town(editor, town_anchors, population, npc_data, &mut rng).await {
+            Ok(placed) => println!("Populated {} NPCs", placed),
+            Err(e) => log::warn!("NPC population failed: {e}"),
         }
     }
 
@@ -942,55 +1078,19 @@ pub async fn generate_town(
     // outfit that matches its type. These are fixtures: always placed, independent
     // of the resident budget above. The NBT interiors are opaque, so workers stand
     // on clear ground cells at the footprint edge — never inside, never on a road
-    // or another building. A workplace can employ several hands (see `workers_for`).
+    // or another building. A workplace can employ several hands (see the per-kind
+    // `workers` count in `data/npcs.yaml`).
     {
-        use crate::generator::npc::Profession;
         use crate::generator::population::{
-            build_roster, populate_npcs, AnchorScene, AnchorSlot, NpcData, SceneKind, SlotRole,
+            build_roster, populate_npcs, AnchorScene, AnchorSlot, SceneKind, SlotRole,
         };
 
-        // Building type -> trade outfit. Shops with a set roll across it so two of
-        // the same kind don't always match. Covers urban processing shops and rural
-        // gather buildings; the default keeps any unmapped workplace staffed.
+        // Building type -> trade outfit. Looked up in `data/npcs.yaml` via
+        // `workplace_spec`: each entry carries a `professions` list (rolled
+        // across so two of the same kind don't always match) and a `workers`
+        // count. Unknown kinds fall back to the `default` entry.
+        let npc_data = &data.npc_data;
         let mut worker_rng = rng.derive();
-        let profession_for = |kind: &str, rng: &mut RNG| -> Option<Profession> {
-            Some(match kind {
-                // — urban processing shops —
-                "smithy" | "smelter" => {
-                    *rng.choose(&[Profession::Weaponsmith, Profession::Toolsmith, Profession::Armorer])
-                }
-                "mill" | "sawmill" | "sugar_mill" | "paper_mill_wood" | "paper_mill_sugar" => {
-                    Profession::Farmer
-                }
-                "bakery" | "confectionery" | "butcher" => Profession::Butcher,
-                "carpenter" | "woodcutter_hut" => {
-                    *rng.choose(&[Profession::Fletcher, Profession::Mason])
-                }
-                "tannery" => Profession::Leatherworker,
-                "weaver" | "tailor" => Profession::Shepherd,
-                "scriptorium" => Profession::Librarian,
-                "brewery" | "chandlery" | "apiary" => Profession::Farmer,
-                // — rural gather buildings —
-                "farm" | "sugar_plantation" => Profession::Farmer,
-                "ranch" | "shepherds_hut" => Profession::Shepherd,
-                "iron_mine" | "coal_mine" | "charcoal_burner" => Profession::Mason,
-                // sensible default so every placed workplace gets a worker
-                _ => Profession::Farmer,
-            })
-        };
-
-        // How many hands a workplace employs, capped later by available stand
-        // cells. Big farms field a full crew; processing shops a standard crew;
-        // small gather huts/mines a pair.
-        let workers_for = |kind: &str| -> usize {
-            match kind {
-                "farm" | "ranch" | "sugar_plantation" => 4,
-                "iron_mine" | "coal_mine" | "charcoal_burner" | "woodcutter_hut"
-                | "shepherds_hut" | "apiary" => 2,
-                // processing shops and anything unmapped run a standard crew
-                _ => 3,
-            }
-        };
 
         // Re-scan the claim map: placed buildings are the only `Structure` claims
         // (wall towers claim `Wall`), and claims persist, so this recovers each
@@ -1060,15 +1160,16 @@ pub async fn generate_town(
             }
             candidates.sort_unstable_by_key(|c| (!road_side(*c), c.x, c.y));
 
-            // Staff up to `workers_for` hands on distinct stand cells, each with a
-            // freshly rolled trade so a multi-worker shop isn't uniform.
-            let want = workers_for(kind).min(candidates.len());
+            // Staff up to the per-kind crew size on distinct stand cells, each
+            // with a freshly rolled trade so a multi-worker shop isn't uniform.
+            let spec = npc_data.workplace_spec(kind);
+            let want = spec.workers.min(candidates.len());
             if want == 0 {
                 log::warn!("no clear stand cell for building '{}' (id {})", kind, id);
                 continue;
             }
             for &stand in candidates.iter().take(want) {
-                let Some(profession) = profession_for(kind, &mut worker_rng) else { continue };
+                let profession = *worker_rng.choose(&spec.professions);
                 // Stand on the ground at the cell; face the footprint centroid.
                 let y = editor.world().get_ocean_floor_height_at(stand);
                 let stand3 = Point3D::new(stand.x, y, stand.y);
@@ -1084,11 +1185,13 @@ pub async fn generate_town(
 
         // ---- Guard posts: gates + wall towers ----
         // Gates get 1–2 guards each; each tower has a 10% chance of 2 guards and a
-        // 20% chance of 1 (else none). Guards are Armorer-skinned fixtures with
-        // their own dialogue, watching the approaches.
+        // 20% chance of 1 (else none). Guards wear the trade outfit set by
+        // `guard_profession` in `data/npcs.yaml` (default Armorer) and carry
+        // their own `guarding` dialogue, watching the approaches.
+        let guard_profession = npc_data.guard_profession;
         let guard_scene = |feet: Point3D, facing: f32| -> AnchorScene {
             let mut slot = AnchorSlot::new(feet, facing, SlotRole::Worker);
-            slot.profession = Some(Profession::Armorer);
+            slot.profession = Some(guard_profession);
             slot.dialogue = Some("guarding".to_string());
             AnchorScene::group(SceneKind::Solo, vec![slot])
         };
@@ -1116,7 +1219,19 @@ pub async fn generate_town(
                 let feet = Point3D::new(s.x, y, s.y);
                 let facing =
                     crate::generator::population::yaw_toward(feet, Point3D::new(base.x, y, base.y));
-                worker_scenes.push(guard_scene(feet, facing));
+                let mut scene = guard_scene(feet, facing);
+                // Gates often sit on a slabbed threshold (sandstone slabs on a
+                // desert gateway, stair-and-slab approach on a stone one). When
+                // the block beneath the guard's feet is a slab, lift them half
+                // a block so they stand on the slab top rather than sunk in it.
+                let underfoot = editor.try_get_block(Point3D::new(s.x, y - 1, s.y));
+                if matches!(
+                    underfoot.map(|b| crate::minecraft::BlockForm::infer_from_block(&b.id)),
+                    Some(crate::minecraft::BlockForm::Slab),
+                ) {
+                    scene.slots[0].y_offset = 0.5;
+                }
+                worker_scenes.push(scene);
             }
         }
         // Towers: weighted small chance of 1–2 guards on the walkway beside each.
@@ -1136,22 +1251,18 @@ pub async fn generate_town(
         let guard_count = worker_scenes.len() - industrial_job_slots;
 
         if !worker_scenes.is_empty() {
-            match NpcData::load() {
-                Ok(npc_data) => {
-                    // Roster supplies names/dialogue/biome; each scene's slot
-                    // overrides the profession, so the roll here is incidental.
-                    let worker_roster =
-                        build_roster(worker_scenes.len(), culture, &npc_data, &mut rng.derive());
-                    let budget = worker_scenes.len();
-                    match populate_npcs(editor, worker_scenes, worker_roster, budget, &npc_data, &mut rng).await {
-                        Ok(staffed) => println!(
-                            "Staffed {} fixture NPCs ({} workers across {} workplaces + {} guards)",
-                            staffed, industrial_job_slots, workplace_count, guard_count,
-                        ),
-                        Err(e) => log::warn!("worker/guard staffing failed: {}", e),
-                    }
-                }
-                Err(e) => log::warn!("could not load npcs.yaml for staffing: {}", e),
+            // Roster supplies names/dialogue/biome; each scene's slot
+            // overrides the profession, so the roll here is incidental.
+            let worker_roster = build_roster(
+                worker_scenes.len(), culture, npc_data, &mut id_alloc, &mut rng.derive(),
+            );
+            let budget = worker_scenes.len();
+            match populate_npcs(editor, worker_scenes, worker_roster, budget, npc_data, &mut rng).await {
+                Ok(staffed) => println!(
+                    "Staffed {} fixture NPCs ({} workers across {} workplaces + {} guards)",
+                    staffed, industrial_job_slots, workplace_count, guard_count,
+                ),
+                Err(e) => log::warn!("worker/guard staffing failed: {}", e),
             }
         }
 

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -23,6 +23,11 @@ use crate::noise::{Seed, RNG};
 /// The caller is responsible for constructing the `Editor` (and the `World`
 /// behind it) and for flushing/finalising afterwards beyond the final
 /// `flush_buffer` performed here.
+/// Residents per bed of sleeping capacity. A house's population budget is
+/// `max(1, round(beds * POPULATION_PER_BED))`, so a single-bed house houses ~2
+/// and a double bed (which sleeps two) ~3 — enough to read as lived-in.
+const POPULATION_PER_BED: f32 = 1.5;
+
 pub async fn generate_town(
     editor: &mut Editor,
     seed: Seed,
@@ -536,6 +541,9 @@ pub async fn generate_town(
     ];
 
     let mut total_buildings = 0usize;
+    // Per-house NPC anchors + bed-derived population budget, gathered from every
+    // house and fed to the town-wide population pass once the town is built.
+    let mut town_anchors: Vec<crate::generator::population::HouseAnchors> = Vec::new();
     let mut tier_cells = [0usize; 3];   // frontage cells found per tier
     let mut tier_placed = [0usize; 3];  // houses placed per tier
     let mut tier_fail = [0usize; 3];    // build_house failures per tier
@@ -628,7 +636,33 @@ pub async fn generate_town(
                     bctx.base_y_override = base_lvl;
                     let mut bctx_editor = BuildCtx::new(editor, &data, &palette, &mut rng);
                     match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
-                        Ok(_) => {
+                        Ok(output) => {
+                            // Population budget tracks sleeping capacity, not bed
+                            // furniture: a double/canopy bed sleeps two. Each
+                            // bed-tagged item's capacity is its number of
+                            // `part=foot` blocks (the head auto-spawns), min 1.
+                            let beds: usize = output
+                                .room_plan
+                                .rooms
+                                .iter()
+                                .flat_map(|r| &r.furniture)
+                                .filter_map(|f| data.furniture.items.get(&f.name))
+                                .filter(|it| it.tags.iter().any(|t| t == "bed"))
+                                .map(|it| {
+                                    it.blocks
+                                        .iter()
+                                        .filter(|b| b.block.contains("part=foot"))
+                                        .count()
+                                        .max(1)
+                                })
+                                .sum();
+                            // Scale capacity so houses feel lived-in, floored at 1.
+                            let population =
+                                ((beds as f32 * POPULATION_PER_BED).round() as usize).max(1);
+                            town_anchors.push(crate::generator::population::HouseAnchors {
+                                scenes: output.npc_anchors,
+                                population,
+                            });
                             plot.mark_rect_used(&rect, SIDE_BUFFER_CELLS);
                             total_buildings += 1;
                             tier_placed[ti] += 1;
@@ -732,6 +766,11 @@ pub async fn generate_town(
     // (paved civic squares), nooks (small ringed gardens), parks (large green
     // commons), and yards (perimeter kitchen gardens).
     let mut place_labels: Vec<(Point2D, String)> = Vec::new();
+    // NPC standing-spot scenes harvested from plazas (stage performers, market
+    // vendors, onlookers in the crowd). Staffed as fixtures after furnishing,
+    // independent of the resident bed budget — a market is busy regardless of
+    // how many beds the town has.
+    let mut plaza_scenes: Vec<crate::generator::population::AnchorScene> = Vec::new();
     {
         use crate::generator::open_space::{
             detect_regions, furnish_nook, furnish_park, furnish_plaza, furnish_yard, OpenSpaceNames,
@@ -748,7 +787,8 @@ pub async fn generate_town(
         for region in &regions {
             match region.region_type() {
                 RegionType::Plaza => {
-                    let plaza_type = furnish_plaza(&*editor, region, &mut os_rng, &theme).await;
+                    let (plaza_type, scenes) = furnish_plaza(&*editor, region, &mut os_rng, &theme).await;
+                    plaza_scenes.extend(scenes);
                     if let Some(name) = names.as_ref().and_then(|n| n.name_plaza(plaza_type, culture, &mut os_rng, &mut used)) {
                         place_labels.push((region.centroid(), name));
                     }
@@ -775,6 +815,174 @@ pub async fn generate_town(
             "Furnished open spaces — plaza {} nook {} park {} yard {}",
             counts[0], counts[1], counts[2], counts[3],
         );
+    }
+
+    // ---- Plaza fixtures: staff every harvested plaza scene ----
+    // Stage performers, market vendors, and onlookers are fixtures like the
+    // industrial workers below — always placed, independent of the resident bed
+    // budget. Each scene already carries its own position, facing, dialogue key,
+    // and bubble volume (criers/performers yell), so we just hand them a roster
+    // and staff them all. Live-only: no-op offline.
+    if !plaza_scenes.is_empty() {
+        use crate::generator::population::{build_roster, populate_npcs, NpcData};
+        match NpcData::load() {
+            Ok(npc_data) => {
+                let budget = plaza_scenes.len();
+                let roster = build_roster(budget, culture, &npc_data, &mut rng.derive());
+                match populate_npcs(editor, plaza_scenes, roster, budget, &npc_data, &mut rng).await {
+                    Ok(staffed) => println!("Staffed {} plaza NPCs", staffed),
+                    Err(e) => log::warn!("plaza staffing failed: {e}"),
+                }
+            }
+            Err(e) => log::warn!("could not load npcs.yaml for plaza staffing: {e}"),
+        }
+    }
+
+    // ---- Population: size the resident crowd to beds, scatter it town-wide ----
+    // Each house's budget is max(1, beds); the town total is their sum. The
+    // town-wide draw seeds one resident per house, then fills the rest weighted
+    // by anchor weight, halving a house's weights each time it gains a resident
+    // so the crowd spreads instead of clustering. Live-only: no-op offline.
+    {
+        use crate::generator::population::{populate_town, NpcData};
+        let budget: usize = town_anchors.iter().map(|h| h.population).sum();
+        let candidate_anchors: usize = town_anchors.iter().map(|h| h.scenes.len()).sum();
+        println!(
+            "Population target: {} residents across {} houses ({} candidate anchors)",
+            budget,
+            town_anchors.len(),
+            candidate_anchors,
+        );
+        match NpcData::load() {
+            Ok(data) => match populate_town(editor, town_anchors, culture, &data, &mut rng).await {
+                Ok(placed) => println!("Populated {} NPCs", placed),
+                Err(e) => log::warn!("NPC population failed: {e}"),
+            },
+            Err(e) => log::warn!("failed to load npcs.yaml; skipping NPC population: {e}"),
+        }
+    }
+
+    // ---- Industrial worker fixtures ----
+    // Staff every industrial shop with exactly one worker NPC standing just
+    // outside it, facing the workshop, wearing the trade outfit that matches its
+    // type (a smith at the smithy, a shepherd at the weaver, ...). These are
+    // fixtures: always placed, independent of the resident budget above. The NBT
+    // interiors are opaque, so the worker stands on a clear ground cell at the
+    // footprint edge — never inside, never on a road or another building.
+    {
+        use crate::generator::npc::Profession;
+        use crate::generator::population::{build_roster, populate_npcs, AnchorScene, NpcData};
+
+        // type name -> trade outfit. smithy/carpenter roll across a small set so
+        // shops of the same kind don't all wear the identical profession.
+        let mut worker_rng = rng.derive();
+        let profession_for = |kind: &str, rng: &mut RNG| -> Option<Profession> {
+            Some(match kind {
+                "smithy" => *rng.choose(&[
+                    Profession::Weaponsmith, Profession::Toolsmith, Profession::Armorer,
+                ]),
+                "mill" => Profession::Farmer,
+                "bakery" => Profession::Butcher, // no baker profession; closest food trade
+                "carpenter" => *rng.choose(&[Profession::Fletcher, Profession::Mason]),
+                "tannery" => Profession::Leatherworker,
+                "weaver" => Profession::Shepherd,
+                _ => return None,
+            })
+        };
+
+        // Re-scan the claim map: industrial buildings are the only `Structure`
+        // claims (wall towers claim `Wall`), and claims persist, so this recovers
+        // each building's footprint + type without threading state out of the
+        // early industrial phase. Group cells by instance id.
+        let mut footprints: HashMap<u32, (String, Vec<Point2D>)> = HashMap::new();
+        for &p in &urban {
+            if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
+                footprints
+                    .entry(id.id)
+                    .or_insert_with(|| (id.structure_type.0.clone(), Vec::new()))
+                    .1
+                    .push(p);
+            }
+        }
+
+        // A cell is a usable stand spot only if nothing else claims it — not a
+        // road, wall, or another building. `get_claim` returns `None` only out
+        // of bounds, so an in-bounds open cell reads as `BuildClaim::None`.
+        let is_clear = |c: Point2D| {
+            matches!(
+                editor.world().get_claim(c),
+                Some(BuildClaim::None) | Some(BuildClaim::Nature)
+            )
+        };
+        let road_side = |c: Point2D| {
+            crate::geometry::CARDINALS_2D
+                .iter()
+                .any(|&d| matches!(editor.world().get_claim(c + d), Some(BuildClaim::Path(_))))
+        };
+
+        // Deterministic order over buildings (HashMap iteration isn't stable).
+        let mut ids: Vec<u32> = footprints.keys().copied().collect();
+        ids.sort_unstable();
+
+        let mut worker_scenes: Vec<AnchorScene> = Vec::new();
+        for id in ids {
+            let (kind, cells) = &footprints[&id];
+            let Some(profession) = profession_for(kind, &mut worker_rng) else { continue };
+            let cell_set: HashSet<Point2D> = cells.iter().copied().collect();
+            let centroid =
+                cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
+
+            // Candidate stand cells: cardinally adjacent to the footprint, outside
+            // it, in bounds, and clear. Sort for determinism, then prefer a cell
+            // that borders a road so the worker reads as standing at the street.
+            let mut candidates: Vec<Point2D> = Vec::new();
+            let mut seen: HashSet<Point2D> = HashSet::new();
+            for &fc in cells {
+                for d in crate::geometry::CARDINALS_2D {
+                    let c = fc + d;
+                    if cell_set.contains(&c) || !editor.world().is_in_bounds_2d(c) || !is_clear(c) {
+                        continue;
+                    }
+                    if seen.insert(c) {
+                        candidates.push(c);
+                    }
+                }
+            }
+            candidates.sort_unstable_by_key(|c| (c.x, c.y));
+            let stand = candidates
+                .iter()
+                .find(|c| road_side(**c))
+                .or_else(|| candidates.first())
+                .copied();
+            let Some(stand) = stand else {
+                log::warn!("no clear stand cell for industrial '{}' (id {})", kind, id);
+                continue;
+            };
+
+            // Stand on the ground at the cell; face the footprint centroid.
+            let y = editor.world().get_ocean_floor_height_at(stand);
+            let stand3 = Point3D::new(stand.x, y, stand.y);
+            let centre3 = Point3D::new(centroid.x, y, centroid.y);
+            let facing = crate::generator::population::yaw_toward(stand3, centre3);
+            worker_scenes.push(AnchorScene::worker(stand3, facing, profession));
+        }
+
+        if !worker_scenes.is_empty() {
+            match NpcData::load() {
+                Ok(npc_data) => {
+                    // Roster supplies names/dialogue/biome; each scene's slot
+                    // overrides the profession, so the roll here is incidental.
+                    let worker_roster =
+                        build_roster(worker_scenes.len(), culture, &npc_data, &mut rng.derive());
+                    let budget = worker_scenes.len();
+                    match populate_npcs(editor, worker_scenes, worker_roster, budget, &npc_data, &mut rng).await {
+                        Ok(staffed) => println!("Staffed {} industrial workers", staffed),
+                        Err(e) => log::warn!("industrial staffing failed: {}", e),
+                    }
+                }
+                Err(e) => log::warn!("could not load npcs.yaml for staffing: {}", e),
+            }
+        }
     }
 
     // Top-down town map (SVG) for inspection: footprints + named roads coloured

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -989,6 +989,25 @@ pub async fn generate_town(
             "Furnished open spaces — plaza {} nook {} park {} yard {}",
             counts[0], counts[1], counts[2], counts[3],
         );
+
+        // Skin the plaza fixtures from data: a stage's performers and a stall's
+        // vendor each roll a look from their fixture pool. Onlookers/browsers in
+        // the crowd keep the roster's own look (their slots are left untouched).
+        use crate::generator::population::{SceneKind, SlotRole};
+        let mut plaza_look_rng = rng.derive();
+        for scene in plaza_scenes.iter_mut() {
+            let performance = scene.kind == SceneKind::Performance;
+            for slot in scene.slots.iter_mut() {
+                let fixture = if performance {
+                    &data.npc_data.performers
+                } else if slot.role == SlotRole::Worker {
+                    &data.npc_data.vendors
+                } else {
+                    continue;
+                };
+                slot.look = Some(*plaza_look_rng.choose(&fixture.looks));
+            }
+        }
     }
 
     // Count plaza employment for the jobs summary: a stall is any scene with a
@@ -1180,7 +1199,11 @@ pub async fn generate_town(
                 vec![inside]
             };
             for s in stands {
-                let y = editor.world().get_ocean_floor_height_at(s);
+                // Stand on the gate's own cleared floor (`gate_point.y`), which is
+                // where the gateway punched its air column upward. Re-deriving the
+                // height from the ocean-floor heightmap dropped feet below the
+                // threshold, burying — and suffocating — the guard in gate blocks.
+                let y = gate_point.y;
                 let feet = Point3D::new(s.x, y, s.y);
                 let facing =
                     crate::generator::population::yaw_toward(feet, Point3D::new(base.x, y, base.y));
@@ -1259,10 +1282,10 @@ pub async fn generate_town(
             by_job.push((npc_data.guards.employment.clone(), guard_count));
         }
         if market_stall_count > 0 {
-            by_job.push(("vendor".to_string(), market_stall_count));
+            by_job.push((npc_data.vendors.employment.clone(), market_stall_count));
         }
         if performer_slot_count > 0 {
-            by_job.push(("performer".to_string(), performer_slot_count));
+            by_job.push((npc_data.performers.employment.clone(), performer_slot_count));
         }
         by_job.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
         for (job, count) in &by_job {

--- a/src/generator/terrain/test.rs
+++ b/src/generator/terrain/test.rs
@@ -166,7 +166,7 @@ mod tests {
 
             let tree = SPECIES[rng.rand_i32(SPECIES.len() as i32) as usize];
             let height = editor.world().get_ocean_floor_height_at(c);
-            generate_tree_feature(tree, &editor, Point3D::new(c.x, height, c.y))
+            generate_tree_feature(tree, &editor, Point3D::new(c.x, height, c.y), &mut rng)
                 .await
                 .expect("place feature failed");
         }

--- a/src/generator/terrain/tree_feature.rs
+++ b/src/generator/terrain/tree_feature.rs
@@ -9,7 +9,7 @@
 //! reproducible from our seed), and it **bypasses the editor's block cache**
 //! (so it's invisible to later `get_block` reads and to offline/dry-run mode).
 
-use crate::{editor::Editor, geometry::Point3D};
+use crate::{editor::Editor, geometry::Point3D, noise::RNG};
 
 use super::Tree;
 
@@ -51,14 +51,13 @@ pub fn tree_feature_id(tree: Tree) -> &'static str {
 }
 
 /// Build a short cactus column (1–3 tall) on a sand footing, in place of a
-/// vanilla feature (there's no cactus equivalent). Height varies by position
-/// since no RNG is threaded through the feature path.
-async fn place_cactus_column(editor: &Editor, point: Point3D) {
+/// vanilla feature (there's no cactus equivalent). Height is rolled from `rng`.
+async fn place_cactus_column(editor: &Editor, point: Point3D, rng: &mut RNG) {
     let (x, y, z) = (point.x, point.y, point.z);
     editor
         .place_block_forced(&"minecraft:sand".into(), Point3D { x, y: y - 1, z })
         .await;
-    let height = 1 + (x * 2 + z).rem_euclid(3); // 1..=3, varied by position
+    let height = 1 + rng.rand_i32(3); // 1..=3
     for i in 0..height {
         editor
             .place_block(&"minecraft:cactus".into(), Point3D { x, y: y + i, z })
@@ -67,15 +66,18 @@ async fn place_cactus_column(editor: &Editor, point: Point3D) {
 }
 
 /// Grow a vanilla tree feature for `tree` at `point` (build-area-local
-/// coordinates) by asking the server to `place feature`.
+/// coordinates) by asking the server to `place feature`. `rng` is only consumed
+/// by the cactus path (which we build ourselves); vanilla features are seeded by
+/// the world.
 pub async fn generate_tree_feature(
     tree: Tree,
     editor: &Editor,
     point: Point3D,
+    rng: &mut RNG,
 ) -> anyhow::Result<()> {
     // Cactus has no vanilla `place feature` — build the column ourselves.
     if matches!(tree, Tree::Cactus) {
-        place_cactus_column(editor, point).await;
+        place_cactus_column(editor, point, rng).await;
         return Ok(());
     }
     editor.place_feature(tree_feature_id(tree), point).await

--- a/src/http_mod/coordinate.rs
+++ b/src/http_mod/coordinate.rs
@@ -6,6 +6,9 @@ use crate::geometry::Point3D;
 #[derive(Clone, Copy, Debug)]
 pub enum Coordinate {
     Absolute(i32),
+    /// A fractional absolute coordinate (entity positions are doubles), e.g. to
+    /// stand an NPC half a block up on a slab. Serialized as a JSON float.
+    AbsoluteF(f64),
     Relative(i32),
 }
 
@@ -51,14 +54,17 @@ impl Into<Point3D> for Coordinate3D {
         Point3D {
             x: match self.x {
                 Coordinate::Absolute(value) => value,
+                Coordinate::AbsoluteF(value) => value.round() as i32,
                 Coordinate::Relative(_) => panic!("Relative coordinates cannot be converted to Point3D"),
             },
             y: match self.y {
                 Coordinate::Absolute(value) => value,
+                Coordinate::AbsoluteF(value) => value.round() as i32,
                 Coordinate::Relative(_) => panic!("Relative coordinates cannot be converted to Point3D"),
             },
             z: match self.z {
                 Coordinate::Absolute(value) => value,
+                Coordinate::AbsoluteF(value) => value.round() as i32,
                 Coordinate::Relative(_) => panic!("Relative coordinates cannot be converted to Point3D"),
             },
         }
@@ -72,6 +78,7 @@ impl Serialize for Coordinate {
     {
         match *self {
             Coordinate::Absolute(value) => serializer.serialize_i32(value),
+            Coordinate::AbsoluteF(value) => serializer.serialize_f64(value),
             Coordinate::Relative(value) => serializer.serialize_str(&format!("~{}", value)),
         }
     }
@@ -87,6 +94,7 @@ impl<'de> Deserialize<'de> for Coordinate {
         enum CoordHelper {
             Str(String),
             Int(i32),
+            Float(f64),
         }
 
         match CoordHelper::deserialize(deserializer)? {
@@ -100,6 +108,7 @@ impl<'de> Deserialize<'de> for Coordinate {
                 }
             }
             CoordHelper::Int(value) => Ok(Coordinate::Absolute(value)),
+            CoordHelper::Float(value) => Ok(Coordinate::AbsoluteF(value)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn run_generation_once() {
     crate::generator::settlement::generate_town(
         &mut editor,
         crate::noise::Seed(12345),
-        crate::generator::buildings_v2::Culture::Medieval,
+        crate::generator::buildings_v2::Culture::Desert,
     ).await;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn run_generation_once() {
     crate::generator::settlement::generate_town(
         &mut editor,
         crate::noise::Seed(12345),
-        crate::generator::buildings_v2::Culture::Desert,
+        crate::generator::buildings_v2::Culture::Medieval,
     ).await;
 }
 


### PR DESCRIPTION
Builds a living settlement on top of the `buildings_v2` town pipeline: a full **NPC population system** (households, kinship, jobs, fixtures) layered over town generation, open-space/plaza furnishing, and exterior decoration. ~36 commits since `master`.

## NPC population system (headline)

A town is populated from its own structure — beds, workplaces, gates, and plazas — and every NPC is a static, named, talking fixture.

- **Bed-based population.** Town size is the sleeping capacity ×1.5 per house (physical `part=foot` beds, doubles count for two, floored at 1). A town-wide weighted anchor draw seeds at least one resident per house, then fills the rest weighted by anchor richness (multi-person scenes boosted), halving a house's remaining weight per placement so the crowd spreads.
- **Household kinship.** Open household-shape model with reciprocal spouse / parent / child / sibling edges, including cross-household links (in-laws, married-out siblings, adult children next door). Each resident carries a `home_<id>` entity tag.
- **Look vs. employment.** The NPC model is split into a `look` (an `NpcLook` — a villager `Profession` outfit *or* a `Mob`) and a free-form `employment` string, two orthogonal axes: a smith-look villager can work as a guard; a pillager-look NPC can hold any post.
- **Data-driven fixtures.** Guards, workplace crews, market vendors, and stage performers are all declared in data as `Fixture`/`Staffing` entries (a job label + a skin pool rolled per spawn). Per-building worker staffing lives on each structure's JSON sidecar (`staffing: { employment, looks, workers }`); guards/vendors/performers live in `npcs.yaml`.
- **Home/work-aware placement.** Households know their house's world position; residents are drafted into nearby workplaces by qualification (proximity-led, trade affinity) before residential placement, so each resident appears once. Unfilled posts fall back to anonymous fixtures.
- **Kids.** A three-state occupant gate (AdultOnly / AnyAge / ChildOnly) threads from furniture specs through to spawn; staffing is atomic and age-aware, and children draw `{key}_child` dialogue. Beds, reading nooks, hearths, and plaza crowds seed children.
- **Guards, troupes, crowds.** Gate guards (1–2 each) and weighted wall-tower battlement guards (standing on the slab via fractional entity Y); plaza stages roll a 1–3 person troupe with a cast-sized `performing` script; quiet civic squares (well, fountain, monument) get their own lighter crowds and dialogue pools.
- **Mob NPCs + babies.** Witches, wandering traders, pillagers, etc. spawn through a villager-free path; baby villagers for children.
- **Robustness.** Every fixture is spawned `Invulnerable` (no suffocation / mob / fire deaths in a persistent town), and gate guards stand on the gate's own cleared floor height (fixing guards buried — and suffocated — in the gateway).

## buildings_v2

- Core-fixed footprint with road-aware wings.
- Thematic per-room furniture with an attic-headroom invariant; display shelves; cellar/rooms.
- `generate_town` pipeline wired into `main`; medieval-town generator test.

## Open spaces & decoration

- Detect dead space and classify it into plaza / nook / park / yard, then furnish all four (split on bottlenecks).
- Town decoration: plazas, markets, road naming, fingerpost signs, wall towers, terrain.
- Door→road A* footpaths, sparser street-light spacing, sparse exterior wall props.
- Rooftop terraces: per-building themes and fabric colours, varied furniture (pergola, awning, tandoor, hammock, …), ~1/3 of roofs left bare.

## Terrain

- Terraform fixes: sample the real surface block (no 1-deep holes), solid base under gravity surfaces, cap with the natural surface, clear leftover city water.
- Desert culture gets sandstone-paved roads.

## Test plan

- `cargo build` / `cargo check` — clean.
- `cargo test build_furnished_houses_offline` — offline furnish pipeline.
- `cargo test pipeline_invariants_property_test` — 12 buildings × 20 seeds invariant guard.
- `cargo test employment_pass_respects_life_stage` / `test_data_loads_cleanly` — NPC model + data load.
- `cargo run` against a live GDMC server — verified population stats, jobs summary, and fixture staffing across multiple runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)