### PR TITLE
fixes: cactus RNG, dedup perimeter BFS, reuse data in tower skin

### DIFF
--- a/src/generator/districts/mod.rs
+++ b/src/generator/districts/mod.rs
@@ -23,7 +23,7 @@ pub use district::District;
 pub use district::DistrictID;
 pub use data::{ParcelData, HasParcelData};
 pub use parcel_painter::*;
-pub use wall::{build_wall, get_wall_points, WallType};
+pub use wall::{build_wall, get_wall_points, TowerSkin, WallType};
 pub use footprint::{regularize_urban_footprint, reconcile_districts_to_footprint};
 pub use gate::build_wall_gate;
 pub use paint_palette::{PaintPaletteId, PaintPalette, PaintPalettesFile};

--- a/src/generator/districts/wall.rs
+++ b/src/generator/districts/wall.rs
@@ -184,11 +184,19 @@ fn parapet_is_outer(cell: Point2D, region: &HashSet<Point2D>, ring: &HashSet<Poi
     })
 }
 
-/// `palette` is the culture's output palette used to re-skin placed wall
-/// structures (towers) into the settlement's look — e.g. a desert town swaps the
-/// stone-brick/oak tower NBT to smooth_sandstone/birch. `None` leaves structures
-/// in their authored blocks.
-pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rng : &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, wall_type: WallType, palette: Option<&Palette>) {
+/// The inputs needed to re-skin placed wall structures (towers) into a culture's
+/// look — e.g. swapping the stone-brick/oak tower NBT to smooth_sandstone/birch.
+/// Both the loaded generator data and the output palette are required for the
+/// swap, so they're bundled to keep them from desyncing; pass `None` to leave
+/// structures in their authored blocks.
+pub struct TowerSkin<'a> {
+    pub data: &'a LoadedData,
+    pub palette: &'a Palette,
+}
+
+/// `skin` re-skins placed wall structures (towers) into the settlement's look;
+/// `None` leaves them in their authored blocks. See [`TowerSkin`].
+pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rng : &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, wall_type: WallType, skin: Option<&TowerSkin<'_>>) {
     let ordered_wall_points = trace_wall_loops(urban_points);
     let total_points: usize = ordered_wall_points.iter().map(|loop_| loop_.len()).sum();
     info!(
@@ -207,11 +215,11 @@ pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rn
 
     for wall_point_list in ordered_wall_points {
         if wall_type == WallType::Standard {
-            build_wall_standard(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, palette).await;
+            build_wall_standard(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, skin).await;
         } else if wall_type == WallType::Palisade {
             build_wall_palisade(&wall_point_list, editor, rng, material_placer, material_id, structures).await;
         } else if wall_type == WallType::StandardWithInner {
-            build_wall_standard_with_inner(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, palette).await;
+            build_wall_standard_with_inner(&wall_point_list, editor, rng, material_placer, material_id, structures, urban_points, skin).await;
         }
     }
 }
@@ -261,7 +269,7 @@ pub async fn build_wall_palisade(wall_points: &Vec<Point2D>, editor: &mut Editor
 
 }
 
-pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, palette: Option<&Palette>) {
+pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, skin: Option<&TowerSkin<'_>>) {
     let wall_points_with_height = add_wall_points_height(wall_points, editor);
     let wall_set: HashSet<Point2D> = wall_points.iter().cloned().collect();
     let enhanced_wall_points = check_water(&mut add_wall_points_directionality(&wall_points_with_height, &wall_set, urban_points), editor);
@@ -348,14 +356,14 @@ pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor
         editor.world_mut().claim(*p, BuildClaim::Wall);
     }
     //add towers
-    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, palette).await;
+    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, skin).await;
     //add gates
     build_wall_gate(&wall_points_with_height, editor, rng, material_placer, true, false, None, None, structures, 6).await
 
 }
 
 
-pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, palette: Option<&Palette>) {
+pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>, urban_points: &HashSet<Point2D>, skin: Option<&TowerSkin<'_>>) {
     let wall_points_with_height = add_wall_points_height(wall_points, editor);
     let wall_set: HashSet<Point2D> = wall_points.iter().cloned().collect();
     let enhanced_wall_points = check_water(&mut add_wall_points_directionality(&wall_points_with_height, &wall_set, urban_points), editor);
@@ -502,7 +510,7 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
         editor.world_mut().claim(p.drop_y(), BuildClaim::Wall);
     }
     //add towers
-    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, palette).await;
+    build_wall_towers(&walkway_points, &walkway_heights, editor, material_placer, material_id, structures, rng, skin).await;
     //add gates
     build_wall_gate(&wall_points_with_height, editor, rng, material_placer, false, false, Some(&enhanced_wall_points), Some(&inner_wall_points), structures, 6).await
 
@@ -850,7 +858,7 @@ pub async fn build_wall_towers(
     material_id: &MaterialId,
     structures: & HashMap<StructureType, Structure>,
     rng: &mut RNG,
-    palette: Option<&Palette>,
+    skin: Option<&TowerSkin<'_>>,
 ) {
     let distance_to_next_tower = 80;
     let mut tower_possible = rng.rand_i32_range(0, distance_to_next_tower / 2);
@@ -860,12 +868,6 @@ pub async fn build_wall_towers(
     // be read.
     let tower_size_y: i32 = load_nbt_structure(&tower.meta.path).map(|s| s.size[1]).unwrap_or(12);
     let walkway_set: HashSet<Point2D> = walkway_points.iter().cloned().collect();
-
-    // When a culture palette is supplied, load the generator data so the tower
-    // NBT (authored in the `wall_base` input palette) can be palette-swapped
-    // into the settlement's look — e.g. desert → smooth_sandstone/birch. Loaded
-    // once here, not per tower.
-    let data = palette.map(|_| LoadedData::load().expect("Failed to load data for tower palette swap"));
 
     for point in walkway_points {
         if tower_possible == 0 {
@@ -891,10 +893,10 @@ pub async fn build_wall_towers(
                     editor.world_mut().claim(*neighbour, BuildClaim::Wall);
                 }
                 info!("Placing tower at: {:?}", point.add_y(point_height+6));
-                // Re-skin the tower into the culture palette when one was given
+                // Re-skin the tower into the culture palette when a skin was given
                 // (data + output palette both present → place_structure runs the
                 // swap); otherwise place the authored blocks unchanged.
-                place_structure(editor, Some(material_placer), &tower, point.add_y(point_height+6), Cardinal::North, data.as_ref(), palette, false, false).await.expect("Failed to place tower");
+                place_structure(editor, Some(material_placer), &tower, point.add_y(point_height+6), Cardinal::North, skin.map(|s| s.data), skin.map(|s| s.palette), false, false).await.expect("Failed to place tower");
 
                 // Two guard posts on the tower's battlement top, where guards
                 // stand watch. The structure's origin maps to (point, point_height

--- a/src/generator/open_space/mod.rs
+++ b/src/generator/open_space/mod.rs
@@ -279,30 +279,6 @@ fn cull_thin(green: &HashSet<Point2D>) -> HashSet<Point2D> {
 /// become the watershed cuts that split sprawling regions apart.
 const CORE_MIN_DIST: i32 = 2;
 
-/// Multi-source BFS distance of every green cell from the nearest non-green
-/// boundary (boundary-adjacent cells are 0).
-fn boundary_distance(green: &HashSet<Point2D>) -> HashMap<Point2D, i32> {
-    let mut dist: HashMap<Point2D, i32> = HashMap::new();
-    let mut queue: VecDeque<Point2D> = VecDeque::new();
-    for &c in green {
-        if CARDINALS_2D.iter().any(|d| !green.contains(&(c + *d))) {
-            dist.insert(c, 0);
-            queue.push_back(c);
-        }
-    }
-    while let Some(c) = queue.pop_front() {
-        let dc = dist[&c];
-        for d in CARDINALS_2D {
-            let n = c + d;
-            if green.contains(&n) && !dist.contains_key(&n) {
-                dist.insert(n, dc + 1);
-                queue.push_back(n);
-            }
-        }
-    }
-    dist
-}
-
 /// Flood the cells reachable from `start` within `allowed` that aren't already
 /// labelled, tagging them `id` in `label`.
 fn flood_label(
@@ -330,7 +306,9 @@ fn flood_label(
 /// nearest core. Sprawling shapes split at their necks; coreless components
 /// (uniformly thin blobs) stay whole.
 fn partition_cells(green: &HashSet<Point2D>) -> Vec<Vec<Point2D>> {
-    let dist = boundary_distance(green);
+    // Multi-source BFS distance of every green cell from the nearest non-green
+    // boundary (boundary-adjacent cells are 0) — the canonical impl in `props`.
+    let dist = props::edge_depth(green);
 
     // Cores: cells deep enough to be a lobe centre.
     let core: HashSet<Point2D> = green

--- a/src/generator/open_space/park.rs
+++ b/src/generator/open_space/park.rs
@@ -451,7 +451,7 @@ async fn furnish_lawn(
         if grand_tree {
             if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
                 lay_soil_patch(editor, centre, h).await;
-                let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y)).await;
+                let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
             } else {
                 place_monument(editor, centre, h, theme).await;
             }
@@ -533,7 +533,7 @@ async fn furnish_zen(
         if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
             let h = world.get_ocean_floor_height_at(centre);
             lay_soil_patch(editor, centre, h).await;
-            let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y)).await;
+            let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
             used.insert(centre);
             for d in CARDINALS_2D {
                 used.insert(centre + d);
@@ -689,7 +689,7 @@ async fn furnish_cactus(
         }
         let h = world.get_ocean_floor_height_at(c);
         // Grow the cactus through the Tree system; it lays its own sand footing.
-        let _ = generate_tree_feature(Tree::Cactus, editor, Point3D::new(c.x, h, c.y)).await;
+        let _ = generate_tree_feature(Tree::Cactus, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
         // Keep the four sides clear so the cactus survives the next tick.
         for d in CARDINALS_2D {
@@ -866,7 +866,7 @@ async fn scatter_trees(
         };
         let h = world.get_ocean_floor_height_at(c);
         lay_soil_patch(editor, c, h).await;
-        let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y)).await;
+        let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
         for d in CARDINALS_2D {
             used.insert(c + d);

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -7,7 +7,7 @@
 //! little greenery in the corners. The roomier types need a bigger open centre;
 //! a cramped plaza falls back to the single-cell monument.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 use crate::editor::Editor;
 use crate::generator::npc::DialogueVolume;
@@ -74,24 +74,9 @@ fn max_square_radius(cells: &HashSet<Point2D>, c: Point2D, limit: i32) -> i32 {
 /// The most-interior region cell (max distance from the perimeter), with the
 /// largest odd-square half-radius that fits there.
 fn centre_cell(region: &Region, cells: &HashSet<Point2D>) -> (Point2D, i32) {
-    let mut dist: HashMap<Point2D, i32> = HashMap::new();
-    let mut queue: VecDeque<Point2D> = VecDeque::new();
-    for &c in &region.cells {
-        if CARDINALS_2D.iter().any(|d| !cells.contains(&(c + *d))) {
-            dist.insert(c, 0);
-            queue.push_back(c);
-        }
-    }
-    while let Some(c) = queue.pop_front() {
-        let dc = dist[&c];
-        for d in CARDINALS_2D {
-            let n = c + d;
-            if cells.contains(&n) && !dist.contains_key(&n) {
-                dist.insert(n, dc + 1);
-                queue.push_back(n);
-            }
-        }
-    }
+    // Distance of each `cells` member from the perimeter; region cells outside
+    // `cells` (e.g. the stepped border) fall back to 0 and so never win.
+    let dist = edge_depth(cells);
     let centre = *region
         .cells
         .iter()

--- a/src/generator/open_space/props.rs
+++ b/src/generator/open_space/props.rs
@@ -159,7 +159,7 @@ pub(super) async fn place_tree(
         return false;
     };
     lay_soil_patch(editor, c, h).await;
-    let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y)).await;
+    let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y), rng).await;
     true
 }
 

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::data::Loadable;
 use crate::editor::Editor;
 use crate::generator::data::LoadedData;
-use crate::generator::districts::{build_wall, generate_parcels, ParcelType, WallType};
+use crate::generator::districts::{build_wall, generate_parcels, ParcelType, TowerSkin, WallType};
 use crate::generator::materials::{Material, MaterialId, Placer};
 use crate::generator::nbts::Structure;
 use crate::generator::paths::{build_paths_merged, build_road_network, build_rural_road_network, find_blocks, Path, PathPriority, RuralBuilding};
@@ -94,9 +94,10 @@ pub async fn generate_town(
             p
         }
     });
+    let tower_skin = tower_palette.as_ref().map(|p| TowerSkin { data: &data, palette: p });
     build_wall(
         &editor.world().get_urban_points(), editor, &mut rng2,
-        &mut placer, &wall_material, &structures, WallType::Standard, tower_palette.as_ref(),
+        &mut placer, &wall_material, &structures, WallType::Standard, tower_skin.as_ref(),
     ).await;
     drop(placer);
 

--- a/src/generator/terrain/test.rs
+++ b/src/generator/terrain/test.rs
@@ -166,7 +166,7 @@ mod tests {
 
             let tree = SPECIES[rng.rand_i32(SPECIES.len() as i32) as usize];
             let height = editor.world().get_ocean_floor_height_at(c);
-            generate_tree_feature(tree, &editor, Point3D::new(c.x, height, c.y))
+            generate_tree_feature(tree, &editor, Point3D::new(c.x, height, c.y), &mut rng)
                 .await
                 .expect("place feature failed");
         }

--- a/src/generator/terrain/tree_feature.rs
+++ b/src/generator/terrain/tree_feature.rs
@@ -9,7 +9,7 @@
 //! reproducible from our seed), and it **bypasses the editor's block cache**
 //! (so it's invisible to later `get_block` reads and to offline/dry-run mode).
 
-use crate::{editor::Editor, geometry::Point3D};
+use crate::{editor::Editor, geometry::Point3D, noise::RNG};
 
 use super::Tree;
 
@@ -51,14 +51,13 @@ pub fn tree_feature_id(tree: Tree) -> &'static str {
 }
 
 /// Build a short cactus column (1–3 tall) on a sand footing, in place of a
-/// vanilla feature (there's no cactus equivalent). Height varies by position
-/// since no RNG is threaded through the feature path.
-async fn place_cactus_column(editor: &Editor, point: Point3D) {
+/// vanilla feature (there's no cactus equivalent). Height is rolled from `rng`.
+async fn place_cactus_column(editor: &Editor, point: Point3D, rng: &mut RNG) {
     let (x, y, z) = (point.x, point.y, point.z);
     editor
         .place_block_forced(&"minecraft:sand".into(), Point3D { x, y: y - 1, z })
         .await;
-    let height = 1 + (x * 2 + z).rem_euclid(3); // 1..=3, varied by position
+    let height = 1 + rng.rand_i32(3); // 1..=3
     for i in 0..height {
         editor
             .place_block(&"minecraft:cactus".into(), Point3D { x, y: y + i, z })
@@ -67,15 +66,18 @@ async fn place_cactus_column(editor: &Editor, point: Point3D) {
 }
 
 /// Grow a vanilla tree feature for `tree` at `point` (build-area-local
-/// coordinates) by asking the server to `place feature`.
+/// coordinates) by asking the server to `place feature`. `rng` is only consumed
+/// by the cactus path (which we build ourselves); vanilla features are seeded by
+/// the world.
 pub async fn generate_tree_feature(
     tree: Tree,
     editor: &Editor,
     point: Point3D,
+    rng: &mut RNG,
 ) -> anyhow::Result<()> {
     // Cactus has no vanilla `place feature` — build the column ourselves.
     if matches!(tree, Tree::Cactus) {
-        place_cactus_column(editor, point).await;
+        place_cactus_column(editor, point, rng).await;
         return Ok(());
     }
     editor.place_feature(tree_feature_id(tree), point).await


### PR DESCRIPTION
Post-merge cleanup on top of `jd/npcs`, from triaging the town-decoration code.

## Changes

### `open_space`: cactus uses real RNG; dedup perimeter-distance BFS
- `generate_tree_feature` now threads an `&mut RNG` so the cactus column height is rolled from the seed instead of a `(x*2+z) % 3` position hash (which produced visible diagonal banding when cacti lined up on a grid). All callers (props / park / test) pass their existing `rng`.
- Collapsed three byte-identical multi-source inward BFS passes into one: `props::edge_depth` is now the single implementation; `mod::partition_cells` and `plaza::centre_cell` call it instead of their own copies.

### `districts`: pass tower skin into `build_wall` instead of reloading data
- `build_wall_towers` reloaded the entire `LoadedData` tree on every wall build to palette-swap the tower NBT, even though `generate_town` already holds one. The swap inputs (`data` + `palette`) are now bundled into a `TowerSkin` and threaded through `build_wall`; the existing `LoadedData` is reused. Callers that don't re-skin still pass `None` unchanged.

## Testing
- `cargo check` clean.
- Tests compile; offline `desert_market_names_use_souk_bazaar` / `medieval_market_names_have_no_souk` pass.
- BFS refactor exercised by `plaza_types_gallery` (`centre_cell`) and `open_space_regions` (`partition_cells`).

## Notes
Two correctness items remain open from the same triage, left for a follow-up: unbounded downward liquid-fill in `terraforming::force_height`, and vanilla `place feature` trees punching leaves through building-adjacent cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)