### PR TITLE
Town colour identity + OOB-safe map accessors + medieval jetty

### DIFF
--- a/data/banners.yaml
+++ b/data/banners.yaml
@@ -1,0 +1,48 @@
+# Heraldic banner designs for manor families. Each manor flies ONE design on
+# every banner it owns — the pair flanking its front door and every banner
+# inside the house. The banner block's own colour is the family's primary colour
+# (the heraldic "field"); each pattern layer below is stamped in a distinct
+# secondary colour (the "charge"). One design is picked per family in
+# `settlement.rs` (see `generator::heraldry::pick_family_banner`).
+#
+# `layers` are minecraft `banner_pattern` registry ids, stacked bottom-to-top.
+# `blazon` is the charge as an English noun phrase for the chronicle, slotted
+# into "a {secondary} {blazon} on a {primary} background" — keep it reading
+# naturally there (e.g. "cross", "saltire", "cross within a border").
+designs:
+  - name: pale
+    layers: [stripe_center]
+    blazon: pale
+  - name: fess
+    layers: [stripe_middle]
+    blazon: fess
+  - name: bend
+    layers: [diagonal_up_right]
+    blazon: bend
+  - name: saltire
+    layers: [cross]
+    blazon: saltire
+  - name: cross
+    layers: [straight_cross]
+    blazon: cross
+  - name: chief
+    layers: [stripe_top]
+    blazon: chief
+  - name: bordure
+    layers: [border]
+    blazon: border
+  - name: lozenge
+    layers: [rhombus]
+    blazon: lozenge
+  - name: pile
+    layers: [triangle_bottom]
+    blazon: pile
+  - name: roundel
+    layers: [circle]
+    blazon: roundel
+  - name: cross_bordure
+    layers: [straight_cross, border]
+    blazon: cross within a border
+  - name: saltire_chief
+    layers: [cross, stripe_top]
+    blazon: saltire beneath a chief

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -47,6 +47,230 @@ first_name_suffixes:
   - ric
   - wyn
 
+# ── Per-culture first names ───────────────────────────────────────────────────
+# Localized first-name pools, picked directly by `roll_first_name` based on the
+# town's `Culture` (see `src/generator/population.rs`). When a culture has a
+# non-empty `first_names` list it is used verbatim; otherwise generation falls
+# back to the legacy `first_name_prefixes` × `first_name_suffixes` composition
+# above. Lists mix masculine and feminine given names — a name is assigned to an
+# NPC at random regardless of villager skin. Surnames are NOT localized here
+# (still composed from `surname_*`); only first names are culture-specific.
+cultures:
+  medieval:
+    # Anglo-Saxon / early-medieval English given names, to match the Old-English
+    # settlement names.
+    first_names:
+      - Aldwin
+      - Aldric
+      - Alfred
+      - Ansel
+      - Baldric
+      - Bardolf
+      - Cedric
+      - Cuthbert
+      - Drogo
+      - Dunstan
+      - Eadric
+      - Edgar
+      - Edmund
+      - Edwin
+      - Egbert
+      - Elric
+      - Ewart
+      - Frewin
+      - Garrick
+      - Godric
+      - Godwin
+      - Hamond
+      - Harold
+      - Herewald
+      - Leofric
+      - Leofwin
+      - Maerwin
+      - Odo
+      - Osbert
+      - Osric
+      - Oswin
+      - Oswald
+      - Raedwald
+      - Roderic
+      - Selwyn
+      - Sigeric
+      - Theobald
+      - Theodric
+      - Wilfred
+      - Wulfric
+      - Wulfstan
+      - Wymer
+      - Aelfgifu
+      - Aethelflaed
+      - Aldith
+      - Alwynn
+      - Audrey
+      - Bertha
+      - Cwen
+      - Cyneburh
+      - Eadgyth
+      - Edith
+      - Elfreda
+      - Ermina
+      - Frideswide
+      - Godiva
+      - Goldwyn
+      - Hereswith
+      - Hilda
+      - Leofgyth
+      - Mathilda
+      - Merewyn
+      - Mildred
+      - Osgith
+      - Rowena
+      - Sunngifu
+      - Wilburh
+      - Winfled
+      - Wynflaed
+      - Wynne
+  japanese:
+    # Traditional Japanese given names suited to a feudal village.
+    first_names:
+      - Akio
+      - Akira
+      - Daisuke
+      - Goro
+      - Hideo
+      - Hiroshi
+      - Ichiro
+      - Isamu
+      - Jiro
+      - Jun
+      - Kaname
+      - Katsuo
+      - Kazuo
+      - Kenji
+      - Kenta
+      - Kiyoshi
+      - Kuro
+      - Mamoru
+      - Masaru
+      - Minoru
+      - Nobuo
+      - Noboru
+      - Osamu
+      - Ryo
+      - Saburo
+      - Satoshi
+      - Shin
+      - Shiro
+      - Sora
+      - Susumu
+      - Tadao
+      - Takeshi
+      - Taro
+      - Tetsuo
+      - Toru
+      - Yoshio
+      - Yutaka
+      - Aiko
+      - Akiko
+      - Asa
+      - Chiyo
+      - Emiko
+      - Hana
+      - Hanako
+      - Haru
+      - Hiroko
+      - Kaede
+      - Keiko
+      - Kiku
+      - Kimiko
+      - Mai
+      - Maki
+      - Michiko
+      - Midori
+      - Nori
+      - Rei
+      - Ren
+      - Sachiko
+      - Sakura
+      - Setsuko
+      - Sumire
+      - Tomoko
+      - Yoko
+      - Yuki
+      - Yumi
+      - Yuriko
+  desert:
+    # Arabic given names for the desert culture.
+    first_names:
+      - Abbas
+      - Amir
+      - Anwar
+      - Aziz
+      - Bilal
+      - Faisal
+      - Farid
+      - Hamza
+      - Harun
+      - Hassan
+      - Husain
+      - Ibrahim
+      - Idris
+      - Imran
+      - Ismail
+      - Jamal
+      - Kamal
+      - Karim
+      - Khalid
+      - Mahmud
+      - Malik
+      - Mansur
+      - Marwan
+      - Musa
+      - Nadir
+      - Nasir
+      - Omar
+      - Qasim
+      - Rashid
+      - Sahl
+      - Salim
+      - Samir
+      - Suhayl
+      - Tahir
+      - Tariq
+      - Walid
+      - Yahya
+      - Yusuf
+      - Zahir
+      - Zayd
+      - Ziyad
+      - Aisha
+      - Amira
+      - Asma
+      - Basma
+      - Dunya
+      - Farida
+      - Fatima
+      - Halima
+      - Iman
+      - Jamila
+      - Karima
+      - Khadija
+      - Layla
+      - Lina
+      - Maryam
+      - Nadia
+      - Najwa
+      - Noor
+      - Rania
+      - Rasha
+      - Safiya
+      - Salma
+      - Samira
+      - Yasmin
+      - Zahra
+      - Zaynab
+      - Zubaida
+
 # Surnames are generated on demand by concatenating a `surname_prefix` (capitalized,
 # noun-like root) with a `surname_suffix` (lowercase place-name ending). All
 # combinations are designed to read as plausible English family names —

--- a/data/settlement_names.yaml
+++ b/data/settlement_names.yaml
@@ -108,58 +108,181 @@ biomes:
 # concept into that culture's words. A concept a culture doesn't define simply
 # contributes no theme (except `biome`, which falls back to `green`). `medieval`
 # is the fallback culture.
+#
+# `glosses` maps every name word (and suffix) to its plain-English meaning. The
+# namer emits an English translation of the composed name as the welcome
+# SUBTITLE — "Bir al-Raml" → "Well of the Sand", "Kawamura" → "River Village".
+# Every concept word, filler, colour word, and suffix MUST appear here (enforced
+# by `every_name_word_has_a_gloss`). Medieval names are readable Old English
+# (Anglo-Saxon) forms — "Myln" (mill), "Ac" (oak), "Stan" (stone) — so the gloss
+# is the modern-English reading: "Mylnham" → "Mill Homestead".
 cultures:
   medieval:
-    suffixes: [bury, ford, ton, holm, wick, dale, barrow, mere, stead, field, ham, worth]
-    fillers: [Hollow, Cross, Watch, Keep, Reach, End]
-    # Colour modifiers — always lead ("Blackmere", "Red Ridge"). Future: bias
-    # this pool toward the build palette's dominant material colour.
-    colors: [Black, White, Red, Green, Grey, Gold, Silver]
+    # Old-English suffixes: burh (fort), ford, tun (town), holm (isle), wic
+    # (farm), dæl (dale), beorg (barrow), mere (pool), stede (stead), feld
+    # (field), ham (homestead), worð (croft).
+    suffixes: [bury, ford, ton, holm, wick, dale, barrow, mere, stead, feld, ham, worth]
+    fillers: [Holh, Weard, Ende, Brycg, Cot]
+    # Colour words keyed by dye id → Old-English word; always lead ("Blacmere",
+    # "Reade Dun"). The namer renders the town's actual scheme colours, so these
+    # keys must cover Medieval's `Culture::color_pool`.
+    colors:
+      red: Reade
+      blue: Blue
+      green: Grene
+      yellow: Gold
+      white: Hwit
+      black: Blac
+      brown: Brun
     concepts:
-      mill: [Mill]
+      mill: [Myln]
       smith: [Smith]
-      baker: [Baker]
-      carpenter: [Carpenter]
+      baker: [Becer]
+      carpenter: [Wright]
       tanner: [Tanner]
-      weaver: [Weaver]
-      brewer: [Brewer]
+      weaver: [Webb]
+      brewer: [Breow]
       butcher: [Shamble]
       sawyer: [Sawyer]
-      chandler: [Chandler]
-      scribe: [Scribe]
-      field: [Field]
-      stock: [Stock]
-      delve: [Delve]
-      market: [Market, Chipping]
-      well: [Well, Wells]
-      cross: [Cross, Standing]
+      chandler: [Candel]
+      scribe: [Writere]
+      field: [Acer]
+      stock: [Stoc]
+      delve: [Delf]
+      market: [Ceap, Chipping]
+      well: [Well, Wielle]
+      cross: [Rod, Cross]
       grave: [Barrow, Hallow]
-      spring: [Spring]
+      spring: [Spring, Funta]
       pool: [Mere, Pool]
-      garden: [Garden, Bower]
-      hill: [Hill, Ridge, Crag]
-      flat: [Field, Plain, Green]
-      water: [Ford, Mere, Brook]
-      mesa: [Mesa, Clay]
-      blossom: [Blossom, Petal]
+      garden: [Orceard, Wyrt]
+      hill: [Dun, Hyll, Crag]
+      flat: [Feld, Grene, Plain]
+      water: [Broc, Mere, Ea]
+      mesa: [Clay, Stan]
+      blossom: [Blostm, Bloom]
       spore: [Spore, Cap]
-      marsh: [Marsh, Bog, Reed]
-      vine: [Vine, Fern]
+      marsh: [Mersc, Fenn, Hreod]
+      vine: [Fearn, Vine]
       sand: [Sand, Dust]
-      savanna: [Acacia, Gold]
-      frost: [Frost, Rime]
-      pine: [Pine, Fir]
-      birch: [Birch, Hazel]
-      wood: [Oak, Elm, Thorn]
-      peak: [Crag, Ridge, Stone]
-      shore: [Tide, Cove, Salt]
-      meadow: [Meadow, Clover, Lark]
-      green: [Green, Long, Stone, Brook]
+      savanna: [Gold, Acacia]
+      frost: [Forst, Rime]
+      pine: [Pin, Fir]
+      birch: [Birce, Hasel]
+      wood: [Ac, Elm, Holt]
+      peak: [Crag, Beorg, Stan]
+      shore: [Tid, Cove, Sealt]
+      meadow: [Maedwe, Lea, Clofa]
+      green: [Grene, Lang, Stan, Broc]
+    # word/suffix → modern-English meaning (the subtitle).
+    glosses:
+      # suffixes
+      bury: Fort
+      ford: Ford
+      ton: Town
+      holm: Isle
+      wick: Farm
+      dale: Dale
+      barrow: Barrow
+      mere: Pool
+      stead: Farmstead
+      feld: Field
+      ham: Homestead
+      worth: Croft
+      # colours
+      Reade: Red
+      Blue: Blue
+      Grene: Green
+      Gold: Gold
+      Hwit: White
+      Blac: Black
+      Brun: Brown
+      # fillers
+      Holh: Hollow
+      Weard: Watch
+      Ende: End
+      Brycg: Bridge
+      Cot: Cottage
+      # concept words
+      Myln: Mill
+      Smith: Smith
+      Becer: Baker
+      Wright: Carpenter
+      Tanner: Tanner
+      Webb: Weaver
+      Breow: Brewer
+      Shamble: Butcher
+      Sawyer: Sawyer
+      Candel: Chandler
+      Writere: Scribe
+      Acer: Field
+      Stoc: Stock
+      Delf: Mine
+      Ceap: Market
+      Chipping: Market
+      Well: Well
+      Wielle: Well
+      Rod: Cross
+      Cross: Cross
+      Barrow: Barrow
+      Hallow: Grave
+      Spring: Spring
+      Funta: Spring
+      Mere: Pool
+      Pool: Pool
+      Orceard: Orchard
+      Wyrt: Garden
+      Dun: Hill
+      Hyll: Hill
+      Crag: Crag
+      Feld: Field
+      Grene: Green
+      Plain: Plain
+      Broc: Brook
+      Ea: River
+      Clay: Clay
+      Stan: Stone
+      Blostm: Blossom
+      Bloom: Bloom
+      Spore: Spore
+      Cap: Cap
+      Mersc: Marsh
+      Fenn: Fen
+      Hreod: Reed
+      Fearn: Fern
+      Vine: Vine
+      Sand: Sand
+      Dust: Dust
+      Acacia: Acacia
+      Forst: Frost
+      Rime: Rime
+      Pin: Pine
+      Fir: Fir
+      Birce: Birch
+      Hasel: Hazel
+      Ac: Oak
+      Elm: Elm
+      Holt: Wood
+      Beorg: Mount
+      Tid: Tide
+      Cove: Cove
+      Sealt: Salt
+      Maedwe: Meadow
+      Lea: Lea
+      Clofa: Clover
+      Lang: Long
   japanese:
     two_word_pct: 15
     suffixes: [mura, machi, dani, gawa, hara, saki, sato]
     fillers: [Sato, Mura, Hama]
-    colors: [Aka, Shiro, Kuro, Ao, Midori, Kin, Murasaki]
+    colors:
+      red: Aka
+      blue: Ao
+      white: Shiro
+      black: Kuro
+      purple: Murasaki
+      yellow: Kin
+      green: Midori
     concepts:
       smith: [Kaji]
       field: [Ta]
@@ -183,6 +306,57 @@ cultures:
       shore: [Hama, Umi]
       meadow: [No, Hara]
       green: [Sato, Midori, Aoki]
+    glosses:
+      # suffixes
+      mura: Village
+      machi: Town
+      dani: Valley
+      gawa: River
+      hara: Plain
+      saki: Cape
+      sato: Hamlet
+      # colours
+      Aka: Red
+      Ao: Blue
+      Shiro: White
+      Kuro: Black
+      Murasaki: Purple
+      Kin: Gold
+      Midori: Green
+      # concept words + fillers
+      Kaji: Smith
+      Ta: Field
+      Ichi: Market
+      Ichiba: Market
+      Ido: Well
+      Tsuji: Crossroads
+      Tera: Temple
+      Izumi: Spring
+      Ike: Pond
+      Niwa: Garden
+      Sono: Garden
+      Yama: Mountain
+      Oka: Hill
+      Take: Peak
+      Hara: Plain
+      No: Field
+      Kawa: River
+      Taki: Waterfall
+      Mizu: Water
+      Sakura: Cherry Blossom
+      Numa: Marsh
+      Suna: Sand
+      Yuki: Snow
+      Shimo: Frost
+      Matsu: Pine
+      Mori: Forest
+      Hayashi: Woods
+      Mine: Peak
+      Hama: Beach
+      Umi: Sea
+      Aoki: Greenwood
+      Sato: Hamlet
+      Mura: Village
   desert:
     # Arabic-style: definite article + construct (iḍāfa), no compound suffixes.
     # ~40% "Al-Wadi" / "Ar-Raml" (sun-letter assimilated), ~45% "Bir al-Raml"
@@ -192,8 +366,15 @@ cultures:
       construct_pct: 45
     fillers: [Dar, Bab, Qasr]
     # Arabic colour forms used in real toponyms (Al-Hamra, Az-Zarqa, Al-Bayda);
-    # take the article + sun-letter assimilation like any other lead.
-    colors: [Bayda, Sawda, Hamra, Khadra, Zarqa, Safra]
+    # take the article + sun-letter assimilation like any other lead. Keyed by
+    # dye id → word, covering Desert's `Culture::color_pool`.
+    colors:
+      white: Bayda
+      red: Hamra
+      green: Khadra
+      yellow: Safra
+      light_blue: Zarqa
+      black: Sawda
     concepts:
       smith: [Haddad]
       market: [Souk]
@@ -213,3 +394,33 @@ cultures:
       shore: [Marsa]
       meadow: [Bustan]
       green: [Bustan, Dar, Wadi]
+    glosses:
+      # colours
+      Bayda: White
+      Hamra: Red
+      Khadra: Green
+      Safra: Yellow
+      Zarqa: Blue
+      Sawda: Black
+      # concept words + fillers
+      Haddad: Smith
+      Souk: Market
+      Bir: Well
+      Qasr: Castle
+      Qubba: Shrine
+      Ain: Spring
+      Birka: Pool
+      Bustan: Garden
+      Jebel: Mountain
+      Tell: Hill
+      Sahel: Plain
+      Hamada: Plateau
+      Wadi: River
+      Raml: Sand
+      Erg: Dunes
+      Sahra: Desert
+      Nakhl: Palms
+      Ras: Cape
+      Marsa: Harbour
+      Dar: House
+      Bab: Gate

--- a/src/editor/test.rs
+++ b/src/editor/test.rs
@@ -28,7 +28,7 @@ mod tests {
 
         for x in 0..build_area.length() {
             for z in 0..build_area.width() {
-                let point = editor.world_mut().add_height(Point2D { x, y: z });
+                let point = editor.world_mut().add_height(Point2D { x, y: z }).expect("test cell in bounds");
                 info!("Placing block at: {:?}", point);
                 editor.place_block( &block, point).await;
             }
@@ -45,7 +45,7 @@ mod tests {
 
         for x in 0..build_area.length() {
             for z in 0..build_area.width() {
-                let biome = world.get_surface_biome_at(Point2D::new(x, z));
+                let biome = world.get_surface_biome_at(Point2D::new(x, z)).expect("test cell in bounds");
                 assert!(!biome.is_unknown(), "Biome should not be unknown");
             }
         }
@@ -74,7 +74,7 @@ mod tests {
 
         for x in 0..build_area.length() {
             for z in 0..build_area.width() {
-                let height = world.get_height_at(Point2D::new(x, z)) - 1;
+                let height = world.get_height_at(Point2D::new(x, z)).expect("test cell in bounds") - 1;
                 let block = world.get_block(Point3D::new(x, height, z));
                 let point = Point3D::new(x, height, z) + world.build_area.origin;
                 println!("Block at ({:?}) height:{} {:?}", point, height, block);
@@ -96,7 +96,7 @@ mod tests {
         println!("Build area: {:?}", build_area);
         for x in 0..build_area.length() {
             for z in 0..build_area.width() {
-                let height = editor.world().get_height_at(Point2D::new(x, z)) - 1;
+                let height = editor.world().get_height_at(Point2D::new(x, z)).expect("test cell in bounds") - 1;
                 let block = editor.world().get_block(Point3D::new(x, height, z));
                 let point = Point3D::new(x, height, z) + editor.world().build_area.origin;
                 let new_point = Point3D::new(x, 200, z);

--- a/src/editor/world.rs
+++ b/src/editor/world.rs
@@ -10,6 +10,38 @@ use super::Editor;
 
 const CHUNK_SIZE : i32 = 16;
 
+/// Checked access into a `map[x][z]` 2D grid by a `Point2D`.
+///
+/// Returns `None` for any out-of-bounds coordinate — crucially including
+/// *negative* ones, which a bare `point.x as usize` cast would otherwise wrap
+/// into a huge index and panic on. This is the single choke point that makes
+/// the World maps impossible to panic-index. Callers that sample a cell or two
+/// past the build edge (road bands, search frontiers) get `None` and decide
+/// what to do, rather than crashing the generator.
+fn cell_2d<T>(map: &[Vec<T>], point: Point2D) -> Option<&T> {
+    if point.x < 0 || point.y < 0 {
+        log_oob(point);
+        return None;
+    }
+    match map.get(point.x as usize).and_then(|col| col.get(point.y as usize)) {
+        Some(cell) => Some(cell),
+        None => {
+            log_oob(point);
+            None
+        }
+    }
+}
+
+/// Trace (not warn) on out-of-bounds map access. OOB is *expected* here —
+/// `is_water` / road-band / search-frontier probes routinely sample a cell or
+/// two past the build edge, so a louder level would flood every normal run and
+/// bury the signal. At `RUST_LOG=trace` this leaves a coordinate trail so a
+/// genuine bug (a wrong point that silently gets skipped instead of panicking)
+/// can still be tracked down.
+fn log_oob(point: Point2D) {
+    log::trace!("World map access out of bounds at {:?}; returning None", point);
+}
+
 #[derive(Debug)]
 pub struct World {
     pub build_area : Rect3D,
@@ -130,8 +162,14 @@ impl World {
                 // `is_water` / `get_ground_block` — actually holds the surface block rather
                 // than the air above it. Without the `-1`, `is_water` reported false over
                 // open water, letting buildings be placed on water and backfilled.
-                world.ground_block_map[x][z] = world.get_block(Point3D::new(x as i32, world.ground_height_map[x][z] - 1, z as i32)).expect("Failed to get block at point");
-                world.ground_biome_map[x][z] = world.get_biome(Point3D::new(x as i32, world.ocean_floor_height_map[x][z], z as i32)).expect("Failed to get biome at point");
+                // Fall back to a sane default if the chunk/section isn't loaded
+                // for this cell rather than aborting the whole world load.
+                world.ground_block_map[x][z] = world
+                    .get_block(Point3D::new(x as i32, world.ground_height_map[x][z] - 1, z as i32))
+                    .unwrap_or_else(|| Block::new(Default::default(), None, None));
+                world.ground_biome_map[x][z] = world
+                    .get_biome(Point3D::new(x as i32, world.ocean_floor_height_map[x][z], z as i32))
+                    .unwrap_or_else(Biome::unknown);
             }
         }
 
@@ -215,18 +253,22 @@ impl World {
         }.iter()
     }
 
-    pub fn get_height_at(&self, point : Point2D) -> i32 {
-        self.ground_height_map[point.x as usize][point.y as usize]
+    pub fn get_height_at(&self, point : Point2D) -> Option<i32> {
+        cell_2d(&self.ground_height_map, point).copied()
     }
 
-    pub fn get_non_tree_height(&self, point : Point2D) -> i32 {
-        let mut height = self.get_height_at(point);
-        let mut block = self.get_block(Point3D::new(point.x, height - 1, point.y)).expect("Failed to get block at point");
-        while block.id.is_tree() {
+    pub fn get_non_tree_height(&self, point : Point2D) -> Option<i32> {
+        let mut height = self.get_height_at(point)?;
+        // Walk down through tree blocks to the real surface. If a block read
+        // fails (unloaded chunk / out of section range), stop where we are
+        // rather than panicking — the height so far is the best estimate.
+        while let Some(block) = self.get_block(Point3D::new(point.x, height - 1, point.y)) {
+            if !block.id.is_tree() {
+                break;
+            }
             height -= 1;
-            block = self.get_block(Point3D::new(point.x, height - 1, point.y)).expect("Failed to get block at point");
         }
-        height
+        Some(height)
     }
 
     pub fn get_height_map(&self) -> &Vec<Vec<i32>> {
@@ -250,7 +292,16 @@ impl World {
     }
 
     pub fn set_heights(&mut self, points : &HashSet<Point3D>) {
+        let xlen = self.ground_height_map.len() as i32;
+        let zlen = self.ground_height_map.first().map_or(0, |col| col.len()) as i32;
         for point in points {
+            // Defensive: terrain ops can hand us a cell one past the build-area
+            // edge, and these maps have no bounds check (see the is-water OOB
+            // gotcha). Those cells aren't ours to flatten, so skip rather than
+            // panic.
+            if point.x < 0 || point.z < 0 || point.x >= xlen || point.z >= zlen {
+                continue;
+            }
             self.ground_height_map[point.x as usize][point.z as usize] = point.y;
             self.ocean_floor_height_map[point.x as usize][point.z as usize] = point.y;
         }
@@ -265,44 +316,42 @@ impl World {
     }
 
     // Get height without counting water
-    pub fn get_ocean_floor_height_at(&self, point : Point2D) -> i32 {
-        let x = (point.x as usize).min(self.ocean_floor_height_map.len() - 1);
-        let z = (point.y as usize).min(self.ocean_floor_height_map[0].len() - 1);
-        self.ocean_floor_height_map[x][z]
+    pub fn get_ocean_floor_height_at(&self, point : Point2D) -> Option<i32> {
+        cell_2d(&self.ocean_floor_height_map, point).copied()
     }
 
-    pub fn get_motion_blocking_height_at(&self, point : Point2D) -> i32 {
-        let x = (point.x as usize).min(self.motion_blocking_height_map.len() - 1);
-        let z = (point.y as usize).min(self.motion_blocking_height_map[0].len() - 1);
-        self.motion_blocking_height_map[x][z]
+    pub fn get_motion_blocking_height_at(&self, point : Point2D) -> Option<i32> {
+        cell_2d(&self.motion_blocking_height_map, point).copied()
     }
 
-    pub fn get_surface_biome_at(&self, point : Point2D) -> Biome {
-        let height = self.get_ocean_floor_height_at(point);
+    pub fn get_surface_biome_at(&self, point : Point2D) -> Option<Biome> {
+        let height = self.get_ocean_floor_height_at(point)?;
         let point_3d = Point3D::new(point.x, height, point.y);
-        self.get_biome(point_3d).expect("Failed to get biome at point")
+        self.get_biome(point_3d)
     }
 
     pub fn get_parcel_at(&self, point : Point2D) -> Option<ParcelID> {
-        self.parcel_map[point.x as usize][point.y as usize]
+        cell_2d(&self.parcel_map, point).copied().flatten()
     }
 
     pub fn get_district_at(&self, point : Point2D) -> Option<DistrictID> {
-        self.district_map[point.x as usize][point.y as usize]
-    }   
-
-    pub fn add_height(&self, point : Point2D) -> Point3D {
-        Point3D::new(point.x, self.get_height_at(point), point.y)
+        cell_2d(&self.district_map, point).copied().flatten()
     }
 
-    pub fn add_non_tree_height(&self, point : Point2D) -> Point3D {
-        let mut new_point = Point3D::new(point.x, self.get_height_at(point), point.y);
-        let mut block = self.get_block(new_point + DOWN).expect("Failed to get block at point");
-        while block.id.is_tree() {
+    pub fn add_height(&self, point : Point2D) -> Option<Point3D> {
+        Some(Point3D::new(point.x, self.get_height_at(point)?, point.y))
+    }
+
+    pub fn add_non_tree_height(&self, point : Point2D) -> Option<Point3D> {
+        let mut new_point = Point3D::new(point.x, self.get_height_at(point)?, point.y);
+        // Walk down through tree blocks; stop on a failed read rather than panic.
+        while let Some(block) = self.get_block(new_point + DOWN) {
+            if !block.id.is_tree() {
+                break;
+            }
             new_point += DOWN;
-            block = self.get_block(new_point + DOWN).expect("Failed to get block at point");
         }
-        new_point
+        Some(new_point)
     }
 
     pub fn is_in_bounds_2d(&self, point : Point2D) -> bool {
@@ -380,26 +429,25 @@ impl World {
         Some(block_index as usize)
     }
 
-    pub fn get_ground_block(&self, point: Point2D) -> &Block {
-        &self.ground_block_map[point.x as usize][point.y as usize]
+    pub fn get_ground_block(&self, point: Point2D) -> Option<&Block> {
+        cell_2d(&self.ground_block_map, point)
     }
 
     pub fn is_water(&self, point : Point2D) -> bool {
         // Out of bounds is dry land, not a panic: callers that sample around a
         // road band / search frontier routinely probe a cell or two past the
-        // build edge, and `ground_block_map` is indexed unchecked.
-        if !self.is_in_bounds_2d(point) {
-            return false;
-        }
-        self.ground_block_map[point.x as usize][point.y as usize].id.is_water()
+        // build edge.
+        cell_2d(&self.ground_block_map, point).map_or(false, |b| b.id.is_water())
     }
 
     pub fn is_water_3d(&self, point : Point3D) -> bool {
-        self.get_block(point).expect("failed to get block").id.is_water()
+        // Missing block (unloaded chunk / out of range) is treated as not water.
+        self.get_block(point).map_or(false, |b| b.id.is_water())
     }
 
     pub fn is_claimed(&self, point : Point2D) -> bool {
-        self.build_claim_map[point.x as usize][point.y as usize] != BuildClaim::None
+        // Out of bounds cells are unclaimable, so treat them as unclaimed.
+        cell_2d(&self.build_claim_map, point).map_or(false, |c| *c != BuildClaim::None)
     }
 
     pub fn claim(&mut self, point: Point2D, claim: BuildClaim) {

--- a/src/generator/buildings/foundation.rs
+++ b/src/generator/buildings/foundation.rs
@@ -28,8 +28,10 @@ pub async fn build_foundation(
     );
 
     for point in area.union(&edge).into_iter() {
-        let height = editor.world().get_ocean_floor_height_at(*point);
-        let grid_height = grid.origin.y; 
+        let Some(height) = editor.world().get_ocean_floor_height_at(*point) else {
+            continue;
+        };
+        let grid_height = grid.origin.y;
         if height >= grid_height - 1 {
             let block = editor.world().get_block(point.add_y(height - 1)).expect("Block not found at point");
             editor.place_block(&block, point.add_y(grid_height - 1)).await;

--- a/src/generator/buildings/placement.rs
+++ b/src/generator/buildings/placement.rs
@@ -156,9 +156,14 @@ pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &Loade
                 //     continue;
                 // }
 
-                let y = editor.world().get_height_at(height_point);
+                let Some(y) = editor.world().get_height_at(height_point) else {
+                    continue;
+                };
+                let Some(point_height) = editor.world().get_height_at(point) else {
+                    continue;
+                };
 
-                if y.abs_diff(editor.world().get_height_at(point)) > 3 {
+                if y.abs_diff(point_height) > 3 {
                     continue; // Skip if the height difference is too large, this is probably indicative of a bad spot to place
                 }
 
@@ -225,7 +230,7 @@ impl PavingType {
 }
 
 pub async fn smooth_and_pave_road(editor : &mut Editor, rng : &mut RNG, outers : &HashSet<Point2D>, paving_type : PavingType) {
-    let mut points = outers.iter().map(|p| editor.world().add_non_tree_height(*p)).collect::<HashSet<_>>();
+    let mut points = outers.iter().filter_map(|p| editor.world().add_non_tree_height(*p)).collect::<HashSet<_>>();
     points = average_to_neighbours_5_away(&points).iter().map(|p| if p.y > 63 { *p } else { p.with_y(63) }).collect();
     force_height(editor, &points, true).await;
 

--- a/src/generator/buildings/test.rs
+++ b/src/generator/buildings/test.rs
@@ -21,7 +21,7 @@ mod tests {
         let palette = data.palettes.get(&"test2".into()).expect("Palette not found").clone();
 
         let midpoint = editor.world_mut().world_rect_2d().size / 2;
-        let point = editor.world_mut().add_height(midpoint);
+        let point = editor.world_mut().add_height(midpoint).expect("test cell in bounds");
 
         println!("Placing structure at: {:?}", point);
 
@@ -57,7 +57,7 @@ mod tests {
         let mut editor = world.get_editor();
 
         let midpoint = editor.world_mut().world_rect_2d().size / 2;
-        let point = editor.world_mut().add_height(midpoint);
+        let point = editor.world_mut().add_height(midpoint).expect("test cell in bounds");
 
         println!("Placing structure at: {:?}", point);
 
@@ -98,7 +98,7 @@ mod tests {
         let mut editor = world.get_editor();
 
         let midpoint = editor.world_mut().world_rect_2d().size / 2;
-        let point = editor.world_mut().add_height(midpoint);
+        let point = editor.world_mut().add_height(midpoint).expect("test cell in bounds");
 
         let shape = BuildingShape::new( 
             vec![

--- a/src/generator/buildings/walls/test.rs
+++ b/src/generator/buildings/walls/test.rs
@@ -27,7 +27,7 @@ mod tests {
         );
 
         let midpoint = editor.world_mut().world_rect_2d().size / 2;
-        let point = editor.world_mut().add_height(midpoint);
+        let point = editor.world_mut().add_height(midpoint).expect("test cell in bounds");
 
         let grid = Grid::new(point.into());
 

--- a/src/generator/buildings_v2/door_ramp/mod.rs
+++ b/src/generator/buildings_v2/door_ramp/mod.rs
@@ -306,7 +306,24 @@ pub fn plan_door_ramps_from_world(
     footprint: &Footprint,
     world: &World,
 ) -> Vec<DoorRamp> {
-    plan_door_ramps(wall_segs, footprint, |p| world.get_ocean_floor_height_at(p))
+    // The planner's terrain closure must yield an `i32` per cell. World height
+    // lookups now return `Option` (None only for out-of-bounds cells). For a
+    // building being placed the footprint and its door-adjacent cells are
+    // in-bounds, so every sample is `Some` and behavior is identical to before.
+    // For the degenerate edge case of a sample falling outside the build area,
+    // fall back to a representative in-bounds footprint height rather than
+    // panicking — never a fabricated constant.
+    let fallback_y = footprint
+        .filled_points()
+        .iter()
+        .find_map(|&p| world.get_ocean_floor_height_at(p));
+    let Some(fallback_y) = fallback_y else {
+        // Whole footprint is out of bounds — nothing sensible to plan.
+        return Vec::new();
+    };
+    plan_door_ramps(wall_segs, footprint, |p| {
+        world.get_ocean_floor_height_at(p).unwrap_or(fallback_y)
+    })
 }
 
 /// Place the planned ramps into the editor. Ascending ramps fill stone under

--- a/src/generator/buildings_v2/engawa.rs
+++ b/src/generator/buildings_v2/engawa.rs
@@ -1,22 +1,19 @@
-//! Engawa: a raised Japanese veranda for large buildings. Built on the same
-//! per-floor-extent machinery as [`super::frame::apply_jetty`], but inset rather
-//! than grown, and by different amounts per floor so the building tapers:
+//! Engawa: a raised Japanese veranda for large buildings. The building mass is
+//! inset from its nominal footprint and the freed perimeter becomes the veranda:
 //!
-//! - the cellar and ground floor inset by **2** on every open-air side,
-//! - the **top** floor also insets by **2**, so the roof is pulled back in,
-//! - the **middle** floors inset by **1**, so they bulge out over the veranda
-//!   (the tapered, overhanging engawa silhouette),
+//! - every floor (cellar through top) insets by **2** on every open-air side, so
+//!   the building is a clean inset box sitting back from the veranda edge,
 //! - the whole building is raised one block onto a wooden platform,
 //! - a **2-deep wooden deck** wraps the entire building perimeter — computed as a
 //!   dilation band around the merged ground-living shape, so it runs continuously
 //!   around corners and bumps around junctions where two rects meet, and
 //! - an **engawa roof** caps the veranda all the way around at the ground-floor
-//!   ceiling: slabs on the inner ring (against the wall), stairs on the outer
+//!   ceiling: full blocks on the inner ring (against the wall), stairs on the outer
 //!   ring (the dripping eave edge), with the diagonal corners filled.
 //!
-//! Planning ([`plan_engawa`]) is pure geometry and gates on the deeply-inset
-//! ground rects staying usable; [`apply_overhang`] rebuilds the frame with the
-//! per-floor extents; [`place_engawa`] lays the deck and roof after the roof.
+//! Planning ([`plan_engawa`]) is pure geometry and gates on the inset ground
+//! rects staying usable; the frame is built straight from the inset footprint;
+//! [`place_engawa`] lays the deck and roof after the roof.
 
 use std::collections::{HashMap, HashSet};
 
@@ -30,17 +27,15 @@ use super::footprint::merge::outline_from_rects;
 use super::frame::Frame;
 use super::pipeline::BuildCtx;
 
-/// Inset (cells) for the cellar, ground floor, and top floor — the deep inset.
-const DEEP_INSET: i32 = 2;
-/// Inset (cells) for the middle floors — one less, so they overhang the ground.
-const MID_INSET: i32 = 1;
-/// Depth of the veranda deck, in cells. Matches `DEEP_INSET` so the deck fills
+/// Inset (cells) applied to every floor on every open-air side.
+const INSET: i32 = 2;
+/// Depth of the veranda deck, in cells. Matches `INSET` so the deck fills
 /// out to the nominal footprint edge on cleanly-inset sides.
-const DECK_DEPTH: i32 = DEEP_INSET;
+const DECK_DEPTH: i32 = INSET;
 
-/// Smallest side a ground rect may have *after* the deep inset. Below this the
+/// Smallest side a ground rect may have *after* the inset. Below this the
 /// room partitioner has nothing usable, so the building falls back to plain
-/// walls. With `DEEP_INSET = 2` this needs a nominal side of at least 8 — i.e.
+/// walls. With `INSET = 2` this needs a nominal side of at least 8 — i.e.
 /// engawa only takes on the larger footprints, as intended.
 const MIN_INSET_SIDE: i32 = 4;
 
@@ -55,16 +50,12 @@ const CARDINALS: [Cardinal; 4] = [
 /// The four diagonal offsets, for corner filling: (dx, dz).
 const DIAGONALS: [(i32, i32); 4] = [(-1, -1), (-1, 1), (1, -1), (1, 1)];
 
-/// Output of [`plan_engawa`]. `building_footprint` (the deep-inset rects) is what
-/// the frame, walls, rooms, and cellar are built from; `mid_rects` are the
-/// per-rect middle-floor extents grafted on by [`apply_overhang`]; and
-/// `deck_cells` is the continuous veranda ring.
+/// Output of [`plan_engawa`]. `building_footprint` (the inset rects) is what the
+/// frame, walls, rooms, and cellar are built from on every floor; `deck_cells`
+/// is the continuous veranda ring.
 pub struct EngawaPlan {
-    /// Deep-inset footprint — cellar, ground floor, and top floor use this.
+    /// Inset footprint — every floor uses this.
     pub building_footprint: Footprint,
-    /// Middle-floor extents (inset by [`MID_INSET`]), parallel to
-    /// `building_footprint.rects()`. Applied to floors `1..count-1`.
-    mid_rects: Vec<Rect2D>,
     /// Veranda deck cells: a [`DECK_DEPTH`]-wide band wrapping the whole ground
     /// living shape, continuous around corners and junctions.
     pub deck_cells: Vec<Point2D>,
@@ -134,7 +125,7 @@ fn affordable_inset(rect: &Rect2D, s: &OpenAir, cap: i32) -> i32 {
 }
 
 /// Try to plan an engawa for `footprint`. Returns `None` (build plain) only when
-/// the **core** rect can't afford the full deep inset — i.e. the main mass is too
+/// the **core** rect can't afford the full inset — i.e. the main mass is too
 /// small for a real veranda. Wings inset by as much as they can fit (down to 0),
 /// so a building with one big core and small wings still gets an engawa; the deck
 /// (a dilation band, below) wraps around the under-inset wings regardless.
@@ -143,21 +134,15 @@ pub fn plan_engawa(footprint: &Footprint) -> Option<EngawaPlan> {
     let sides = open_air_sides(rects);
 
     // Per-rect inset amounts, clamped to what each rect can afford.
-    let deep_amounts: Vec<i32> = rects.iter().zip(&sides)
-        .map(|(r, s)| affordable_inset(r, s, DEEP_INSET))
+    let inset_amounts: Vec<i32> = rects.iter().zip(&sides)
+        .map(|(r, s)| affordable_inset(r, s, INSET))
         .collect();
-    // The core (rect 0) must afford the full deep inset for a proper veranda.
-    if deep_amounts[0] < DEEP_INSET {
+    // The core (rect 0) must afford the full inset for a proper veranda.
+    if inset_amounts[0] < INSET {
         return None;
     }
-    // Middle floors inset one less than the ground (but never more), so they
-    // bulge out wherever the ground actually inset.
-    let mid_amounts: Vec<i32> = deep_amounts.iter().map(|&d| MID_INSET.min(d)).collect();
 
-    let deep: Vec<Rect2D> = rects.iter().zip(&sides).zip(&deep_amounts)
-        .map(|((r, s), &a)| inset_one(r, s, a))
-        .collect();
-    let mid: Vec<Rect2D> = rects.iter().zip(&sides).zip(&mid_amounts)
+    let inset_rects: Vec<Rect2D> = rects.iter().zip(&sides).zip(&inset_amounts)
         .map(|((r, s), &a)| inset_one(r, s, a))
         .collect();
 
@@ -165,7 +150,7 @@ pub fn plan_engawa(footprint: &Footprint) -> Option<EngawaPlan> {
     // Computed by dilation (Chebyshev) so it runs continuously around corners and
     // around junctions where a partial seam stopped a rect from insetting — the
     // band simply bumps outward there to keep the ring unbroken.
-    let ground_cells: HashSet<Point2D> = deep.iter().flat_map(|r| r.iter()).collect();
+    let ground_cells: HashSet<Point2D> = inset_rects.iter().flat_map(|r| r.iter()).collect();
     let mut deck: HashSet<Point2D> = HashSet::new();
     for cell in &ground_cells {
         for dx in -DECK_DEPTH..=DECK_DEPTH {
@@ -182,36 +167,12 @@ pub fn plan_engawa(footprint: &Footprint) -> Option<EngawaPlan> {
     }
     let deck_cells: Vec<Point2D> = deck.into_iter().collect();
 
-    let building_footprint = Footprint::new(outline_from_rects(&deep), deep);
-    Some(EngawaPlan { building_footprint, mid_rects: mid, deck_cells })
-}
-
-/// Rebuild `frame` with the engawa's per-floor extents: the ground floor (0) and
-/// the top floor keep the deep-inset rect; the middle floors use the mid-inset
-/// rect (bulging out over the ground floor). `frame` must already have been
-/// generated from `plan.building_footprint`.
-pub fn apply_overhang(frame: Frame, plan: &EngawaPlan) -> Frame {
-    let max_floors = frame.max_floors();
-    let extents: Vec<Vec<Option<Rect2D>>> = (0..frame.rect_count()).map(|i| {
-        let count = frame.floor_counts()[i];
-        let deep = frame.rect_at(i, 0).expect("ground extent at floor 0");
-        let mid = plan.mid_rects[i];
-        (0..max_floors).map(|f| {
-            if f >= count { None }
-            else if f == 0 || f == count - 1 { Some(deep) } // ground or top → deep
-            else { Some(mid) }                              // middle → bulge out
-        }).collect()
-    }).collect();
-    Frame::with_per_floor_extents(
-        frame.footprint().clone(),
-        frame.base_y(),
-        extents,
-        frame.wall_height(),
-    )
+    let building_footprint = Footprint::new(outline_from_rects(&inset_rects), inset_rects);
+    Some(EngawaPlan { building_footprint, deck_cells })
 }
 
 /// Place the veranda deck and its engawa roof. `frame` is the inset, raised frame
-/// with the overhang applied (so `floor_y(0)` is the raised interior surface).
+/// (so `floor_y(0)` is the raised interior surface).
 pub async fn place_engawa(ctx: &mut BuildCtx<'_>, frame: &Frame, plan: &EngawaPlan) {
     let editor: &Editor = &*ctx.editor;
 
@@ -237,7 +198,7 @@ pub async fn place_engawa(ctx: &mut BuildCtx<'_>, frame: &Frame, plan: &EngawaPl
         roof_material,
     );
 
-    // Ground living cells (the deep-inset footprint). The engawa roof's inner
+    // Ground living cells (the inset footprint). The engawa roof's inner
     // ring is the deck band one cell out from these (against the wall); the outer
     // ring is the band two cells out (the dripping eave edge).
     let ground: HashSet<Point2D> = plan
@@ -297,15 +258,15 @@ pub async fn place_engawa(ctx: &mut BuildCtx<'_>, frame: &Frame, plan: &EngawaPl
         }
     }
 
-    let top_slab = HashMap::from([("type".to_string(), "top".to_string())]);
-
-    // Inner ring → top slabs (the higher part of the pent eave, against the wall).
+    // Inner ring → full roof blocks (the higher part of the pent eave, against
+    // the wall). Full blocks rather than top slabs so the inner eave reads solid
+    // and leaves no half-height gap beneath it where it meets the wall.
     for &cell in &inner {
         roof_placer.place_block_forced(
             editor,
             Point3D::new(cell.x, roof_y, cell.y),
-            BlockForm::Slab,
-            Some(&top_slab),
+            BlockForm::Block,
+            None,
             None,
         ).await;
     }

--- a/src/generator/buildings_v2/exterior.rs
+++ b/src/generator/buildings_v2/exterior.rs
@@ -6,13 +6,14 @@
 //! built. Tasteful by design: most houses get one or two props, never blocking
 //! a door, a road, or another building.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::editor::Editor;
 use crate::generator::BuildClaim;
 use crate::generator::buildings::BuildingID;
-use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
-use crate::minecraft::{string_to_block, Block, Color};
+use crate::generator::materials::{Material, MaterialId, MaterialRole, Palette};
+use crate::geometry::{Cardinal, Point2D, Point3D, CARDINALS_2D};
+use crate::minecraft::{string_to_block, Block, BlockForm, Color};
 use crate::noise::RNG;
 
 use super::footprint::Footprint;
@@ -37,6 +38,9 @@ pub async fn place_family_banner(
     let out: Point2D = (-seg.facing).into();
     let facing = (-seg.facing).to_string();
     let color_str: String = color.into();
+    // The family's heraldic pattern (if any), stamped on both door banners so
+    // they match the interior banners. `None` leaves them solid `color`.
+    let banner_data = ctx.palette.banner_data.clone();
     // Mid-wall row: solid infill beside the door on every door height.
     let y = seg.base_y + 1;
     // The wall cell just left and just right of the doorway.
@@ -50,13 +54,132 @@ pub async fn place_family_banner(
         // behind it. Forced so a verge lip or terrain can't block the placement.
         let pos = wall_cell + out;
         let banner = format!("minecraft:{color_str}_wall_banner[facing={facing}]");
+        let mut block = string_to_block(&banner).expect("family banner block");
+        block.data = banner_data.clone();
         ctx.editor
-            .place_block_forced(
-                &string_to_block(&banner).expect("family banner block"),
-                Point3D::new(pos.x, y, pos.y),
-            )
+            .place_block_forced(&block, Point3D::new(pos.x, y, pos.y))
             .await;
     }
+}
+
+/// One manor's pending name sign. The geometry + wood are worked out while the
+/// building is fresh (its front door known), but the board can't be lettered
+/// until the household's surname is rolled in the population pass — so the site
+/// is held and lettered later by [`place_manor_sign`]. `anchor_idx` is the
+/// manor's index in the town house list, used to look up its household.
+pub struct ManorSignSite {
+    pub anchor_idx: usize,
+    sign_pos: Point3D,
+    rotation: u8,
+    wood: String,
+    designation: String,
+}
+
+impl ManorSignSite {
+    /// The designation line (e.g. "Manor", "Estate") — for logging.
+    pub fn designation(&self) -> &str {
+        &self.designation
+    }
+}
+
+/// Work out where a manor's name sign hangs over its front door, or `None` if it
+/// has no ground-floor door. Reuses the door the family banner flanks. The sign
+/// is a ceiling hanging sign in the air cell just outside the door top, hanging
+/// from whatever structure is above (wall overhang / jettied upper floor). The
+/// board faces along the wall so it hangs **perpendicular to the wall** — edge-on
+/// to the doorway, broadside to anyone coming up the street.
+pub fn plan_manor_sign(
+    wall_segs: &WallSegments,
+    palette: &Palette,
+    materials: &HashMap<MaterialId, Material>,
+    rng: &mut RNG,
+    anchor_idx: usize,
+    designation: String,
+) -> Option<ManorSignSite> {
+    let (seg, opening) = wall_segs.doors().find(|(s, _)| s.floor == 0)?;
+    let cells = segment_cells(seg);
+    // The wall cell over the door's middle, then one step out toward the street.
+    let mid = (opening.offset + opening.width / 2) as usize;
+    let door_cell = *cells.get(mid)?;
+    // `seg.facing` is the INWARD normal; the street side is its negation.
+    let out: Point2D = (-seg.facing).into();
+    let out_cell = door_cell + out;
+    // Hang the board level with the door top (just above the opening).
+    let door_top = seg.base_y + opening.y_offset as i32 + opening.height as i32;
+    let sign_y = door_top;
+    // Text faces along the wall (perpendicular to the street normal), so the board
+    // hangs edge-on to the doorway and broadside to the street.
+    let rotation = sign_rotation(seg.facing.rotate_right());
+    let wood = wood_prefix(palette, materials, rng);
+    Some(ManorSignSite {
+        anchor_idx,
+        sign_pos: Point3D::new(out_cell.x, sign_y, out_cell.y),
+        rotation,
+        wood,
+        designation,
+    })
+}
+
+/// Letter and place a planned manor sign now its family `name` is known. The
+/// board reads blank / name / designation / blank so the two lines sit centred.
+pub async fn place_manor_sign(editor: &Editor, site: &ManorSignSite, name: &str) {
+    let face = format!(
+        "{{messages:[{},{},{},{}]}}",
+        sign_text(""),
+        sign_text(name),
+        sign_text(&site.designation),
+        sign_text(""),
+    );
+    let data = format!("{{front_text:{face},back_text:{face}}}");
+    let mut state = HashMap::new();
+    state.insert("rotation".to_string(), site.rotation.to_string());
+    // Attached = hangs rigidly from the block above (the bracket) on two chains.
+    state.insert("attached".to_string(), "true".to_string());
+    let sign = Block::new(
+        format!("minecraft:{}_hanging_sign", site.wood).as_str().into(),
+        Some(state),
+        Some(data),
+    );
+    editor.place_block_forced(&sign, site.sign_pos).await;
+}
+
+/// Sign rotation (0-15) for the cardinal the front text should face. Mirrors
+/// vanilla: south=0, west=4, north=8, east=12 (each step is 22.5°).
+fn sign_rotation(facing: Cardinal) -> u8 {
+    match facing {
+        Cardinal::South => 0,
+        Cardinal::West => 4,
+        Cardinal::North => 8,
+        Cardinal::East => 12,
+    }
+}
+
+/// Wood types that have `<wood>_hanging_sign` / `<wood>_planks` blocks.
+const SIGN_WOODS: [&str; 12] = [
+    "oak", "spruce", "birch", "jungle", "acacia", "dark_oak", "mangrove",
+    "cherry", "pale_oak", "bamboo", "crimson", "warped",
+];
+
+/// PrimaryWood as a hanging-sign / planks prefix ("spruce", "dark_oak", …),
+/// defaulting to oak if the palette's wood has no hanging-sign variant.
+fn wood_prefix(palette: &Palette, materials: &HashMap<MaterialId, Material>, rng: &mut RNG) -> String {
+    palette
+        .get_block(MaterialRole::PrimaryWood, &BlockForm::Block, materials, rng)
+        .map(|id| {
+            id.as_str()
+                .trim_start_matches("minecraft:")
+                .trim_end_matches("_planks")
+                .to_string()
+        })
+        .filter(|w| SIGN_WOODS.contains(&w.as_str()))
+        .unwrap_or_else(|| "oak".to_string())
+}
+
+/// Wrap a string as a single-quoted SNBT literal for sign text, escaping `\` and
+/// `'` so a name with an apostrophe can't break the sign data.
+fn sign_text(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+    format!("'{escaped}'")
 }
 
 /// Prop blocks placed against exterior walls — a varied, mostly single-block
@@ -143,7 +266,9 @@ pub async fn decorate_exterior_walls(
         }
 
         let prop = pick_prop(&mut rng);
-        let y = ctx.editor.world().get_height_at(cell);
+        let Some(y) = ctx.editor.world().get_height_at(cell) else {
+            continue;
+        };
         ctx.editor.place_block(&prop, Point3D::new(cell.x, y, cell.y)).await;
         ctx.editor
             .world_mut()
@@ -164,7 +289,9 @@ fn is_open_ground(editor: &Editor, cell: Point2D) -> bool {
         return false;
     }
     // The block the prop will stand on (one below the placement Y).
-    let y = world.get_height_at(cell);
+    let Some(y) = world.get_height_at(cell) else {
+        return false;
+    };
     match world.get_block(Point3D::new(cell.x, y - 1, cell.y)) {
         Some(b) => {
             let id = b.id.as_str();

--- a/src/generator/buildings_v2/exterior.rs
+++ b/src/generator/buildings_v2/exterior.rs
@@ -12,12 +12,52 @@ use crate::editor::Editor;
 use crate::generator::BuildClaim;
 use crate::generator::buildings::BuildingID;
 use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
-use crate::minecraft::{string_to_block, Block};
+use crate::minecraft::{string_to_block, Block, Color};
 use crate::noise::RNG;
 
 use super::footprint::Footprint;
 use super::pipeline::BuildCtx;
 use super::walls::{segment_cells, WallSegments};
+
+/// Hang a manor's family colour as wall banners flanking its front door, so the
+/// street reads the household before you step inside. Placed on the solid wall
+/// to either side of the ground-floor doorway (not above — an archway doorway
+/// has no wall block over it to support a banner), facing out toward the street.
+/// A no-op if the building has no ground-floor door.
+pub async fn place_family_banner(
+    ctx: &mut BuildCtx<'_>,
+    wall_segs: &WallSegments,
+    color: Color,
+) {
+    let Some((seg, opening)) = wall_segs.doors().find(|(s, _)| s.floor == 0) else {
+        return;
+    };
+    let cells = segment_cells(seg);
+    // `seg.facing` is the INWARD normal; the street side is its negation.
+    let out: Point2D = (-seg.facing).into();
+    let facing = (-seg.facing).to_string();
+    let color_str: String = color.into();
+    // Mid-wall row: solid infill beside the door on every door height.
+    let y = seg.base_y + 1;
+    // The wall cell just left and just right of the doorway.
+    let flanks = [opening.offset as i32 - 1, (opening.offset + opening.width) as i32];
+    for idx in flanks {
+        if idx < 0 || idx as usize >= cells.len() {
+            continue;
+        }
+        let wall_cell = cells[idx as usize];
+        // The banner hangs in the exterior air cell, supported by the wall block
+        // behind it. Forced so a verge lip or terrain can't block the placement.
+        let pos = wall_cell + out;
+        let banner = format!("minecraft:{color_str}_wall_banner[facing={facing}]");
+        ctx.editor
+            .place_block_forced(
+                &string_to_block(&banner).expect("family banner block"),
+                Point3D::new(pos.x, y, pos.y),
+            )
+            .await;
+    }
+}
 
 /// Prop blocks placed against exterior walls — a varied, mostly single-block
 /// set of everyday household clutter. Keep this list 10+ deep so a street shows

--- a/src/generator/buildings_v2/footprint/test.rs
+++ b/src/generator/buildings_v2/footprint/test.rs
@@ -410,7 +410,7 @@ mod minecraft_tests {
             for x in 0..64i32 {
                 for z in 0..64i32 {
                     let world_point = Point2D::new(area_min.x + x, area_min.y + z);
-                    let y = editor.world().get_height_at(world_point);
+                    let y = editor.world().get_height_at(world_point).expect("test cell in bounds");
 
                     let block: Block = if edge_set.contains(&world_point) {
                         "stone_bricks".into()
@@ -428,7 +428,7 @@ mod minecraft_tests {
             let sign_x = if ox < 0 { area_max.x } else { area_min.x };
             let sign_z = if oz < 0 { area_max.y } else { area_min.y };
             let sign_point = Point2D::new(sign_x, sign_z);
-            let sign_y = editor.world().get_height_at(sign_point);
+            let sign_y = editor.world().get_height_at(sign_point).expect("test cell in bounds");
             editor.place_block(&sign_block(name), sign_point.add_y(sign_y + 1)).await;
         }
 
@@ -445,7 +445,7 @@ mod minecraft_tests {
 
         let world_rect = editor.world().world_rect_2d();
         let center = world_rect.midpoint();
-        let y = editor.world().get_height_at(center);
+        let y = editor.world().get_height_at(center).expect("test cell in bounds");
 
         // Create a 30x30 plot with some obstacles
         let plot_min = Point2D::new(center.x - 15, center.y - 15);

--- a/src/generator/buildings_v2/foundation/course.rs
+++ b/src/generator/buildings_v2/foundation/course.rs
@@ -62,10 +62,7 @@ pub fn analyze_terrain(footprint: &Footprint, world: &World, base_y_override: Op
 
     let heights: HashMap<Point2D, i32> = points
         .iter()
-        .map(|&p| {
-            let h = world.get_ocean_floor_height_at(p);
-            (p, h)
-        })
+        .filter_map(|&p| world.get_ocean_floor_height_at(p).map(|h| (p, h)))
         .collect();
 
     let min_height = *heights.values().min().expect("Footprint has no points");

--- a/src/generator/buildings_v2/foundation/terraform.rs
+++ b/src/generator/buildings_v2/foundation/terraform.rs
@@ -57,7 +57,9 @@ pub async fn blend_terrain(ctx: &mut BuildCtx<'_>, footprint: &Footprint, base_y
                 continue;
             }
 
-            let terrain_y = ctx.editor.world().get_ocean_floor_height_at(point);
+            let Some(terrain_y) = ctx.editor.world().get_ocean_floor_height_at(point) else {
+                continue;
+            };
 
             // Only raise terrain, never lower it. If terrain is already at or
             // above the lerped target there's nothing to do.

--- a/src/generator/buildings_v2/furnish/block.rs
+++ b/src/generator/buildings_v2/furnish/block.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::generator::materials::{Material, MaterialId, MaterialRole, Palette};
 use crate::geometry::{Cardinal, Point2D};
-use crate::minecraft::{Block, BlockForm, color_block, string_to_block};
+use crate::minecraft::{Block, BlockForm, BlockID, color_block, string_to_block};
 use crate::noise::RNG;
 
 use super::data::PaletteSwap;
@@ -59,6 +59,19 @@ pub(super) fn parse_block(block_str: &str) -> Block {
         .unwrap_or_else(|| Block::from_id(block_str.into()))
 }
 
+/// If `id` is a banner and the palette carries a family banner design, return
+/// that design's pattern SNBT; otherwise keep the block's existing data. Lets a
+/// manor stamp its one heraldic design onto every banner the furnish pass
+/// recolours, while leaving all other recoloured blocks (beds, carpets, …)
+/// untouched.
+fn banner_data_or(id: &BlockID, palette: &Palette, existing: Option<String>) -> Option<String> {
+    if palette.banner_data.is_some() && id.as_str().contains("banner") {
+        palette.banner_data.clone()
+    } else {
+        existing
+    }
+}
+
 /// Apply palette substitution to a block.
 pub(super) fn swap_block_for_palette(
     block: Block,
@@ -83,7 +96,9 @@ pub(super) fn swap_block_for_palette(
         }
         PaletteSwap::Color => {
             if let Some(color) = palette.primary_color {
-                Block::new(color_block(block.id, color), block.state, block.data)
+                let id = color_block(block.id, color);
+                let data = banner_data_or(&id, palette, block.data);
+                Block::new(id, block.state, data)
             } else {
                 block
             }
@@ -93,7 +108,9 @@ pub(super) fn swap_block_for_palette(
             // primary-color when no secondary is defined.
             let color = palette.secondary_color.or(palette.primary_color);
             if let Some(color) = color {
-                Block::new(color_block(block.id, color), block.state, block.data)
+                let id = color_block(block.id, color);
+                let data = banner_data_or(&id, palette, block.data);
+                Block::new(id, block.state, data)
             } else {
                 block
             }

--- a/src/generator/buildings_v2/furnish/test.rs
+++ b/src/generator/buildings_v2/furnish/test.rs
@@ -1225,6 +1225,7 @@ async fn place_room_sizes_in_world() {
             // Drives PaletteSwap::SecondaryColor — accent color for patterned
             // carpets and any future two-tone items.
             secondary_color: Some(secondary),
+            banner_data: None,
             tags: None,
         }
     };
@@ -1234,7 +1235,7 @@ async fn place_room_sizes_in_world() {
     // internally) — keep everything below in local space.
     let base_x = 8i32;
     let base_z = 8i32;
-    let ground_local = editor.world().get_height_at(Point2D::new(base_x, base_z));
+    let ground_local = editor.world().get_height_at(Point2D::new(base_x, base_z)).expect("test cell in bounds");
     let floor_y = ground_local + 1;
 
     // (rect_size, interior-door, wall-door (opening), label, world offset, palette)
@@ -1396,6 +1397,7 @@ async fn place_feature_rooms_in_world() {
             materials: mats,
             primary_color: Some(primary),
             secondary_color: Some(secondary),
+            banner_data: None,
             tags: None,
         }
     };
@@ -1455,7 +1457,7 @@ async fn place_feature_rooms_in_world() {
     let build_size = editor.world().build_area.size;
     let base_x = ((build_size.x - layout_w) / 2).max(0);
     let base_z = ((build_size.z - layout_h) / 2).max(0);
-    let ground_local = editor.world().get_height_at(Point2D::new(base_x, base_z));
+    let ground_local = editor.world().get_height_at(Point2D::new(base_x, base_z)).expect("test cell in bounds");
     let floor_y = ground_local + 1;
 
     let floor_block = Block::from_id("minecraft:oak_planks".into());
@@ -2211,7 +2213,7 @@ async fn build_furniture_gallery() {
 
     let world_rect = editor.world().world_rect_2d();
     let center = world_rect.midpoint();
-    let ground_y = editor.world().get_height_at(center);
+    let ground_y = editor.world().get_height_at(center).expect("test cell in bounds");
     let floor_y = ground_y + LIFT;          // furniture stands here
     let surface_y = floor_y - 1;            // solid platform top
     let ceiling_y = floor_y + WALL_HEIGHT;  // solid ceiling here

--- a/src/generator/buildings_v2/mod.rs
+++ b/src/generator/buildings_v2/mod.rs
@@ -17,6 +17,7 @@ pub use pipeline::{BuildCtx, HouseOutput, build_house};
 pub use self::walls::{TimberPattern, WindowFill};
 
 use crate::generator::materials::PaletteId;
+use crate::minecraft::Color;
 use footprint::SizeClass;
 use roof::RoofStyle;
 use roof::gable::GablePitch;
@@ -42,6 +43,32 @@ impl Culture {
             Culture::Medieval => "medieval_spruce".into(),
             Culture::Desert => "desert_sandstone".into(),
             Culture::Japanese => "japanese_dark_blackstone".into(),
+        }
+    }
+
+    /// Curated, harmonious dye palette this culture's buildings draw their
+    /// accent colour from. The settlement's `ColorScheme` picks its two town
+    /// colours and the manor family colours out of this pool, so the whole town
+    /// reads as one coherent colour family. Every colour here must have a
+    /// matching `colors:` word entry for this culture in `settlement_names.yaml`
+    /// so a town named after its dominant colour can render it.
+    pub fn color_pool(&self) -> Vec<Color> {
+        match self {
+            // Heraldic + earthy: the classic medieval banner colours.
+            Culture::Medieval => vec![
+                Color::Red, Color::Blue, Color::Green,
+                Color::Yellow, Color::White, Color::Black, Color::Brown,
+            ],
+            // Vermilion / indigo / ink — the traditional Japanese register.
+            Culture::Japanese => vec![
+                Color::Red, Color::Blue, Color::White,
+                Color::Black, Color::Purple, Color::Yellow, Color::Green,
+            ],
+            // Sun-bleached earth tones for the desert.
+            Culture::Desert => vec![
+                Color::White, Color::Red, Color::Green,
+                Color::Yellow, Color::LightBlue, Color::Black,
+            ],
         }
     }
 

--- a/src/generator/buildings_v2/pipeline.rs
+++ b/src/generator/buildings_v2/pipeline.rs
@@ -126,11 +126,11 @@ pub async fn build_house(
 
     // Frame consumes a Footprint; keep `building_footprint` for later lookups
     // (find_boundaries, filled_points). The frame is generated from the
-    // ground-inset footprint; for an engawa, `apply_overhang` then grafts on the
-    // upper-floor extents (inset by one, overhanging the ground floor).
+    // deep-inset footprint, so every engawa floor already sits at that inset —
+    // no per-floor overhang. A non-engawa building may instead jetty its uppers.
     let frame = generate_frame(building_footprint.clone(), frame_base_y, &size_class, ctx.rng);
-    let frame = if let Some(plan) = &engawa_plan {
-        engawa::apply_overhang(frame, plan)
+    let frame = if engawa_plan.is_some() {
+        frame
     } else if bctx.jetty {
         apply_jetty(frame, &plot_bounds)
     } else {

--- a/src/generator/buildings_v2/walls/test.rs
+++ b/src/generator/buildings_v2/walls/test.rs
@@ -638,7 +638,7 @@ async fn debug_single_manor_segments() {
     let footprint = generate_footprint(&mut rng, &mut plot, &SizeClass::Manor)
         .expect("Failed to generate manor footprint");
 
-    let base_y = editor.world().get_ocean_floor_height_at(center);
+    let base_y = editor.world().get_ocean_floor_height_at(center).expect("test cell in bounds");
     let frame_footprint = Footprint::new(
         outline_from_rects(footprint.rects()),
         footprint.rects().to_vec(),

--- a/src/generator/city_houses/walk.rs
+++ b/src/generator/city_houses/walk.rs
@@ -129,7 +129,7 @@ fn road_floor_level(chain_slice: &[Point2D], outward: Cardinal, editor: &Editor)
 /// the debug road markers that float high above the surface. `None` if the
 /// window holds only air (no road here).
 fn road_surface_top(editor: &Editor, cell: Point2D) -> Option<i32> {
-    let ref_y = editor.world().get_ocean_floor_height_at(cell);
+    let ref_y = editor.world().get_ocean_floor_height_at(cell)?;
     for y in (ref_y - 5..=ref_y + 5).rev() {
         if let Some(block) = editor.try_get_block(cell.add_y(y)) {
             if !block.id.is_air() {

--- a/src/generator/districts/analysis.rs
+++ b/src/generator/districts/analysis.rs
@@ -94,21 +94,21 @@ pub async fn analyze_parcel<'a, TID : 'a>(area: &ParcelData<TID>, editor: &Edito
 
 
     for point in area.points() {
-        let biome = editor.world().get_surface_biome_at(point.drop_y());
+        let Some(biome) = editor.world().get_surface_biome_at(point.drop_y()) else { continue; };
         let block = editor.get_block(*point + DOWN);
         let is_water = block.id.is_water();
-        let leaf_height = editor.world().get_motion_blocking_height_at(point.drop_y());
+        let Some(leaf_height) = editor.world().get_motion_blocking_height_at(point.drop_y()) else { continue; };
 
         root_mean_square_height += ((point.y - average_height) as f32).powi(2);
 
-        let height = editor.world().get_non_tree_height(point.drop_y());
+        let Some(height) = editor.world().get_non_tree_height(point.drop_y()) else { continue; };
         let average_neighbour_height = CARDINALS_2D.iter()
-            .map(|cardinal| {
+            .filter_map(|cardinal| {
                 let neighbour = point.drop_y() + *cardinal;
                 if editor.world().is_in_bounds_2d(neighbour) {
-                    (height - editor.world().get_non_tree_height(neighbour)).abs()
+                    editor.world().get_non_tree_height(neighbour).map(|nh| (height - nh).abs())
                 } else {
-                    0
+                    Some(0)
                 }
             })
             .sum::<i32>() as f32 / 4.0;

--- a/src/generator/districts/gate.rs
+++ b/src/generator/districts/gate.rs
@@ -215,7 +215,7 @@ fn score_candidate(wall_points: &Vec<Point3D>, editor: &Editor, i: usize) -> f64
         let y = wall_points[j].y;
         min_y = min_y.min(y);
         max_y = max_y.max(y);
-        let t = editor.world().get_height_at(wall_points[j].drop_y());
+        let Some(t) = editor.world().get_height_at(wall_points[j].drop_y()) else { continue; };
         min_t = min_t.min(t);
         max_t = max_t.max(t);
     }
@@ -337,9 +337,10 @@ async fn place_palisade_gate(
 ) {
     let air = "air".into();
     let point = wall_points[i];
+    let Some(middle_height) = editor.world().get_height_at(wall_points[i + 2].drop_y()) else { return; };
     let middle_point = Point3D::new(
         wall_points[i + 2].x,
-        editor.world().get_height_at(wall_points[i + 2].drop_y()),
+        middle_height,
         wall_points[i + 2].z,
     );
     let direction = if point.x == wall_points[i + 6].x {
@@ -379,9 +380,10 @@ async fn place_thin_gate(
 ) {
     let air = "air".into();
     let point = wall_points[i];
+    let Some(middle_height) = editor.world().get_height_at(wall_points[i + 3].drop_y()) else { return; };
     let middle_point = Point3D::new(
         wall_points[i + 3].x,
-        editor.world().get_height_at(wall_points[i + 3].drop_y()),
+        middle_height,
         wall_points[i + 3].z,
     );
     let direction = if point.x == wall_points[i + 6].x {
@@ -428,7 +430,7 @@ async fn place_wide_gate(
     let neighbours: Vec<Point2D> = ((middle_point.x - 3)..=(middle_point.x + 3))
         .flat_map(|x| ((middle_point.y - 3)..=(middle_point.y + 3)).map(move |y| Point2D { x, y }))
         .collect();
-    let height = editor.world().get_height_at(middle_point);
+    let Some(height) = editor.world().get_height_at(middle_point) else { return; };
     for neighbour in neighbours.iter() {
         editor.world_mut().claim(*neighbour, BuildClaim::Gate);
         for h in height..height + gate_height {

--- a/src/generator/districts/parcel.rs
+++ b/src/generator/districts/parcel.rs
@@ -182,12 +182,13 @@ fn bubble_out(parcels : &mut HashMap<ParcelID, Parcel>, world : &mut World) { //
                 continue;
             }
 
+            let Some(neighbour_point) = world.add_non_tree_height(neighbour) else { continue; };
             visited.insert(neighbour);
             queue.push(neighbour);
             world.parcel_map[neighbour.x as usize][neighbour.y as usize] = Some(current_parcel);
             parcels.get_mut(&current_parcel)
                 .expect(&format!("No parcel found with id {}", current_parcel.0))
-                .add_point(world.add_non_tree_height(neighbour));
+                .add_point(neighbour_point);
         }
     }
 }
@@ -196,7 +197,8 @@ fn recenter_parcels(world : &mut World, parcels : &mut HashMap<ParcelID, Parcel>
     world.parcel_map = vec![vec![None; world.build_area.size.z as usize]; world.build_area.size.x as usize];
         
     for parcel in parcels.values_mut() {
-        parcel.data.origin = world.add_non_tree_height(parcel.average().drop_y());
+        let Some(origin) = world.add_non_tree_height(parcel.average().drop_y()) else { continue; };
+        parcel.data.origin = origin;
         parcel.data.points.clear();
         parcel.data.points_2d.clear();
         parcel.data.sum = Point3D::default();
@@ -234,7 +236,7 @@ fn spawn_parcels(seed : Seed, world : &mut World) -> Vec<Parcel> {
         while trials < SPAWN_PARCELS_RETRIES {
             trials += 1;
 
-            let trial_point = world.add_non_tree_height(rng.rand_point2d(rect.size) + rect.origin);//fix to use non tree height
+            let Some(trial_point) = world.add_non_tree_height(rng.rand_point2d(rect.size) + rect.origin) else { continue; };//fix to use non tree height
 
             if points.iter().all(|p| p.distance_squared(trial_point) > SPAWN_PARCELS_MIN_DISTANCE * SPAWN_PARCELS_MIN_DISTANCE) {
                 points.push(trial_point);

--- a/src/generator/districts/parcel_painter.rs
+++ b/src/generator/districts/parcel_painter.rs
@@ -28,7 +28,8 @@ pub async fn replace_ground(
                 }
             }
 
-            let mut height = editor.world_mut().get_non_tree_height(*point) - 1; // -1 to ensure we are placing on the ground
+            let Some(ground_height) = editor.world_mut().get_non_tree_height(*point) else { continue; };
+            let mut height = ground_height - 1; // -1 to ensure we are placing on the ground
             let block = editor.get_block(Point3D::new(point.x, height, point.y));
 
             if let Some(permit_blocks) = permit_blocks {
@@ -69,7 +70,7 @@ pub async fn replace_ground_smooth(
                 }
             }
 
-            let mut height = editor.world_mut().get_non_tree_height(*point); 
+            let Some(mut height) = editor.world_mut().get_non_tree_height(*point) else { continue; };
             let block = editor.get_block(Point3D::new(point.x, height, point.y));
             
             if let Some(permit_blocks) = permit_blocks {
@@ -90,13 +91,15 @@ pub async fn replace_ground_smooth(
                 if !points.contains(&neighbor) {
                     continue; // skip if neighbor is not in points
                 }
+                let Some(neighbor_height) = editor.world_mut().get_non_tree_height(neighbor) else { continue; };
                 if points.contains(&neighbor) {
-                    y_in_dir.insert(direction, editor.world_mut().get_non_tree_height(neighbor));
+                    y_in_dir.insert(direction, neighbor_height);
                 }
                 if !points.contains(&opposite_neighbour) {
                     continue; // skip if opposite neighbor is not in points
                 }
-                if editor.world_mut().get_non_tree_height(neighbor) == height + 1 && editor.world_mut().get_non_tree_height(opposite_neighbour) == height - 1 {
+                let Some(opposite_height) = editor.world_mut().get_non_tree_height(opposite_neighbour) else { continue; };
+                if neighbor_height == height + 1 && opposite_height == height - 1 {
                     //place stair
                     block = block_list[*rng.choose_weighted(block_dict.get(&1).unwrap()) as usize].clone();
                     block.state = Some(HashMap::from([("facing".to_string(), cardinal_to_str(&direction).unwrap())]));
@@ -137,7 +140,7 @@ pub async fn plant_forest(
             continue; // skip water points if ignore_water is true
         }
 
-        let height = editor.world().get_non_tree_height(point);
+        let Some(height) = editor.world().get_non_tree_height(point) else { continue; };
         let block = editor.get_block(Point3D::new(point.x, height, point.y));
 
         if let Some(permit_blocks) = permit_blocks {

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -702,7 +702,7 @@ mod tests {
             if p.x < 0 || p.y < 0 || p.x >= build_area.size.x || p.y >= build_area.size.z {
                 continue;
             }
-            let h = editor.world().get_ocean_floor_height_at(*p);
+            let Some(h) = editor.world().get_ocean_floor_height_at(*p) else { continue; };
             editor.place_block(&alley_block, Point3D::new(p.x, h - 1, p.y)).await;
             editor.world_mut().claim(*p, BuildClaim::Path(PathType::Pavement));
         }

--- a/src/generator/districts/wall.rs
+++ b/src/generator/districts/wall.rs
@@ -226,17 +226,17 @@ pub async fn build_wall(urban_points: &HashSet<Point2D>, editor: &mut Editor, rn
 
 pub async fn build_wall_palisade(wall_points: &Vec<Point2D>, editor: &mut Editor, rng: &mut RNG, material_placer: &mut Placer<'_>, material_id: &MaterialId, structures: & HashMap<StructureType, Structure>) {
     let wall_points_with_height = wall_points.iter()
-        .map(|&point| {
+        .filter_map(|&point| {
             let height = rng.rand_i32_range(4, 7);
-            let new_point = editor.world().add_height(point);
-            (new_point, height)
+            let new_point = editor.world().add_height(point)?;
+            Some((new_point, height))
         })
         .collect::<HashMap<_, _>>();
 
     let mut main_points = Vec::new();
     let mut top_points = Vec::new();
     let wall_points_with_world_height = wall_points.iter()
-        .map(|&point| editor.world().add_height(point))
+        .filter_map(|&point| editor.world().add_height(point))
         .collect::<Vec<_>>();
 
     for (point, height) in wall_points_with_height {
@@ -292,7 +292,8 @@ pub async fn build_wall_standard(wall_points: &Vec<Point2D>, editor: &mut Editor
             // sit flush with the walkway behind them instead of jutting up as a block.
             let is_outer = parapet_is_outer(point.drop_y(), urban_points, &wall_set);
             let column_top = if is_outer { point.y } else { point.y - 1 };
-            for y in editor.world().get_height_at(point.drop_y())..=column_top {
+            let Some(column_base) = editor.world().get_height_at(point.drop_y()) else { continue; };
+            for y in column_base..=column_top {
                 let new_point = Point3D { x: point.x, y, z: point.z };
                 material_placer.place_block(editor, new_point, material_id, BlockForm::Block, None, None).await;
             }
@@ -397,7 +398,8 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
             // sit flush with the walkway behind them instead of jutting up as a block.
             let is_outer = parapet_is_outer(point.drop_y(), urban_points, &wall_set);
             let column_top = if is_outer { point.y } else { point.y - 1 };
-            for y in editor.world().get_height_at(point.drop_y())..=column_top {
+            let Some(column_base) = editor.world().get_height_at(point.drop_y()) else { continue; };
+            for y in column_base..=column_top {
                 let new_point = Point3D { x: point.x, y, z: point.z };
                 material_placer.place_block(editor, new_point, material_id, BlockForm::Block, None, None).await;
             }
@@ -440,8 +442,10 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
                             
                         }
                         if fill_in {
-                            for y in editor.world().get_height_at(new_pt)..point.y {
-                                material_placer.place_block(editor, new_pt.add_y(y), material_id, BlockForm::Block, None, None).await;
+                            if let Some(base_y) = editor.world().get_height_at(new_pt) {
+                                for y in base_y..point.y {
+                                    material_placer.place_block(editor, new_pt.add_y(y), material_id, BlockForm::Block, None, None).await;
+                                }
                             }
                             if editor.world().is_water(new_pt) {
                                 fill_water(new_pt, editor, material_placer, material_id).await;
@@ -475,8 +479,10 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
                         }
                     }
                     if fill_in {
-                        for y in editor.world().get_height_at(new_pt)..point.y {
-                            material_placer.place_block(editor, new_pt.add_y(y), material_id, BlockForm::Block, None, None).await;
+                        if let Some(base_y) = editor.world().get_height_at(new_pt) {
+                            for y in base_y..point.y {
+                                material_placer.place_block(editor, new_pt.add_y(y), material_id, BlockForm::Block, None, None).await;
+                            }
                         }
                         if editor.world().is_water(new_pt) {
                             fill_water(new_pt, editor, material_placer, material_id).await;
@@ -489,7 +495,8 @@ pub async fn build_wall_standard_with_inner(wall_points: &Vec<Point2D>, editor: 
 
     for (_i, point) in inner_wall_points.clone().iter().enumerate() {
         if !walkway_points.contains(&point.drop_y()) {
-            for y in editor.world().get_height_at(point.drop_y())..=point.y {
+            let Some(base_y) = editor.world().get_height_at(point.drop_y()) else { continue; };
+            for y in base_y..=point.y {
                 material_placer.place_block(editor, point.drop_y().add_y(y), material_id, BlockForm::Block, None, None).await;
             }
             if editor.world().is_water(point.drop_y()) {
@@ -599,11 +606,18 @@ pub fn add_wall_points_height(
     wall_points: &[Point2D],
     editor: &mut Editor,
 ) -> Vec<Point3D> {
-    let n = wall_points.len();
-
-    let desired: Vec<i32> = wall_points
+    // Drop any out-of-bounds ring points up front so the per-index vectors below
+    // (`desired`, `above`, `below`, `tops`) stay aligned with `in_bounds_points`.
+    let in_bounds_points: Vec<Point2D> = wall_points
         .iter()
-        .map(|p| editor.world().get_height_at(*p) + WALL_HEIGHT)
+        .filter(|p| editor.world().get_height_at(**p).is_some())
+        .cloned()
+        .collect();
+    let n = in_bounds_points.len();
+
+    let desired: Vec<i32> = in_bounds_points
+        .iter()
+        .filter_map(|p| editor.world().get_height_at(*p).map(|h| h + WALL_HEIGHT))
         .collect();
 
     let mut above = desired.clone();
@@ -621,7 +635,7 @@ pub fn add_wall_points_height(
         })
         .collect();
 
-    wall_points
+    in_bounds_points
         .iter()
         .zip(tops)
         .map(|(point, y)| Point3D { x: point.x, y, z: point.y })
@@ -678,7 +692,8 @@ pub async fn fill_water(
     material_id: &MaterialId,
 ) {
     let mut water_points = Vec::new();
-    let mut height = editor.world().get_height_at(point) - 1;
+    let Some(surface_height) = editor.world().get_height_at(point) else { return; };
+    let mut height = surface_height - 1;
     while editor.world().is_water_3d(point.add_y(height)) && height > 0 {
         water_points.push(Point3D { x: point.x, y: height, z: point.y });
         height -= 1;

--- a/src/generator/heraldry.rs
+++ b/src/generator/heraldry.rs
@@ -1,0 +1,114 @@
+//! Heraldic banner designs for manor families. Every banner a manor owns — the
+//! pair flanking its front door and every banner inside — flies one shared
+//! design: the banner block's own colour is the family's primary colour (the
+//! heraldic "field"), and each pattern layer is stamped in a distinct secondary
+//! colour (the "charge"). The design is rendered both as block-entity pattern
+//! SNBT (stamped on every one of the family's banners) and as an English blazon
+//! for the chronicle, e.g. "a red cross on a black background". Designs live in
+//! `data/banners.yaml`.
+
+use serde_derive::Deserialize;
+
+use crate::data::load_yaml;
+use crate::minecraft::Color;
+use crate::noise::RNG;
+
+#[derive(Debug, Clone, Deserialize)]
+struct BannerDesign {
+    /// Identifier — documents the entry; unused at runtime.
+    #[allow(dead_code)]
+    name: String,
+    /// Pattern ids (minecraft `banner_pattern` registry names), stacked
+    /// bottom-to-top, each stamped in the secondary colour over the base.
+    layers: Vec<String>,
+    /// The charge as an English noun phrase, slotted into
+    /// "a {secondary} {blazon} on a {primary} background".
+    blazon: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BannerCfg {
+    designs: Vec<BannerDesign>,
+}
+
+/// A family's chosen banner: the block-entity pattern SNBT to stamp on every one
+/// of its banners, plus the English blazon describing it.
+pub struct FamilyBanner {
+    /// `{patterns:[...]}` block-entity data; pair with a `<primary>_*banner`
+    /// block so the field reads as the primary colour.
+    pub data: String,
+    /// e.g. "a red cross on a black background".
+    pub blazon: String,
+}
+
+/// Pick a heraldic design for one family and render it for a banner whose base
+/// (field) colour is `primary`, with the charge in `secondary`. `secondary` must
+/// differ from `primary` for the charge to read against the field. Returns
+/// `None` if the design list is empty or fails to load — the family's banners
+/// then stay solid `primary`.
+pub fn pick_family_banner(primary: Color, secondary: Color, rng: &mut RNG) -> Option<FamilyBanner> {
+    let cfg: BannerCfg = load_yaml("banners.yaml")
+        .map_err(|e| log::warn!("banners.yaml failed to load ({e}); plain manor banners"))
+        .ok()?;
+    if cfg.designs.is_empty() {
+        return None;
+    }
+    let design = rng.choose(&cfg.designs).clone();
+    let sec: String = secondary.into();
+    let patterns: Vec<String> = design
+        .layers
+        .iter()
+        .map(|p| format!("{{pattern:\"minecraft:{p}\",color:\"{sec}\"}}"))
+        .collect();
+    Some(FamilyBanner {
+        data: format!("{{patterns:[{}]}}", patterns.join(",")),
+        blazon: format!(
+            "a {} {} on a {} background",
+            color_word(secondary),
+            design.blazon,
+            color_word(primary),
+        ),
+    })
+}
+
+/// A colour as an English word for prose ("light_blue" -> "light blue").
+fn color_word(c: Color) -> String {
+    let s: String = c.into();
+    s.replace('_', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::noise::{Seed, RNG};
+
+    #[test]
+    fn banners_yaml_loads_and_is_nonempty() {
+        let cfg: BannerCfg = load_yaml("banners.yaml").expect("banners.yaml parses");
+        assert!(!cfg.designs.is_empty(), "no banner designs defined");
+        for d in &cfg.designs {
+            assert!(!d.layers.is_empty(), "design {} has no layers", d.name);
+            assert!(!d.blazon.is_empty(), "design {} has no blazon", d.name);
+        }
+    }
+
+    #[test]
+    fn pick_renders_pattern_snbt_and_blazon() {
+        let mut rng = RNG::new(Seed(7));
+        let b = pick_family_banner(Color::Black, Color::Red, &mut rng)
+            .expect("a design is picked");
+        // SNBT carries the charge colour and is a patterns list.
+        assert!(b.data.starts_with("{patterns:["), "data: {}", b.data);
+        assert!(b.data.contains("color:\"red\""), "data: {}", b.data);
+        // Blazon names both colours as the field/charge of the sentence.
+        assert!(b.blazon.starts_with("a red "), "blazon: {}", b.blazon);
+        assert!(b.blazon.ends_with("on a black background"), "blazon: {}", b.blazon);
+    }
+
+    #[test]
+    fn multiword_colour_reads_with_a_space() {
+        let mut rng = RNG::new(Seed(1));
+        let b = pick_family_banner(Color::LightBlue, Color::White, &mut rng).unwrap();
+        assert!(b.blazon.ends_with("on a light blue background"), "blazon: {}", b.blazon);
+    }
+}

--- a/src/generator/materials/palette.rs
+++ b/src/generator/materials/palette.rs
@@ -37,6 +37,14 @@ pub struct Palette {
     pub primary_color : Option<Color>,
     pub secondary_color : Option<Color>,
 
+    /// Block-entity pattern SNBT (`{patterns:[...]}`) stamped on every banner
+    /// this palette recolours, giving a manor family one heraldic design across
+    /// all its banners. Set per-building at placement time (see `settlement.rs`
+    /// / `generator::heraldry`); `None` for ordinary buildings, whose banners
+    /// stay solid-colour. Not loaded from data files.
+    #[serde(default)]
+    pub banner_data : Option<String>,
+
     pub tags : Option<Vec<String>>,
 }
 

--- a/src/generator/materials/test.rs
+++ b/src/generator/materials/test.rs
@@ -60,7 +60,7 @@ mod tests {
         });
 
         for point in editor.world_mut().world_rect_2d().clone().iter() {
-            let point = editor.world_mut().add_height(point);
+            let point = editor.world_mut().add_height(point).expect("test cell in bounds");
             placer.place_block(&mut editor, point, &material, BlockForm::Block, None, None).await;
         }
     }
@@ -89,10 +89,10 @@ mod tests {
             .world_rect_2d()
             .clone()
             .iter()
-            .map(|point| editor.world_mut().add_height(point))
+            .map(|point| editor.world_mut().add_height(point).expect("test cell in bounds"))
             .collect();
         placer.place_blocks(
-            &mut editor, 
+            &mut editor,
             points.into_iter(),
             &material,
             BlockForm::Block, 
@@ -126,10 +126,10 @@ mod tests {
             .world_rect_2d()
             .clone()
             .iter()
-            .map(|point| editor.world_mut().add_height(point))
+            .map(|point| editor.world_mut().add_height(point).expect("test cell in bounds"))
             .collect();
         placer.place_blocks(
-            &mut editor, 
+            &mut editor,
             points.into_iter(),
             &material,
             BlockForm::Block,

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -15,6 +15,7 @@ pub mod chronicle;
 pub mod settlement;
 pub mod open_space;
 pub mod naming;
+pub mod heraldry;
 pub mod npc;
 pub mod population;
 pub mod welcome;

--- a/src/generator/naming.rs
+++ b/src/generator/naming.rs
@@ -5,14 +5,19 @@
 //!
 //! Detection is **culture-neutral** — each feature maps to an abstract *concept*
 //! (`water`, `hill`, `market`, `wood`, …). Each culture then translates the
-//! concept into its OWN words and morphology, so a river town is `Brookford`
-//! (medieval), `Kawamura` (japanese), or `Bir Wadi` (desert) — never an English
-//! stem glued onto a foreign suffix (the "Gardenyama" problem).
+//! concept into its OWN words and morphology, so a river town is `Brocford`
+//! (medieval, Old English), `Kawamura` (japanese), or `Bir Wadi` (desert) —
+//! never an English stem glued onto a foreign suffix (the "Gardenyama" problem).
 //!
 //! Each detected concept becomes a weighted theme. A lead word is drawn from a
 //! weighted theme, then the name is composed as either:
-//!   - **stem + suffix** — `Mill` + `ford` → `Millford`, `Yama` + `mura` → `Yamamura`
+//!   - **stem + suffix** — `Myln` + `ham` → `Mylnham`, `Yama` + `mura` → `Yamamura`
 //!   - **two words** — pairing two themes, `Bir` + `Wadi` → `Bir Wadi`
+//!
+//! Alongside the name we build an **English subtitle** from the same words via
+//! each culture's `glosses` map — `Mylnham` → "Mill Homestead", `Bir al-Raml` →
+//! "Well of the Sand". Medieval names use readable Old-English (Anglo-Saxon)
+//! forms, so their subtitle is the modern-English reading.
 //!
 //! Everything is drawn from the town's seeded RNG, so a given seed always yields
 //! the same name. Vocabulary + tuning live in `data/settlement_names.yaml`.
@@ -26,6 +31,7 @@ use crate::editor::World;
 use crate::generator::buildings_v2::Culture;
 use crate::generator::BuildClaim;
 use crate::geometry::{Point2D, CARDINALS_2D};
+use crate::minecraft::Color;
 use crate::noise::RNG;
 
 /// Vocabulary + tuning, loaded from `data/settlement_names.yaml`.
@@ -83,11 +89,19 @@ struct CultureWords {
     article: Option<ArticleCfg>,
     /// capitalised second words for the two-word form.
     fillers: Vec<String>,
-    /// colour modifiers — always lead the name (never a trailing word).
+    /// colour-name words, keyed by the dye colour's id (`red`, `light_blue`, …)
+    /// → this culture's word for it (`Aka`, `Zarqa`, …). The namer renders the
+    /// town's actual scheme colours, so this bridges the `Color` enum to
+    /// vocabulary. Colour words always LEAD the name, never trail.
     #[serde(default)]
-    colors: Vec<String>,
+    colors: HashMap<String, String>,
     /// concept -> this culture's words for it.
     concepts: HashMap<String, Vec<String>>,
+    /// every name word (and suffix) -> its plain-English meaning. Used to render
+    /// the English-translation subtitle. Every word the namer can emit must have
+    /// an entry (guarded by `every_name_word_has_a_gloss`).
+    #[serde(default)]
+    glosses: HashMap<String, String>,
 }
 
 /// Tuning for definite-article naming. The remainder after `prefix_pct +
@@ -108,6 +122,26 @@ impl CultureWords {
             .map(|v| v.iter().map(String::as_str).collect())
             .unwrap_or_default()
     }
+
+    /// The plain-English meaning of a name token (concept word or suffix). Tries
+    /// the token verbatim, then lower-cased (suffixes are stored lower-case),
+    /// falling back to the token itself so a missing gloss degrades gracefully.
+    fn gloss(&self, token: &str) -> String {
+        self.glosses
+            .get(token)
+            .or_else(|| self.glosses.get(&token.to_ascii_lowercase()))
+            .cloned()
+            .unwrap_or_else(|| token.to_string())
+    }
+}
+
+/// A composed settlement name plus its English-translation subtitle.
+/// For medieval (Old-English) names the subtitle is the modern-English reading
+/// ("Mylnham" → "Mill Homestead"); for japanese/desert it is the translation
+/// ("Bir al-Raml" → "Well of the Sand").
+pub struct SettlementName {
+    pub name: String,
+    pub subtitle: String,
 }
 
 /// A name source: a word pool plus the weight it carries when picking the lead.
@@ -132,15 +166,17 @@ fn culture_key(culture: Culture) -> &'static str {
 /// coords). Reads the dominant building, civic landmarks (the open-space feature
 /// keys in `civic_features` — plaza/park `.key()` strings), land shape, and
 /// biome as concepts, renders them in the culture's vocabulary, and composes a
-/// name with `rng`. Falls back to a culture-appropriate default if the
+/// name with `rng`. Returns the name plus an English-translation subtitle built
+/// from the same words. Falls back to a culture-appropriate default if the
 /// vocabulary file can't be loaded.
 pub fn generate_settlement_name(
     world: &World,
     urban: &HashSet<Point2D>,
     civic_features: &[String],
     culture: Culture,
+    town_colors: &[Color],
     rng: &mut RNG,
-) -> String {
+) -> SettlementName {
     let cfg: NamesCfg = match load_yaml("settlement_names.yaml") {
         Ok(c) => c,
         Err(e) => {
@@ -212,14 +248,21 @@ pub fn generate_settlement_name(
             themes.push(Theme { words, weight: cfg.weights.landform, modifier: false });
         }
     }
-    // Colour: a modifier theme — always available, leads the name only. Future:
-    // bias this pool toward the build palette's dominant material colour.
-    if !cul.colors.is_empty() {
-        themes.push(Theme {
-            words: cul.colors.iter().map(String::as_str).collect(),
-            weight: cfg.weights.color,
-            modifier: true,
-        });
+    // Colour: a modifier theme — leads the name only. Built from the town's
+    // actual scheme colours so a mostly-red town tends to a red-rooted name. The
+    // dominant colour (index 0) is repeated 2:1 over the second so it wins more
+    // often within the theme.
+    let mut color_words: Vec<&str> = Vec::new();
+    for (i, c) in town_colors.iter().enumerate() {
+        let key: String = (*c).into();
+        if let Some(word) = cul.colors.get(&key) {
+            for _ in 0..if i == 0 { 2 } else { 1 } {
+                color_words.push(word.as_str());
+            }
+        }
+    }
+    if !color_words.is_empty() {
+        themes.push(Theme { words: color_words, weight: cfg.weights.color, modifier: true });
     }
     // Biome theme always contributes: fall back to the culture's `green` words
     // when it doesn't translate this specific biome concept.
@@ -243,13 +286,16 @@ pub fn generate_settlement_name(
     let lead_idx = pick_weighted_theme(&themes, rng);
     let lead = (*rng.choose(&themes[lead_idx].words)).to_string();
 
-    let name = if let Some(article) = &cul.article {
+    let (name, subtitle) = if let Some(article) = &cul.article {
         compose_article(article, &themes, lead_idx, &lead, cul, rng)
     } else {
         let two_word_pct = cul.two_word_pct.unwrap_or(cfg.two_word_pct);
         if themes.len() > 1 && rng.percent(two_word_pct) {
             match second_word(&themes, lead_idx, &lead, cul, rng) {
-                Some(w) => format!("{lead} {w}"),
+                Some(w) => (
+                    format!("{lead} {w}"),
+                    format!("{} {}", cul.gloss(&lead), cul.gloss(&w)),
+                ),
                 None => attach_suffix(&lead, cul, rng),
             }
         } else {
@@ -258,8 +304,9 @@ pub fn generate_settlement_name(
     };
 
     log::info!(
-        "settlement name '{}' (building={:?}, civic={:?}, landform={:?}, relief={}, biome='{}'->{})",
+        "settlement name '{}' / '{}' (building={:?}, civic={:?}, landform={:?}, relief={}, biome='{}'->{})",
         name,
+        subtitle,
         building_concept,
         civic_concepts,
         landform_concept,
@@ -267,21 +314,27 @@ pub fn generate_settlement_name(
         biome.name(),
         biome_concept,
     );
-    name
+    SettlementName { name, subtitle }
 }
 
-/// Append a culture suffix to the lead word (`Mill` + `ford` → `Millford`).
-fn attach_suffix(lead: &str, cul: &CultureWords, rng: &mut RNG) -> String {
+/// Append a culture suffix to the lead word (`Myln` + `ham` → `Mylnham`),
+/// returning the name and its English gloss (`Mill Homestead`).
+fn attach_suffix(lead: &str, cul: &CultureWords, rng: &mut RNG) -> (String, String) {
     if cul.suffixes.is_empty() {
-        return lead.to_string();
+        return (lead.to_string(), cul.gloss(lead));
     }
     let suffix = rng.choose(&cul.suffixes);
-    format!("{lead}{suffix}")
+    (
+        format!("{lead}{suffix}"),
+        format!("{} {}", cul.gloss(lead), cul.gloss(suffix)),
+    )
 }
 
 /// Arabic-style composition: `Al-{lead}` (article prefix), `{lead} al-{second}`
 /// (construct/iḍāfa), or a bare `{lead} {second}` compound. The article
-/// assimilates to sun letters (`al-Raml` → `ar-Raml`).
+/// assimilates to sun letters (`al-Raml` → `ar-Raml`). Returns the name and its
+/// English gloss: prefix → "The {lead}", construct → "{lead} of the {second}",
+/// bare → "{lead} {second}".
 fn compose_article(
     article: &ArticleCfg,
     themes: &[Theme],
@@ -289,24 +342,33 @@ fn compose_article(
     lead: &str,
     cul: &CultureWords,
     rng: &mut RNG,
-) -> String {
+) -> (String, String) {
     let roll = rng.rand_i32_range(0, 100);
     let prefixed = |word: &str| {
         let art = assimilated_article(word);
-        format!("{}-{}", capitalize(&art), word)
+        (
+            format!("{}-{}", capitalize(&art), word),
+            format!("The {}", cul.gloss(word)),
+        )
     };
     if roll < article.prefix_pct {
         prefixed(lead)
     } else if roll < article.prefix_pct + article.construct_pct {
         // {lead} al-{second}, with the article lower-case in mid-name.
         match second_word(themes, lead_idx, lead, cul, rng) {
-            Some(second) => format!("{lead} {}-{second}", assimilated_article(&second)),
+            Some(second) => (
+                format!("{lead} {}-{second}", assimilated_article(&second)),
+                format!("{} of the {}", cul.gloss(lead), cul.gloss(&second)),
+            ),
             None => prefixed(lead),
         }
     } else {
         // Bare compound: Bir Zeit, Wadi Rum.
         match second_word(themes, lead_idx, lead, cul, rng) {
-            Some(second) => format!("{lead} {second}"),
+            Some(second) => (
+                format!("{lead} {second}"),
+                format!("{} {}", cul.gloss(lead), cul.gloss(&second)),
+            ),
             None => prefixed(lead),
         }
     }
@@ -440,18 +502,59 @@ fn centroid(urban: &HashSet<Point2D>) -> Point2D {
 }
 
 /// Culture-appropriate fallback when the vocabulary file is missing.
-fn default_name(culture: Culture) -> String {
-    match culture {
-        Culture::Desert => "Sandhaven",
-        Culture::Japanese => "Yamamura",
-        Culture::Medieval => "Blackbarrow",
-    }
-    .to_string()
+fn default_name(culture: Culture) -> SettlementName {
+    let (name, subtitle) = match culture {
+        Culture::Desert => ("Ar-Raml", "The Sand"),
+        Culture::Japanese => ("Yamamura", "Mountain Village"),
+        Culture::Medieval => ("Blacbarrow", "Black Barrow"),
+    };
+    SettlementName { name: name.to_string(), subtitle: subtitle.to_string() }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The vocabulary file parses, and every dye colour a culture can actually
+    /// build with (`Culture::color_pool`) has a name word — so a town named
+    /// after its dominant colour can always render it. Guards the two from
+    /// drifting apart.
+    #[test]
+    fn every_pool_colour_has_a_name_word() {
+        let cfg: NamesCfg = load_yaml("settlement_names.yaml").expect("settlement_names.yaml parses");
+        for culture in [Culture::Medieval, Culture::Japanese, Culture::Desert] {
+            let cul = cfg.cultures.get(culture_key(culture)).expect("culture vocab present");
+            for color in culture.color_pool() {
+                let key: String = color.into();
+                assert!(
+                    cul.colors.contains_key(&key),
+                    "{} pool colour '{key}' has no name word in settlement_names.yaml",
+                    culture_key(culture),
+                );
+            }
+        }
+    }
+
+    /// Every word the namer can emit — concept words, fillers, colour words, and
+    /// suffixes — has a gloss, so the English-translation subtitle never falls
+    /// back to the raw foreign token. Guards the vocabulary and glosses from
+    /// drifting apart.
+    #[test]
+    fn every_name_word_has_a_gloss() {
+        let cfg: NamesCfg = load_yaml("settlement_names.yaml").expect("settlement_names.yaml parses");
+        for (key, cul) in &cfg.cultures {
+            let mut tokens: Vec<String> = Vec::new();
+            tokens.extend(cul.concepts.values().flatten().cloned());
+            tokens.extend(cul.fillers.iter().cloned());
+            tokens.extend(cul.colors.values().cloned());
+            tokens.extend(cul.suffixes.iter().cloned());
+            for t in tokens {
+                let has = cul.glosses.contains_key(&t)
+                    || cul.glosses.contains_key(&t.to_ascii_lowercase());
+                assert!(has, "culture '{key}': name word '{t}' has no gloss in settlement_names.yaml");
+            }
+        }
+    }
 
     #[test]
     fn article_assimilates_sun_letters() {

--- a/src/generator/naming.rs
+++ b/src/generator/naming.rs
@@ -213,7 +213,7 @@ pub fn generate_settlement_name(
     // Land shape: relief across the footprint + whether the edge touches water.
     let (lo, hi) = urban
         .iter()
-        .map(|&c| world.get_height_at(c))
+        .filter_map(|&c| world.get_height_at(c))
         .fold((i32::MAX, i32::MIN), |(lo, hi), h| (lo.min(h), hi.max(h)));
     let relief = (hi - lo).max(0);
     let landform_concept: Option<&str> = if touches_water(world, urban, cfg.water_share) {
@@ -226,8 +226,11 @@ pub fn generate_settlement_name(
         None
     };
 
-    // Biome: always available.
-    let biome = world.get_surface_biome_at(centre);
+    // Biome: always available for in-bounds centres; fall back to the default
+    // name if the centre is somehow off the map.
+    let Some(biome) = world.get_surface_biome_at(centre) else {
+        return default_name(culture);
+    };
     let biome_concept = biome_concept(&cfg, biome.name());
 
     // ── Render concepts in the culture's vocabulary into weighted themes ──

--- a/src/generator/nbts/test.rs
+++ b/src/generator/nbts/test.rs
@@ -104,7 +104,7 @@ mod tests {
             .join("data").join("structures").join("test_save.nbt");
         
         let midpoint = editor.world_mut().world_rect_2d().size / 2;
-        let point = editor.world_mut().add_height(midpoint);
+        let point = editor.world_mut().add_height(midpoint).expect("test cell in bounds");
 
         let data = RefCell::new(data);
         let materials = &data.borrow().materials;
@@ -140,7 +140,7 @@ mod tests {
         let mut editor = world.get_editor();
 
         let midpoint = editor.world().world_rect_2d().size / 2;
-        let point = editor.world().add_height(midpoint);
+        let point = editor.world().add_height(midpoint).expect("test cell in bounds");
         //point.y = point.y - 1; // Adjust height if necessary
 
         let structures = Structure::load().expect("Failed to load structures");

--- a/src/generator/npc.rs
+++ b/src/generator/npc.rs
@@ -434,7 +434,7 @@ mod tests {
         // Build-area-local coordinates: the editor adds the origin back on spawn.
         let size = editor.world().world_rect_2d().size;
         let centre = Point2D::new(size.x / 2, size.y / 2);
-        let ground = editor.world().get_ocean_floor_height_at(centre);
+        let ground = editor.world().get_ocean_floor_height_at(centre).expect("centre in bounds");
         let feet = Point3D::new(centre.x, ground, centre.y);
 
         spawn_villager_npc(

--- a/src/generator/open_space/nook.rs
+++ b/src/generator/open_space/nook.rs
@@ -77,12 +77,15 @@ pub async fn furnish_nook(editor: &Editor, region: &Region, rng: &mut RNG, theme
             .iter()
             .min_by_key(|c| c.distance_squared(&centroid))
         {
-            let biome = world.get_surface_biome_at(center);
-            place_tree(editor, theme, &biome, center, height_at(center), rng).await;
-            // Keep the centrepiece cell and its neighbours clear of furniture.
-            used.insert(center);
-            for d in CARDINALS_2D {
-                used.insert(center + d);
+            if let (Some(biome), Some(h)) =
+                (world.get_surface_biome_at(center), height_at(center))
+            {
+                place_tree(editor, theme, &biome, center, h, rng).await;
+                // Keep the centrepiece cell and its neighbours clear of furniture.
+                used.insert(center);
+                for d in CARDINALS_2D {
+                    used.insert(center + d);
+                }
             }
         }
     }
@@ -96,8 +99,9 @@ pub async fn furnish_nook(editor: &Editor, region: &Region, rng: &mut RNG, theme
         if used.contains(&c) {
             continue;
         }
+        let Some(h) = height_at(c) else { continue; };
         if let Some(inward) = inward_dir(world, c, &cells) {
-            place_bench(editor, c, height_at(c), inward, theme.wood).await;
+            place_bench(editor, c, h, inward, theme.wood).await;
             used.insert(c);
             placed += 1;
         }
@@ -112,7 +116,8 @@ pub async fn furnish_nook(editor: &Editor, region: &Region, rng: &mut RNG, theme
         if used.contains(&c) {
             continue;
         }
-        place_planter(editor, c, height_at(c), theme.wood).await;
+        let Some(h) = height_at(c) else { continue; };
+        place_planter(editor, c, h, theme.wood).await;
         used.insert(c);
         placed += 1;
     }
@@ -122,7 +127,8 @@ pub async fn furnish_nook(editor: &Editor, region: &Region, rng: &mut RNG, theme
         if used.contains(&c) {
             continue;
         }
-        place_lantern_post(editor, c, height_at(c), theme.wood).await;
+        let Some(h) = height_at(c) else { continue; };
+        place_lantern_post(editor, c, h, theme.wood).await;
         break;
     }
 }

--- a/src/generator/open_space/park.rs
+++ b/src/generator/open_space/park.rs
@@ -204,7 +204,7 @@ async fn flatten_region(editor: &mut Editor, region: &Region, theme: &Theme) {
         region
             .cells
             .iter()
-            .map(|&c| (c, world.get_ocean_floor_height_at(c)))
+            .filter_map(|&c| world.get_ocean_floor_height_at(c).map(|h| (c, h)))
             .collect()
     };
     let mut sorted: Vec<i32> = nat.values().copied().collect();
@@ -221,7 +221,7 @@ async fn flatten_region(editor: &mut Editor, region: &Region, theme: &Theme) {
         if is_building(editor.world().get_claim(c).as_ref()) {
             continue;
         }
-        let nat_h = nat[&c];
+        let Some(&nat_h) = nat.get(&c) else { continue; };
         let t = flatten_blend(depth.get(&c).copied().unwrap_or(2));
         let tgt = (nat_h as f32 * (1.0 - t) + target_h as f32 * t).round() as i32;
         let surface = tgt - 1; // the grass surface y
@@ -305,7 +305,15 @@ pub async fn furnish_park(
     // One type per region, chosen from the centroid biome.
     let sum = region.cells.iter().fold(Point2D::ZERO, |a, p| a + *p);
     let centroid = sum / region.cells.len().max(1) as i32;
-    let biome = world.get_surface_biome_at(centroid);
+    // Sample the centroid's biome; if that cell is out of bounds, fall back to the
+    // first region cell that has one. A region with no in-bounds cell at all can't
+    // be furnished, so bail with no scenes.
+    let Some(biome) = world
+        .get_surface_biome_at(centroid)
+        .or_else(|| region.cells.iter().find_map(|&c| world.get_surface_biome_at(c)))
+    else {
+        return (ParkType::Wooded, Vec::new());
+    };
     let park_type = choose_park_type(&biome, theme.arid, rng);
 
     // In a sand-floored (desert) biome, green the whole park so flowers, trees,
@@ -317,7 +325,7 @@ pub async fn furnish_park(
         && !matches!(park_type, ParkType::Cemetery | ParkType::Cactus);
     if green_floor {
         for &c in &region.cells {
-            let h = world.get_ocean_floor_height_at(c);
+            let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
             lay_soil(editor, c, h).await;
         }
     }
@@ -404,7 +412,8 @@ fn scatter_park_visitors(
         if !CARDINALS_2D.iter().all(|d| region_cells.contains(&(c + *d))) {
             continue;
         }
-        let feet = Point3D::new(c.x, world.get_ocean_floor_height_at(c), c.y);
+        let Some(feet_y) = world.get_ocean_floor_height_at(c) else { continue; };
+        let feet = Point3D::new(c.x, feet_y, c.y);
         let facing = yaw_toward(feet, Point3D::new(centroid.x, feet.y, centroid.y));
         let mut scene = AnchorScene::solo_with(
             feet,
@@ -444,14 +453,14 @@ async fn furnish_cemetery(
         if used.contains(&c) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         put(editor, c.x, h, c.y, theme.wall).await;
         used.insert(c);
     }
     // A lantern on every eighth wall post so the plot reads at night.
     for (i, &c) in perimeter.iter().enumerate() {
         if i % 8 == 0 {
-            let h = world.get_ocean_floor_height_at(c);
+            let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
             put(editor, c.x, h + 1, c.y, "minecraft:lantern").await;
         }
     }
@@ -467,8 +476,9 @@ async fn furnish_cemetery(
         while gz <= max_z {
             let c = Point2D::new(gx, gz);
             if cells.contains(&c) && !used.contains(&c) {
-                let h = world.get_ocean_floor_height_at(c);
-                place_grave(editor, c, h, used, rng, theme).await;
+                if let Some(h) = world.get_ocean_floor_height_at(c) {
+                    place_grave(editor, c, h, used, rng, theme).await;
+                }
             }
             gz += 3;
         }
@@ -516,21 +526,25 @@ async fn furnish_lawn(
     let centroid = sum / region.cells.len().max(1) as i32;
 
     if let Some(centre) = interior.iter().copied().min_by_key(|c| c.distance_squared(&centroid)) {
-        let h = world.get_ocean_floor_height_at(centre);
-        let grand_tree = rng.percent(50);
-        if grand_tree {
-            if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
+        if let Some(h) = world.get_ocean_floor_height_at(centre) {
+            let grand_tree = rng.percent(50);
+            let tree = if grand_tree {
+                world
+                    .get_surface_biome_at(centre)
+                    .and_then(|b| park_tree(theme, &b, rng))
+            } else {
+                None
+            };
+            if let Some(tree) = tree {
                 lay_soil_patch(editor, centre, h).await;
                 let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
             } else {
                 place_monument(editor, centre, h, theme).await;
             }
-        } else {
-            place_monument(editor, centre, h, theme).await;
-        }
-        used.insert(centre);
-        for d in CARDINALS_2D {
-            used.insert(centre + d);
+            used.insert(centre);
+            for d in CARDINALS_2D {
+                used.insert(centre + d);
+            }
         }
     }
 
@@ -555,7 +569,7 @@ async fn furnish_zen(
         if used.contains(&c) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         put_forced(editor, c.x, h - 1, c.y, theme.rake).await;
     }
 
@@ -569,7 +583,7 @@ async fn furnish_zen(
         if used.contains(&c) || rocks.iter().any(|r| chebyshev(*r, c) < 3) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         place_rock(editor, c, h, cells, used, rng, theme).await;
         rocks.push(c);
     }
@@ -584,7 +598,7 @@ async fn furnish_zen(
         if used.contains(&c) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         put(editor, c.x, h, c.y, theme.stone).await;
         put(editor, c.x, h + 1, c.y, "minecraft:lantern").await;
         used.insert(c);
@@ -600,13 +614,17 @@ async fn furnish_zen(
         .filter(|c| !used.contains(c))
         .min_by_key(|c| c.distance_squared(&centroid))
     {
-        if let Some(tree) = park_tree(theme, &world.get_surface_biome_at(centre), rng) {
-            let h = world.get_ocean_floor_height_at(centre);
-            lay_soil_patch(editor, centre, h).await;
-            let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
-            used.insert(centre);
-            for d in CARDINALS_2D {
-                used.insert(centre + d);
+        if let (Some(biome), Some(h)) = (
+            world.get_surface_biome_at(centre),
+            world.get_ocean_floor_height_at(centre),
+        ) {
+            if let Some(tree) = park_tree(theme, &biome, rng) {
+                lay_soil_patch(editor, centre, h).await;
+                let _ = generate_tree_feature(tree, editor, Point3D::new(centre.x, h, centre.y), rng).await;
+                used.insert(centre);
+                for d in CARDINALS_2D {
+                    used.insert(centre + d);
+                }
             }
         }
     }
@@ -633,7 +651,9 @@ async fn furnish_fountain(
     let Some(centre) = interior.iter().copied().min_by_key(|c| c.distance_squared(&centroid)) else {
         return;
     };
-    let h = world.get_ocean_floor_height_at(centre);
+    let Some(h) = world.get_ocean_floor_height_at(centre) else {
+        return;
+    };
 
     // Build the largest fountain that fits (5×5), else a plain monument.
     if square_fits(cells, used, centre, 2) {
@@ -652,7 +672,7 @@ async fn furnish_fountain(
                 if !cells.contains(&p) || used.contains(&p) {
                     break;
                 }
-                let hp = world.get_ocean_floor_height_at(p);
+                let Some(hp) = world.get_ocean_floor_height_at(p) else { break; };
                 put_forced(editor, p.x, hp - 1, p.y, theme.path).await;
                 used.insert(p);
                 step += 1;
@@ -690,7 +710,7 @@ async fn furnish_hedge(
         if used.contains(&c) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         place_hedge(editor, c, h, theme.hedge).await;
         used.insert(c);
     }
@@ -704,10 +724,11 @@ async fn furnish_hedge(
             continue;
         }
         if rng.percent(40) {
-            let h = world.get_ocean_floor_height_at(c);
-            let flower = *rng.choose(&FORMAL_FLOWERS);
-            lay_soil(editor, c, h).await;
-            put_forced(editor, c.x, h, c.y, flower).await;
+            if let Some(h) = world.get_ocean_floor_height_at(c) {
+                let flower = *rng.choose(&FORMAL_FLOWERS);
+                lay_soil(editor, c, h).await;
+                put_forced(editor, c.x, h, c.y, flower).await;
+            }
         }
         used.insert(c);
     }
@@ -722,8 +743,9 @@ async fn furnish_hedge(
     let passages = carve_maze(&maze_area, rng);
     for &c in &maze_area {
         if !passages.contains(&c) {
-            let h = world.get_ocean_floor_height_at(c);
-            place_hedge(editor, c, h, theme.hedge).await;
+            if let Some(h) = world.get_ocean_floor_height_at(c) {
+                place_hedge(editor, c, h, theme.hedge).await;
+            }
         }
         used.insert(c); // keep passages clear of later props too
     }
@@ -757,7 +779,7 @@ async fn furnish_cactus(
         if used.contains(&c) || placed.iter().any(|t| chebyshev(*t, c) < 2) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         // Grow the cactus through the Tree system; it lays its own sand footing.
         let _ = generate_tree_feature(Tree::Cactus, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
@@ -778,7 +800,7 @@ async fn furnish_cactus(
         if used.contains(&c) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         place_rock(editor, c, h, cells, used, rng, theme).await;
         rocks += 1;
     }
@@ -788,7 +810,7 @@ async fn furnish_cactus(
         if used.contains(&c) || !rng.percent(15) {
             continue;
         }
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         put_forced(editor, c.x, h - 1, c.y, pad).await;
         put_forced(editor, c.x, h, c.y, "minecraft:dead_bush").await;
         used.insert(c);
@@ -872,7 +894,7 @@ async fn place_rock(
     for d in CARDINALS_2D {
         let n = c + d;
         if rng.percent(35) && cells.contains(&n) && !used.contains(&n) {
-            let hn = editor.world().get_ocean_floor_height_at(n);
+            let Some(hn) = editor.world().get_ocean_floor_height_at(n) else { continue; };
             put(editor, n.x, hn, n.y, rock).await;
             used.insert(n);
         }
@@ -931,10 +953,15 @@ async fn scatter_trees(
         if used.contains(&c) || placed.iter().any(|t| chebyshev(*t, c) < min_gap) {
             continue;
         }
-        let Some(tree) = park_tree(theme, &world.get_surface_biome_at(c), rng) else {
+        let Some(biome) = world.get_surface_biome_at(c) else {
             continue;
         };
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(tree) = park_tree(theme, &biome, rng) else {
+            continue;
+        };
+        let Some(h) = world.get_ocean_floor_height_at(c) else {
+            continue;
+        };
         lay_soil_patch(editor, c, h).await;
         let _ = generate_tree_feature(tree, editor, Point3D::new(c.x, h, c.y), rng).await;
         used.insert(c);
@@ -960,7 +987,7 @@ async fn dapple_plants(
             continue;
         }
         let plant = *rng.choose(plants);
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         lay_soil(editor, c, h).await;
         put_forced(editor, c.x, h, c.y, plant).await;
         used.insert(c);
@@ -985,7 +1012,7 @@ async fn scatter_tall_flowers(
             continue;
         }
         let kind = *rng.choose(&["rose_bush", "lilac", "peony", "sunflower"]);
-        let h = world.get_ocean_floor_height_at(c);
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         lay_soil(editor, c, h).await;
         put_forced(editor, c.x, h, c.y, &format!("minecraft:{kind}[half=lower]")).await;
         put_forced(editor, c.x, h + 1, c.y, &format!("minecraft:{kind}[half=upper]")).await;
@@ -1006,11 +1033,13 @@ async fn small_pond(
         if used.contains(&c) {
             continue;
         }
-        let h0 = world.get_ocean_floor_height_at(c);
+        let Some(h0) = world.get_ocean_floor_height_at(c) else { continue; };
         let flat = (-1..=1).all(|dx| {
             (-1..=1).all(|dz| {
                 let p = Point2D::new(c.x + dx, c.y + dz);
-                cells.contains(&p) && !used.contains(&p) && world.get_ocean_floor_height_at(p) == h0
+                cells.contains(&p)
+                    && !used.contains(&p)
+                    && world.get_ocean_floor_height_at(p) == Some(h0)
             })
         });
         if !flat {
@@ -1024,7 +1053,7 @@ async fn small_pond(
                 CARDINALS_2D.iter().all(|d| {
                     let n = p + *d;
                     let inside = (n.x - c.x).abs() <= 1 && (n.y - c.y).abs() <= 1;
-                    inside || world.get_ocean_floor_height_at(n) >= h0
+                    inside || world.get_ocean_floor_height_at(n).is_some_and(|hn| hn >= h0)
                 })
             })
         });
@@ -1058,18 +1087,24 @@ async fn carve_pond(
         if used.contains(&c) {
             return false;
         }
-        let h0 = world.get_ocean_floor_height_at(c);
+        let Some(h0) = world.get_ocean_floor_height_at(c) else {
+            return false;
+        };
         (-1..=1).all(|dx| {
             (-1..=1).all(|dz| {
                 let p = Point2D::new(c.x + dx, c.y + dz);
-                cells.contains(&p) && !used.contains(&p) && world.get_ocean_floor_height_at(p) == h0
+                cells.contains(&p)
+                    && !used.contains(&p)
+                    && world.get_ocean_floor_height_at(p) == Some(h0)
             })
         })
     }) else {
         return Vec::new();
     };
 
-    let h0 = world.get_ocean_floor_height_at(seed);
+    let Some(h0) = world.get_ocean_floor_height_at(seed) else {
+        return Vec::new();
+    };
     let mut pond: Vec<(Point2D, i32)> = Vec::new();
     let mut queue: VecDeque<Point2D> = VecDeque::new();
     let mut seen: HashSet<Point2D> = HashSet::new();
@@ -1079,7 +1114,7 @@ async fn carve_pond(
         if pond.len() >= max_cells {
             break;
         }
-        if !cells.contains(&c) || used.contains(&c) || world.get_ocean_floor_height_at(c) != h0 {
+        if !cells.contains(&c) || used.contains(&c) || world.get_ocean_floor_height_at(c) != Some(h0) {
             continue;
         }
         // Only fill where every side is walled by solid terrain (>= h0) or more
@@ -1087,7 +1122,7 @@ async fn carve_pond(
         // fringe cells stay dry and become the shore.
         let contained = CARDINALS_2D
             .iter()
-            .all(|d| world.get_ocean_floor_height_at(c + *d) >= h0);
+            .all(|d| world.get_ocean_floor_height_at(c + *d).is_some_and(|hn| hn >= h0));
         if !contained {
             continue;
         }
@@ -1168,8 +1203,9 @@ async fn place_benches(
         if used.contains(&c) || placed.iter().any(|b| chebyshev(*b, c) < 4) {
             continue;
         }
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
         if let Some(inward) = inward_dir(world, c, cells) {
-            place_bench(editor, c, world.get_ocean_floor_height_at(c), inward, wood).await;
+            place_bench(editor, c, h, inward, wood).await;
             used.insert(c);
             placed.push(c);
         }
@@ -1194,7 +1230,8 @@ async fn place_lamps(
         if used.contains(&c) || placed.iter().any(|l| chebyshev(*l, c) < 6) {
             continue;
         }
-        place_lantern_post(editor, c, world.get_ocean_floor_height_at(c), wood).await;
+        let Some(h) = world.get_ocean_floor_height_at(c) else { continue; };
+        place_lantern_post(editor, c, h, wood).await;
         used.insert(c);
         placed.push(c);
     }

--- a/src/generator/open_space/plaza.rs
+++ b/src/generator/open_space/plaza.rs
@@ -139,7 +139,7 @@ async fn furnish_plaza_inner(
     // level square. The flatten *eases out* at the border: the two outermost
     // rings only partly level, lerping from natural ground toward the flat
     // interior, so the plaza doesn't drop off a cliff at its edge.
-    let mut heights: Vec<i32> = region.cells.iter().map(|&c| height_at(c)).collect();
+    let mut heights: Vec<i32> = region.cells.iter().filter_map(|&c| height_at(c)).collect();
     heights.sort_unstable();
     let target_top = heights[heights.len() / 2] - 1; // the flat paved surface y
 
@@ -147,10 +147,10 @@ async fn furnish_plaza_inner(
     let surf: HashMap<Point2D, i32> = region
         .cells
         .iter()
-        .map(|&c| {
-            let nat = height_at(c) - 1; // natural surface y
+        .filter_map(|&c| {
+            let nat = height_at(c)? - 1; // natural surface y
             let t = flatten_blend(depth.get(&c).copied().unwrap_or(2));
-            (c, (nat as f32 * (1.0 - t) + target_top as f32 * t).round() as i32)
+            Some((c, (nat as f32 * (1.0 - t) + target_top as f32 * t).round() as i32))
         })
         .collect();
 
@@ -161,7 +161,7 @@ async fn furnish_plaza_inner(
         .cells
         .iter()
         .copied()
-        .filter(|c| surf[c] == target_top)
+        .filter(|c| surf.get(c).copied() == Some(target_top))
         .collect();
 
     // Placement lists drawn from the plateau (never the stepped border):
@@ -190,8 +190,9 @@ async fn furnish_plaza_inner(
         if is_building(world.get_claim(c).as_ref()) {
             continue;
         }
-        let s = surf[&c]; // tapered surface y for this cell
-        let base = height_at(c) - 1; // current surface y
+        let Some(&s) = surf.get(&c) else { continue; }; // tapered surface y for this cell
+        let Some(base_h) = height_at(c) else { continue; };
+        let base = base_h - 1; // current surface y
         // Cut anything above the new surface.
         for y in (s + 1)..=base {
             put_forced(editor, c.x, y, c.y, "minecraft:air").await;
@@ -440,7 +441,7 @@ async fn furnish_plaza_inner(
             continue;
         }
         if trees < 3 {
-            let biome = world.get_surface_biome_at(c);
+            let Some(biome) = world.get_surface_biome_at(c) else { continue; };
             if place_tree(editor, theme, &biome, c, surf[&c] + 1, rng).await {
                 used.insert(c);
                 trees += 1;

--- a/src/generator/open_space/props.rs
+++ b/src/generator/open_space/props.rs
@@ -175,7 +175,7 @@ pub(super) async fn lay_soil_patch(editor: &Editor, c: Point2D, h: i32) {
     lay_soil(editor, c, h).await;
     for d in CARDINALS_2D {
         let n = c + d;
-        let hn = editor.world().get_ocean_floor_height_at(n);
+        let Some(hn) = editor.world().get_ocean_floor_height_at(n) else { continue; };
         lay_soil(editor, n, hn).await;
     }
 }

--- a/src/generator/open_space/yard.rs
+++ b/src/generator/open_space/yard.rs
@@ -71,7 +71,7 @@ pub async fn furnish_yard(editor: &Editor, region: &Region, rng: &mut RNG, theme
                 .all(|d| cells.contains(&(c + *d)) && height_at(c + *d) == h)
         });
         for &c in &interior {
-            let h = height_at(c);
+            let Some(h) = height_at(c) else { continue; };
             if Some(c) == water_cell {
                 put_forced(editor, c.x, h - 1, c.y, "minecraft:water").await;
             } else {
@@ -90,7 +90,7 @@ pub async fn furnish_yard(editor: &Editor, region: &Region, rng: &mut RNG, theme
         if used.contains(&c) {
             continue;
         }
-        let h = height_at(c);
+        let Some(h) = height_at(c) else { continue; };
         let open_side = CARDINALS_2D.iter().any(|d| {
             let n = c + *d;
             !cells.contains(&n)
@@ -117,7 +117,8 @@ pub async fn furnish_yard(editor: &Editor, region: &Region, rng: &mut RNG, theme
         if used.contains(&c) {
             continue;
         }
-        place_lantern_post(editor, c, height_at(c), theme.wood).await;
+        let Some(h) = height_at(c) else { continue; };
+        place_lantern_post(editor, c, h, theme.wood).await;
         break;
     }
 }

--- a/src/generator/paths/connect.rs
+++ b/src/generator/paths/connect.rs
@@ -58,8 +58,8 @@ pub async fn connect_doors_to_roads(
             continue;
         }
 
-        let start = editor.world().add_height(door);
-        let end = editor.world().add_height(goal);
+        let Some(start) = editor.world().add_height(door) else { continue; };
+        let Some(end) = editor.world().add_height(goal) else { continue; };
 
         // Route a Low-priority (width-1) path that stays in the urban area,
         // dodges building/wall footprints, and ends the moment it touches a road.

--- a/src/generator/paths/lanterns.rs
+++ b/src/generator/paths/lanterns.rs
@@ -85,7 +85,7 @@ pub async fn scatter_garden_lanterns(
         if placed.iter().any(|p| chebyshev(*p, c) < GARDEN_GAP) {
             continue;
         }
-        let foot = editor.world().add_height(c);
+        let Some(foot) = editor.world().add_height(c) else { continue; };
         build_stone_lantern(editor, &mut placer, foot).await;
         placed.push(c);
     }

--- a/src/generator/paths/lights.rs
+++ b/src/generator/paths/lights.rs
@@ -175,7 +175,7 @@ fn is_valid_spot(
 /// light leans out over the street. `toward_road` is a unit step from the verge
 /// cell back toward the centreline.
 async fn place_lamp(editor: &Editor, cell: Point2D, toward_road: Point2D, lantern: &Block) {
-    let ground = editor.world().add_height(cell);
+    let Some(ground) = editor.world().add_height(cell) else { return; };
     let fence: Block = "minecraft:oak_fence".into();
 
     // Vertical post.

--- a/src/generator/paths/naming.rs
+++ b/src/generator/paths/naming.rs
@@ -248,7 +248,10 @@ pub fn name_roads_layered(
             (dedup(&mut used, "High", suf), Layer::Centre)
         } else {
             let biome = world.get_surface_biome_at(cells[cells.len() / 2]);
-            let pool = cfg.generic_pool(biome.name(), culture);
+            // OOB centre cell -> no biome hint; generic_pool handles an unknown
+            // biome name by falling back to its culture-only word list.
+            let biome_name = biome.as_ref().map(|b| b.name()).unwrap_or("");
+            let pool = cfg.generic_pool(biome_name, culture);
             (generic_name(&pool, rid, suf, flav, &mut used), Layer::Generic)
         };
 

--- a/src/generator/paths/network.rs
+++ b/src/generator/paths/network.rs
@@ -249,8 +249,10 @@ fn assemble_nodes(
 
     if include_town_center {
         if let Some(c) = centroid_snapped(urban) {
-            nodes.push(editor.world().add_height(c));
-            kinds.push(NodeKind::TownCentre);
+            if let Some(p) = editor.world().add_height(c) {
+                nodes.push(p);
+                kinds.push(NodeKind::TownCentre);
+            }
         }
     }
     nodes.extend_from_slice(anchor_nodes);
@@ -260,14 +262,17 @@ fn assemble_nodes(
             continue;
         }
         if let Some(c) = centroid_snapped(&sd.data.points_2d) {
-            nodes.push(editor.world().add_height(c));
-            kinds.push(NodeKind::District);
+            if let Some(p) = editor.world().add_height(c) {
+                nodes.push(p);
+                kinds.push(NodeKind::District);
+            }
         }
     }
     // Gates use their exact centre so the road meets the threshold; paving lays
     // road surface across the gate/wall tiles without cutting into the wall.
     for (gate_point, _dir) in editor.world().gate_locations.clone() {
-        nodes.push(editor.world().add_height(gate_point.drop_y()));
+        let Some(p) = editor.world().add_height(gate_point.drop_y()) else { continue; };
+        nodes.push(p);
         kinds.push(NodeKind::Gate);
     }
 
@@ -276,7 +281,9 @@ fn assemble_nodes(
     for node in nodes.iter_mut() {
         if blocked.contains(&node.drop_y()) {
             if let Some(c) = nearest_unblocked(node.drop_y(), urban, blocked) {
-                *node = editor.world().add_height(c);
+                if let Some(p) = editor.world().add_height(c) {
+                    *node = p;
+                }
             }
         }
     }

--- a/src/generator/paths/routing.rs
+++ b/src/generator/paths/routing.rs
@@ -4,13 +4,13 @@ use lerp::num_traits::clamp;
 
 use crate::{editor::Editor, generator::{materials::MaterialId, paths::path::{Path, PathPriority}}, geometry::{Point2D, Point3D, ALL_8}};
 
-fn mod4_point(point : Point3D, editor : &Editor) -> Point3D {
-    let point = Point2D{
+fn mod4_point(point : Point3D, editor : &Editor) -> Option<Point3D> {
+    let snapped = Point2D{
         x : point.x - point.x.rem_euclid(4),
         y : point.z - point.z.rem_euclid(4),
     };
 
-    editor.world().add_height(point)
+    editor.world().add_height(snapped)
 }
 
 fn get_best_mod4_point(point : Point3D, editor : &Editor) -> Point3D {
@@ -22,11 +22,14 @@ fn get_best_mod4_point(point : Point3D, editor : &Editor) -> Point3D {
             z: point.z + dz,
         })
         .filter(|p| editor.world().is_in_bounds_2d(p.drop_y()))
-        .map(|p| mod4_point(p, editor))
+        .filter_map(|p| mod4_point(p, editor))
         .min_by_key(|p| {
             p.y.abs_diff(point.y)
         })
-        .unwrap_or(mod4_point(point, editor))
+        // No in-bounds mod-4 candidate had a height: fall back to the snapped
+        // point, or — if that's also OOB — the original point unchanged.
+        .or_else(|| mod4_point(point, editor))
+        .unwrap_or(point)
 }
 
 /// Tunable knobs for A* road routing. `step` is the horizontal lattice spacing
@@ -315,7 +318,7 @@ pub async fn route_path_with(
                     }
                 }
 
-                let raw = editor.world().add_height(neighbour_2d);
+                let Some(raw) = editor.world().add_height(neighbour_2d) else { continue; };
                 if (raw.y.abs_diff(state.y) as i32) <= factor {
                     let y = clamp(raw.y, state.y - params.max_grade, state.y + params.max_grade);
                     chosen = Some(Point3D { x: neighbour_2d.x, y, z: neighbour_2d.y });
@@ -354,7 +357,8 @@ pub async fn route_path_with(
                 if let Some(in_dir) = state.dir {
                     c += delta.distance(in_dir) as u64 * params.turn_weight;
                 }
-                let burrow = editor.world().get_height_at(neighbour.drop_y()).abs_diff(neighbour.y) as u64;
+                let Some(surface_y) = editor.world().get_height_at(neighbour.drop_y()) else { continue; };
+                let burrow = surface_y.abs_diff(neighbour.y) as u64;
                 c += burrow * params.burrow_weight;
                 c += neighbour.y.abs_diff(new_end.y) as u64 * params.goal_height_weight;
                 if editor.world().is_water(neighbour.drop_y()) {

--- a/src/generator/paths/rural.rs
+++ b/src/generator/paths/rural.rs
@@ -128,7 +128,7 @@ pub async fn build_rural_road_network(
     let mut road_height: HashMap<Point2D, i32> = HashMap::new();
 
     for (anchor, gate) in jobs {
-        let start = editor.world().add_height(anchor);
+        let Some(start) = editor.world().add_height(anchor) else { continue; };
 
         // Discount field = laid roads ∪ predicted rings, so routes prefer running
         // along an existing road or a ring rather than carving a parallel one.
@@ -180,7 +180,10 @@ pub async fn build_rural_road_network(
             log::warn!("rural road: gate {:?} found no dry edge to spur to", gnode);
             continue;
         };
-        let target = editor.world().add_height(*land_path.last().expect("path has an edge cell"));
+        let Some(target) = editor.world().add_height(*land_path.last().expect("path has an edge cell")) else {
+            log::warn!("rural road: gate {:?} edge target had no height", gnode);
+            continue;
+        };
 
         let mut discount = network_cells.clone();
         discount.extend(&ring_cells);
@@ -200,7 +203,7 @@ pub async fn build_rural_road_network(
         // long/steep for its search), fall back to the BFS dry-land path so the
         // gate still gets a road. Width 2 matches the Medium collector tier.
         let path = routed.unwrap_or_else(|| {
-            let pts: Vec<Point3D> = land_path.iter().map(|&c| editor.world().add_height(c)).collect();
+            let pts: Vec<Point3D> = land_path.iter().filter_map(|&c| editor.world().add_height(c)).collect();
             Path::new(pts, 2, material.clone(), PathPriority::Medium)
         });
         for p in path.points() {
@@ -226,7 +229,7 @@ fn gate_nodes(editor: &Editor) -> Vec<Point3D> {
     world
         .gate_locations
         .iter()
-        .map(|(gate, dir)| {
+        .filter_map(|(gate, dir)| {
             let cell = gate.drop_y();
             let d = Point2D::from(*dir);
             // Step toward whichever side is not urban (the countryside).
@@ -329,7 +332,7 @@ fn building_anchor(editor: &Editor, footprint: &HashSet<Point2D>, target: Point2
 fn door_approach(editor: &Editor, footprint: &HashSet<Point2D>, target: Point2D) -> Option<Point2D> {
     let mut approaches: Vec<Point2D> = Vec::new();
     for &cell in footprint {
-        let ground = editor.world().get_non_tree_height(cell);
+        let Some(ground) = editor.world().get_non_tree_height(cell) else { continue; };
         for dy in 0..DOOR_SCAN_HEIGHT {
             // Read from the placement cache by local coord: the door was placed
             // this run, and `try_get_block` would subtract the build-area origin

--- a/src/generator/paths/signs.rs
+++ b/src/generator/paths/signs.rs
@@ -232,7 +232,7 @@ async fn place_fingerpost(
     if signs.is_empty() {
         return;
     }
-    let ground = editor.world().add_height(cell);
+    let Some(ground) = editor.world().add_height(cell) else { return; };
 
     // Signs stacked from the ground up, one block apart.
     for (i, &(rid, rotation, arrow)) in signs.iter().enumerate() {

--- a/src/generator/paths/test.rs
+++ b/src/generator/paths/test.rs
@@ -57,8 +57,8 @@ mod tests {
 
         let rect = editor.world().world_rect_2d();
 
-        let start = editor.world().add_height(rect.origin);
-        let end = editor.world().add_height(rect.max());
+        let start = editor.world().add_height(rect.origin).expect("test cell in bounds");
+        let end = editor.world().add_height(rect.max()).expect("test cell in bounds");
 
         
         let path = route_path(&editor, start, end, async |point : &Vec<Point3D>| {
@@ -81,8 +81,8 @@ mod tests {
 
         let rect = editor.world().world_rect_2d();
 
-        let start = editor.world().add_height(rect.origin);
-        let end = editor.world().add_height(rect.max());
+        let start = editor.world().add_height(rect.origin).expect("test cell in bounds");
+        let end = editor.world().add_height(rect.max()).expect("test cell in bounds");
 
         let data = LoadedData::load().expect("Failed to load data");
 

--- a/src/generator/paths/torii.rs
+++ b/src/generator/paths/torii.rs
@@ -117,7 +117,8 @@ async fn build_torii(editor: &Editor, center: Point3D, road_dir: Cardinal) {
     let post_top = base_y + POST_HEIGHT - 1;
     for side in [-POST_OFFSET, POST_OFFSET] {
         let foot = c + p * side;
-        let ground_y = editor.world().add_height(foot).y;
+        let Some(ground) = editor.world().add_height(foot) else { continue; };
+        let ground_y = ground.y;
         for y in ground_y.min(post_top)..=post_top {
             editor.place_block_forced(&red, at(side, y)).await;
         }

--- a/src/generator/placement/placement.rs
+++ b/src/generator/placement/placement.rs
@@ -314,7 +314,7 @@ fn flattest_candidate_centres(
     // re-walk tree columns for every overlapping window.
     let height_at: HashMap<Point2D, i32> = interior
         .iter()
-        .map(|&p| (p, editor.world().get_non_tree_height(p)))
+        .filter_map(|&p| editor.world().get_non_tree_height(p).map(|h| (p, h)))
         .collect();
 
     let mut ranked: Vec<Point2D> = interior.to_vec();
@@ -393,7 +393,7 @@ pub fn district_seatable_footprints(
     // Precompute non-tree surface heights once, reused for every footprint's window.
     let height_at: HashMap<Point2D, i32> = interior
         .iter()
-        .map(|&p| (p, editor.world().get_non_tree_height(p)))
+        .filter_map(|&p| editor.world().get_non_tree_height(p).map(|h| (p, h)))
         .collect();
 
     footprints
@@ -836,7 +836,7 @@ pub fn score_candidate(rect: &Rect2D, editor: &Editor) -> Option<CandidateScore>
         if world.is_water(p) {
             return None;
         }
-        heights.push(world.get_non_tree_height(p));
+        heights.push(world.get_non_tree_height(p)?);
     }
 
     let mean = heights.iter().sum::<i32>() as f32 / heights.len() as f32;
@@ -969,7 +969,7 @@ fn expanded_rect_cells(rect: &Rect2D, radius: i32) -> Vec<Point2D> {
 fn footprint_target_height(cells: &[Point2D], editor: &Editor, allow_steep: bool) -> i32 {
     let mut heights: Vec<i32> = cells
         .iter()
-        .map(|p| editor.world().get_non_tree_height(*p))
+        .filter_map(|p| editor.world().get_non_tree_height(*p))
         .collect();
     heights.sort_unstable();
     let percentile = if allow_steep { STEEP_TARGET_PERCENTILE } else { 0.5 };
@@ -991,7 +991,9 @@ fn build_blend_ring(rect: &Rect2D, target_y: i32, editor: &Editor) -> HashSet<Po
         if dist == 0 || dist > BLEND_RADIUS {
             continue;
         }
-        let natural_y = world.get_non_tree_height(p);
+        let Some(natural_y) = world.get_non_tree_height(p) else {
+            continue;
+        };
         // Always grade toward natural terrain — no early bail on steep deltas, so
         // the pad edge ramps down instead of leaving a cliff. The footprint slope
         // is already bounded by MAX_PLACEMENT_SLOPE (except allow_steep buildings,
@@ -1014,7 +1016,10 @@ fn sample_foundation_material(rect: &Rect2D, editor: &Editor) -> Block {
         if !world.is_in_bounds_2d(p) {
             continue;
         }
-        *counts.entry(world.get_ground_block(p).id.as_str().to_string()).or_insert(0) += 1;
+        let Some(ground) = world.get_ground_block(p) else {
+            continue;
+        };
+        *counts.entry(ground.id.as_str().to_string()).or_insert(0) += 1;
     }
     counts
         .into_iter()
@@ -1048,7 +1053,9 @@ async fn build_foundation_skirt(editor: &mut Editor, rect: &Rect2D, target_y: i3
             if dist == 0 || dist > FOUNDATION_SKIRT_RADIUS {
                 continue;
             }
-            let natural_y = world.get_non_tree_height(p);
+            let Some(natural_y) = world.get_non_tree_height(p) else {
+                continue;
+            };
             // Taper from the pad height (just outside the wall) to natural grade at
             // the skirt's outer edge.
             let t = dist as f32 / (FOUNDATION_SKIRT_RADIUS as f32 + 1.0);

--- a/src/generator/placement/test.rs
+++ b/src/generator/placement/test.rs
@@ -273,7 +273,7 @@ mod tests {
         let anchor_nodes: Vec<Point3D> = footprint_by_id.values()
             .map(|cells| {
                 let c = cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
-                editor.world().add_height(c)
+                editor.world().add_height(c).expect("test cell in bounds")
             })
             .collect();
         println!("Placed {} / {} industrial buildings; {} building nodes for the network", placed, want, anchor_nodes.len());
@@ -491,7 +491,7 @@ mod tests {
         let ind_nodes: Vec<Point3D> = ind_footprints.values()
             .map(|cells| {
                 let c = cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
-                editor.world().add_height(c)
+                editor.world().add_height(c).expect("test cell in bounds")
             })
             .collect();
 
@@ -527,8 +527,8 @@ mod tests {
                 println!(
                     "  ({:>4},{:>4})  road_y={:>3}  ground_h={:>3}  ocean_h={:>3}",
                     xz.x, xz.y, p.y,
-                    editor.world().get_height_at(xz),
-                    editor.world().get_ocean_floor_height_at(xz),
+                    editor.world().get_height_at(xz).expect("test cell in bounds"),
+                    editor.world().get_ocean_floor_height_at(xz).expect("test cell in bounds"),
                 );
             }
         }
@@ -573,7 +573,7 @@ mod tests {
                     for dz in -WIN..=WIN {
                         let n = Point2D::new(c.x + dx, c.y + dz);
                         if !urban.contains(&n) { continue; }
-                        let h = editor.world().get_ocean_floor_height_at(n);
+                        let h = editor.world().get_ocean_floor_height_at(n).expect("test cell in bounds");
                         lo = lo.min(h);
                         hi = hi.max(h);
                     }
@@ -655,7 +655,7 @@ mod tests {
             }
         }
         for &c in &alley_band {
-            road_h.entry(c).or_insert_with(|| editor.world().add_height(c).y);
+            road_h.entry(c).or_insert_with(|| editor.world().add_height(c).expect("test cell in bounds").y);
         }
 
         // Frontage bands per tier (paved cells, matching the roads we'll build).
@@ -1016,7 +1016,7 @@ mod tests {
         let mut verge_total = 0usize;
         for (ti, cells) in tier_verge.iter().enumerate() {
             for c in cells {
-                let h = editor.world().get_ocean_floor_height_at(*c);
+                let h = editor.world().get_ocean_floor_height_at(*c).expect("test cell in bounds");
                 editor.place_block(&verge_blocks[ti], Point3D::new(c.x, h - 1, c.y)).await;
                 verge_total += 1;
             }
@@ -1047,7 +1047,7 @@ mod tests {
             "Alleys: {} corridor + {} connector cells -> {} total",
             alley_band.len(), connectors.len(), full_alleys.len(),
         );
-        let alley_pts: Vec<Point3D> = full_alleys.iter().map(|c| editor.world().add_height(*c)).collect();
+        let alley_pts: Vec<Point3D> = full_alleys.iter().map(|c| editor.world().add_height(*c).expect("test cell in bounds")).collect();
         let alley_path = Path::new(alley_pts, 1, MaterialId::new("sandstone".to_string()), PathPriority::Low);
         build_paths_merged(&editor, &data, &[alley_path], &mut rng).await;
         for c in &full_alleys {
@@ -1114,7 +1114,7 @@ mod tests {
         let city_rect = editor.world().world_rect_2d();
         let city_centre = (city_rect.origin + city_rect.max()) / 2;
         let cold = {
-            let n = editor.world().get_surface_biome_at(city_centre);
+            let n = editor.world().get_surface_biome_at(city_centre).expect("test cell in bounds");
             let n = n.name();
             n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
         };

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -45,6 +45,7 @@ use crate::generator::buildings_v2::footprint::SizeClass;
 use crate::generator::buildings_v2::Culture;
 use crate::generator::nbts::{Structure, StructureType};
 use crate::geometry::{Point2D, Point3D};
+use crate::minecraft::Color;
 use crate::noise::RNG;
 
 use super::npc::{
@@ -482,9 +483,33 @@ pub struct Fixture {
 }
 
 
+/// Per-culture name pools (currently just first names). Loaded from the
+/// `cultures` map in `data/npcs.yaml`, keyed by [`culture_key`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct CultureNames {
+    /// Localized first names, picked verbatim by [`roll_first_name`]. Mixes
+    /// masculine and feminine names; one is assigned per NPC at random.
+    #[serde(default)]
+    pub first_names: Vec<String>,
+}
+
+/// The `data/npcs.yaml` key for a culture's name pools.
+fn culture_key(culture: Culture) -> &'static str {
+    match culture {
+        Culture::Desert => "desert",
+        Culture::Japanese => "japanese",
+        Culture::Medieval => "medieval",
+    }
+}
+
 /// Name + dialogue pools, loaded from `data/npcs.yaml`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NpcData {
+    /// Per-culture name pools, keyed by [`culture_key`] (`medieval`, `japanese`,
+    /// `desert`). A culture's `first_names` list, when non-empty, supersedes the
+    /// legacy `first_name_prefixes`/`first_name_suffixes` composition.
+    #[serde(default)]
+    pub cultures: HashMap<String, CultureNames>,
     /// Consonant-ending stems that open a generated first name (Ael, Cor,
     /// Hild, Theod, …). Combined with [`Self::first_name_suffixes`] in
     /// [`roll_first_name`] to mint first names — Aelric, Coran, Hilda,
@@ -723,11 +748,17 @@ fn professions_for(wealth: Wealth) -> &'static [Profession] {
 // Name + epithet rolls
 // ============================================================================
 
-/// Mint a first name by combining a random stem prefix with a random suffix —
-/// "Cor" + "an" → "Coran", "Hild" + "a" → "Hilda", "Theod" + "ric" →
-/// "Theodric". Falls back to `"Stranger"` if either pool is empty (so a
-/// partial yaml doesn't panic).
-fn roll_first_name(data: &NpcData, rng: &mut RNG) -> String {
+/// Pick a first name localized to `culture`. Prefers the culture's explicit
+/// `first_names` list from `data/npcs.yaml` (Anglo-Saxon for medieval, Japanese,
+/// Arabic for desert). Falls back to the legacy prefix×suffix composition —
+/// "Cor" + "an" → "Coran" — when the culture lists no names, and to
+/// `"Stranger"` only if every pool is empty (so a partial yaml doesn't panic).
+fn roll_first_name(culture: Culture, data: &NpcData, rng: &mut RNG) -> String {
+    if let Some(names) = data.cultures.get(culture_key(culture)) {
+        if !names.first_names.is_empty() {
+            return rng.choose(&names.first_names).clone();
+        }
+    }
     if data.first_name_prefixes.is_empty() || data.first_name_suffixes.is_empty() {
         return "Stranger".to_string();
     }
@@ -967,6 +998,7 @@ fn expand_shape(
     alloc: &mut IdAllocator,
     primary_surname: &str,
     data: &NpcData,
+    culture: Culture,
     biome: VillagerBiome,
     rng: &mut RNG,
 ) {
@@ -986,13 +1018,13 @@ fn expand_shape(
         HouseholdShape::SoloAdult => {
             let stage = LifeStage::Adult;
             push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(stage, data, rng), stage, biome);
         }
         HouseholdShape::SoloElder => {
             let stage = LifeStage::Elder;
             push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(stage, data, rng), stage, biome);
         }
         HouseholdShape::Couple => {
@@ -1002,21 +1034,21 @@ fn expand_shape(
             let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
             let stage = LifeStage::Adult;
             let a = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(stage, data, rng), stage, biome);
             let b = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), sn_b,
+                roll_first_name(culture, data, rng), sn_b,
                 roll_epithet(stage, data, rng), stage, biome);
             link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
         }
         HouseholdShape::SingleParent(n_kids) => {
             let parent = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             let mut kid_idxs = Vec::with_capacity(n_kids as usize);
             for _ in 0..n_kids {
                 let k = push_member(h_idx, members, by_id, alloc,
-                    roll_first_name(data, rng), primary_surname.to_string(),
+                    roll_first_name(culture, data, rng), primary_surname.to_string(),
                     None, LifeStage::Child, biome);
                 link_pair(members, parent, k, RelationshipKind::Child, RelationshipKind::Parent);
                 kid_idxs.push(k);
@@ -1027,17 +1059,17 @@ fn expand_shape(
             let married_in = rng.percent(40);
             let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
             let a = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             let b = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), sn_b,
+                roll_first_name(culture, data, rng), sn_b,
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
             // Kids take the primary surname (the family name).
             let mut kid_idxs = Vec::with_capacity(n_kids as usize);
             for _ in 0..n_kids {
                 let k = push_member(h_idx, members, by_id, alloc,
-                    roll_first_name(data, rng), primary_surname.to_string(),
+                    roll_first_name(culture, data, rng), primary_surname.to_string(),
                     None, LifeStage::Child, biome);
                 link_pair(members, a, k, RelationshipKind::Child, RelationshipKind::Parent);
                 link_pair(members, b, k, RelationshipKind::Child, RelationshipKind::Parent);
@@ -1049,15 +1081,15 @@ fn expand_shape(
             let married_in = rng.percent(40);
             let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
             let a = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             let b = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), sn_b,
+                roll_first_name(culture, data, rng), sn_b,
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
             // Elder is a parent of whichever spouse shares the family name.
             let elder = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
             link_pair(members, elder, a, RelationshipKind::Child, RelationshipKind::Parent);
         }
@@ -1065,20 +1097,20 @@ fn expand_shape(
             let married_in = rng.percent(40);
             let sn_b = if married_in { alt_surname(rng) } else { primary_surname.to_string() };
             let a = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             let b = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), sn_b,
+                roll_first_name(culture, data, rng), sn_b,
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             link_pair(members, a, b, RelationshipKind::Spouse, RelationshipKind::Spouse);
             let elder = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
             link_pair(members, elder, a, RelationshipKind::Child, RelationshipKind::Parent);
             let mut kid_idxs = Vec::with_capacity(n_kids as usize);
             for _ in 0..n_kids {
                 let k = push_member(h_idx, members, by_id, alloc,
-                    roll_first_name(data, rng), primary_surname.to_string(),
+                    roll_first_name(culture, data, rng), primary_surname.to_string(),
                     None, LifeStage::Child, biome);
                 link_pair(members, a, k, RelationshipKind::Child, RelationshipKind::Parent);
                 link_pair(members, b, k, RelationshipKind::Child, RelationshipKind::Parent);
@@ -1093,7 +1125,7 @@ fn expand_shape(
             let mut idxs = Vec::with_capacity(n as usize);
             for _ in 0..n {
                 let i = push_member(h_idx, members, by_id, alloc,
-                    roll_first_name(data, rng), primary_surname.to_string(),
+                    roll_first_name(culture, data, rng), primary_surname.to_string(),
                     roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
                 idxs.push(i);
             }
@@ -1110,16 +1142,16 @@ fn expand_shape(
                     alt_surname(rng)
                 };
                 push_member(h_idx, members, by_id, alloc,
-                    roll_first_name(data, rng), sn,
+                    roll_first_name(culture, data, rng), sn,
                     roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             }
         }
         HouseholdShape::ElderWithAdultChild => {
             let elder = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Elder, data, rng), LifeStage::Elder, biome);
             let child = push_member(h_idx, members, by_id, alloc,
-                roll_first_name(data, rng), primary_surname.to_string(),
+                roll_first_name(culture, data, rng), primary_surname.to_string(),
                 roll_epithet(LifeStage::Adult, data, rng), LifeStage::Adult, biome);
             link_pair(members, elder, child, RelationshipKind::Child, RelationshipKind::Parent);
         }
@@ -1161,19 +1193,34 @@ pub fn build_households(
     for (h_idx, house) in houses.iter().enumerate() {
         let budget = house.population.max(1);
         let wealth = house.wealth;
-        let mut primary_surname = roll_surname(data, rng);
+        // A manor usually takes its surname from its family colour (Black →
+        // Blackwell), matching the colour it flies on its banners; 40% of the
+        // time it falls back to a plain random surname. The colour choice is made
+        // once per house so the uniqueness loop re-rolls a fresh colour *suffix*
+        // (preserving the colour) rather than silently dropping it on collision.
+        const COLOR_SURNAME_PCT: i32 = 40;
+        let color_root = house.family_color.and_then(|c| c.surname_root());
+        let use_color =
+            color_root.is_some() && !data.surname_suffixes.is_empty() && rng.percent(COLOR_SURNAME_PCT);
+        let roll = |rng: &mut RNG| -> String {
+            match color_root {
+                Some(root) if use_color => format!("{root}{}", rng.choose(&data.surname_suffixes)),
+                _ => roll_surname(data, rng),
+            }
+        };
+        let mut primary_surname = roll(rng);
         for _ in 0..SURNAME_MAX_TRIES {
             if !used_surnames.contains(&primary_surname) {
                 break;
             }
-            primary_surname = roll_surname(data, rng);
+            primary_surname = roll(rng);
         }
         used_surnames.insert(primary_surname.clone());
         let mut members: Vec<Npc> = Vec::new();
         let shape = pick_household_shape(budget, wealth, rng);
         expand_shape(
             shape, h_idx, &mut members, &mut pop.by_id, alloc,
-            &primary_surname, data, biome, rng,
+            &primary_surname, data, culture, biome, rng,
         );
         pop.households.push(Household {
             surname: primary_surname,
@@ -1674,7 +1721,7 @@ pub fn build_roster(
             };
             Npc {
                 id: alloc.next_id(),
-                first_name: roll_first_name(data, rng),
+                first_name: roll_first_name(culture, data, rng),
                 surname: roll_surname(data, rng),
                 epithet: roll_epithet(stage, data, rng),
                 life_stage: stage,
@@ -1706,6 +1753,11 @@ pub struct HouseAnchors {
     /// cheap proximity queries (work-binding to nearby workplaces, friendship
     /// drafting between neighbours).
     pub pos: Point2D,
+    /// A manor's unique family colour, if this house is a manor. The household it
+    /// seeds takes its surname from this colour most of the time (Black →
+    /// Blackwell), matching the colour it flies on its exterior banners. `None`
+    /// for ordinary houses, which keep a plain random surname.
+    pub family_color: Option<Color>,
 }
 
 /// One candidate scene in the town-wide draw, tagged with the house it belongs
@@ -2207,6 +2259,37 @@ mod tests {
         assert!(data.small_talk.contains(&none));
     }
 
+    /// Every culture defines a non-empty localized first-name pool, and
+    /// `roll_first_name` draws from that culture's list (not another's). Guards
+    /// the `cultures` block in `npcs.yaml` against drifting away from the code.
+    /// No server.
+    #[test]
+    fn first_names_are_localized_per_culture() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        for culture in [Culture::Medieval, Culture::Japanese, Culture::Desert] {
+            let pool = data
+                .cultures
+                .get(culture_key(culture))
+                .map(|c| &c.first_names)
+                .unwrap_or_else(|| panic!("npcs.yaml: no `cultures.{}` block", culture_key(culture)));
+            assert!(
+                !pool.is_empty(),
+                "culture '{}' has an empty first_names pool",
+                culture_key(culture),
+            );
+            // Several draws all land in this culture's own pool.
+            let mut rng = RNG::new(Seed(42));
+            for _ in 0..20 {
+                let name = roll_first_name(culture, &data, &mut rng);
+                assert!(
+                    pool.contains(&name),
+                    "roll_first_name({}) produced '{name}', not in that culture's pool",
+                    culture_key(culture),
+                );
+            }
+        }
+    }
+
     /// `exchange_of_len` returns only entries with the requested line count, so a
     /// fixed-size stage scene draws a script that fits its cast. No server.
     #[test]
@@ -2314,6 +2397,7 @@ mod tests {
                 population: pop,
                 wealth: Wealth::Modest,
                 pos: Point2D::new(pop as i32 * 16, 0),
+                family_color: None,
             })
             .collect();
         let pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
@@ -2371,6 +2455,7 @@ mod tests {
                 population: pop,
                 wealth: Wealth::Modest,
                 pos: Point2D::new(pop as i32 * 16, 0),
+                family_color: None,
             })
             .collect();
         let mut pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -435,6 +435,10 @@ pub struct Household {
     /// Wealth tier derived from the building's size class at placement time.
     /// Biases [`assign_employment`] and [`pick_household_shape`].
     pub wealth: Wealth,
+    /// English blazon of the family's banner, copied from its [`HouseAnchors`]
+    /// for the chronicle — e.g. "a red cross on a black background". `Some` only
+    /// for manor families that fly a heraldic design.
+    pub banner_blazon: Option<String>,
     pub members: Vec<Npc>,
 }
 
@@ -1227,6 +1231,7 @@ pub fn build_households(
             home: h_idx,
             pos: house.pos,
             wealth,
+            banner_blazon: house.banner_blazon.clone(),
             members,
         });
     }
@@ -1758,6 +1763,10 @@ pub struct HouseAnchors {
     /// Blackwell), matching the colour it flies on its exterior banners. `None`
     /// for ordinary houses, which keep a plain random surname.
     pub family_color: Option<Color>,
+    /// English blazon of the family's banner design for the chronicle, e.g.
+    /// "a red cross on a black background". `Some` only for manors that fly a
+    /// heraldic design; `None` for ordinary houses.
+    pub banner_blazon: Option<String>,
 }
 
 /// One candidate scene in the town-wide draw, tagged with the house it belongs
@@ -2342,6 +2351,7 @@ mod tests {
             home: id as usize,
             pos,
             wealth: Wealth::Modest,
+            banner_blazon: None,
             members: vec![Npc {
                 id,
                 first_name: "A".into(),
@@ -2398,6 +2408,7 @@ mod tests {
                 wealth: Wealth::Modest,
                 pos: Point2D::new(pop as i32 * 16, 0),
                 family_color: None,
+                banner_blazon: None,
             })
             .collect();
         let pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
@@ -2456,6 +2467,7 @@ mod tests {
                 wealth: Wealth::Modest,
                 pos: Point2D::new(pop as i32 * 16, 0),
                 family_color: None,
+                banner_blazon: None,
             })
             .collect();
         let mut pop = build_households(&houses, Culture::Medieval, &data, &mut alloc, &mut rng);
@@ -2507,7 +2519,7 @@ mod tests {
         let scenes: Vec<AnchorScene> = (0..count)
             .map(|i| {
                 let c = Point2D::new(start_x + i * 3, cz);
-                let y = editor.world().get_ocean_floor_height_at(c);
+                let y = editor.world().get_ocean_floor_height_at(c).expect("test cell in bounds");
                 AnchorScene::solo(Point3D::new(c.x, y, c.y), 0.0, SlotRole::Resident)
             })
             .collect();

--- a/src/generator/resource_chain/production_area.rs
+++ b/src/generator/resource_chain/production_area.rs
@@ -209,7 +209,9 @@ async fn logging_production_painter(
     let mut to_log: HashSet<Point2D> = HashSet::new();
     let mut stumps: Vec<(Point3D, Block)> = Vec::with_capacity(selected.len());
     for tree in &selected {
-        let stump_y = editor.world().get_non_tree_height(tree.trunk);
+        let Some(stump_y) = editor.world().get_non_tree_height(tree.trunk) else {
+            continue;
+        };
         let stump_pos = tree.trunk.add_y(stump_y);
         stumps.push((stump_pos, editor.get_block(stump_pos)));
         to_log.extend(tree.cells.iter().copied());
@@ -491,7 +493,10 @@ async fn sugarcane_production_painter(
     // 1. Soil bed — every cell gets a cane-supportable solid surface, keeping the
     //    existing block where it already qualifies.
     for &c in &ordered {
-        let y = editor.world().get_non_tree_height(c) - 1;
+        let Some(ch) = editor.world().get_non_tree_height(c) else {
+            continue;
+        };
+        let y = ch - 1;
         let pos = Point3D::new(c.x, y, c.y);
         let current = editor.get_block(pos);
         if !can_support_sugar_cane(&current.id) {
@@ -514,7 +519,11 @@ async fn sugarcane_production_painter(
     loop {
         let mut demote: Vec<Point2D> = Vec::new();
         for &w in &water_set {
-            let wy = editor.world().get_non_tree_height(w) - 1;
+            let Some(wh) = editor.world().get_non_tree_height(w) else {
+                demote.push(w);
+                continue;
+            };
+            let wy = wh - 1;
             // Floor must be solid.
             if !is_solid_support(&editor.get_block(Point3D::new(w.x, wy - 1, w.y))) {
                 demote.push(w);
@@ -526,7 +535,8 @@ async fn sugarcane_production_painter(
                 if is_solid_support(&editor.get_block(Point3D::new(n.x, wy, n.y))) {
                     return true;
                 }
-                water_set.contains(&n) && editor.world().get_non_tree_height(n) - 1 == wy
+                water_set.contains(&n)
+                    && editor.world().get_non_tree_height(n).is_some_and(|nh| nh - 1 == wy)
             });
             if !boxed {
                 demote.push(w);
@@ -543,7 +553,10 @@ async fn sugarcane_production_painter(
     // 3. Place the validated (boxed) water.
     let water_block: Block = "water".into();
     for &w in &water_set {
-        let wy = editor.world().get_non_tree_height(w) - 1;
+        let Some(wh) = editor.world().get_non_tree_height(w) else {
+            continue;
+        };
+        let wy = wh - 1;
         editor.place_block_forced(&water_block, Point3D::new(w.x, wy, w.y)).await;
     }
     editor.flush_buffer().await;
@@ -559,11 +572,14 @@ async fn sugarcane_production_painter(
         if water_set.contains(&c) {
             continue;
         }
-        let cy = editor.world().get_non_tree_height(c); // base air cell of the column
+        let Some(cy) = editor.world().get_non_tree_height(c) else {
+            continue;
+        }; // base air cell of the column
         let support_y = cy - 1;
         let has_water = CARDINALS_2D.iter().any(|&d| {
             let n = c + d;
-            water_set.contains(&n) && editor.world().get_non_tree_height(n) - 1 == support_y
+            water_set.contains(&n)
+                && editor.world().get_non_tree_height(n).is_some_and(|nh| nh - 1 == support_y)
         });
         if !has_water {
             continue;
@@ -636,7 +652,7 @@ fn beehive_nbt(bee_names: &[String], prefixes: &[String], suffixes: &[String], r
 /// directly above (the canopy roof) — hanging beneath a leaf is fine even without
 /// neighbouring leaves.
 fn find_hive_spot(trunk: Point2D, editor: &Editor) -> Option<(Point3D, Point2D)> {
-    let base_y = editor.world().get_non_tree_height(trunk);
+    let base_y = editor.world().get_non_tree_height(trunk)?;
 
     // Walk up the trunk's logs to find the top of the stem.
     let mut top_y = base_y;
@@ -769,7 +785,10 @@ fn detect_local_rock(ordered: &[Point2D], editor: &Editor) -> (String, bool) {
     let mut counts: HashMap<&'static str, usize> = HashMap::new();
     let step = (ordered.len() / MINE_GEOLOGY_SAMPLES).max(1);
     for c in ordered.iter().step_by(step) {
-        let top = editor.world().get_non_tree_height(*c) - 1;
+        let Some(ch) = editor.world().get_non_tree_height(*c) else {
+            continue;
+        };
+        let top = ch - 1;
         for dy in 0..MINE_GEOLOGY_SCAN_DEPTH {
             // `try_get_block` (not `get_block`) so scanning below the world floor —
             // common for a mine near bedrock — returns None instead of panicking.
@@ -804,7 +823,10 @@ fn detect_outcrop_rock(center: Point2D, editor: &Editor) -> (String, bool) {
             if !editor.world().is_in_bounds_2d(cell) {
                 continue;
             }
-            let top = editor.world().get_non_tree_height(cell) - 1;
+            let Some(ch) = editor.world().get_non_tree_height(cell) else {
+                continue;
+            };
+            let top = ch - 1;
             for dy in 0..MINE_GEOLOGY_SCAN_DEPTH {
                 let Some(block) = editor.try_get_block(Point3D::new(cell.x, top - dy, cell.y)) else {
                     break;
@@ -884,7 +906,10 @@ async fn place_outcrop(
             if !editor.world().is_in_bounds_2d(cell) {
                 continue;
             }
-            let top = editor.world().get_non_tree_height(cell) - 1;
+            let Some(ch) = editor.world().get_non_tree_height(cell) else {
+                continue;
+            };
+            let top = ch - 1;
             // Height tapers from the centre outward, plus a 0–1 block of jitter.
             let falloff = 1.0 - (dist2 as f32 / (r2 as f32 + 1.0)).sqrt();
             let taper = (falloff * MINE_BOULDER_MAX_HEIGHT as f32).round() as i32;
@@ -970,7 +995,10 @@ async fn mine_production_painter(
             if rng.rand_i32_range(0, 1000) >= MINE_TERRAIN_ORE_PERMILLE {
                 continue;
             }
-            let top = editor.world().get_non_tree_height(c) - 1;
+            let Some(ch) = editor.world().get_non_tree_height(c) else {
+                continue;
+            };
+            let top = ch - 1;
             editor.place_block_forced(&seam_ore, Point3D::new(c.x, top, c.y)).await;
         }
     }
@@ -1200,7 +1228,9 @@ async fn pasture_production_painter(
     let (fence_block, gate_id) = resolve_fence_blocks(&p.palette, data, rng);
 
     for &cell in &fence_cells {
-        let y = editor.world().get_non_tree_height(cell);
+        let Some(y) = editor.world().get_non_tree_height(cell) else {
+            continue;
+        };
         let pos = Point3D::new(cell.x, y, cell.y);
         if gate_cells.contains(&cell) {
             // Face the gate toward an outward (non-pasture) neighbour.
@@ -1234,7 +1264,9 @@ async fn pasture_production_painter(
         let spots = rng.choose_many(&interior, count);
         let mut entities: Vec<(Point3D, String, Option<String>)> = Vec::with_capacity(spots.len());
         for &spot in spots {
-            let y = editor.world().get_non_tree_height(spot);
+            let Some(y) = editor.world().get_non_tree_height(spot) else {
+                continue;
+            };
             let pos = Point3D::new(spot.x, y, spot.y);
             let nbt = animal_name_nbt(&reg.animal_names, &reg.animal_name_prefixes, &reg.animal_name_suffixes, rng);
             entities.push((pos, p.animal.clone(), nbt));

--- a/src/generator/resource_chain/test.rs
+++ b/src/generator/resource_chain/test.rs
@@ -645,7 +645,7 @@ mod tests {
 
                 let block = district_color.get(&district_id).expect("district color");
                 // Post-terraform surface height (local, matching block-write coords).
-                let height = editor.world().get_height_at(Point2D::new(x, z));
+                let height = editor.world().get_height_at(Point2D::new(x, z)).expect("test cell in bounds");
 
                 let on_edge = edge_cells.contains(&Point2D::new(x, z));
 
@@ -839,7 +839,7 @@ mod tests {
                     continue;
                 }
                 let on_edge = edge_cells.contains(&p);
-                let height = editor.world().get_height_at(p);
+                let height = editor.world().get_height_at(p).expect("test cell in bounds");
                 match ptype {
                     ParcelType::Urban | ParcelType::OffLimits => {
                         let block = if matches!(ptype, ParcelType::Urban) { &blue } else { &red };

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -67,6 +67,15 @@ impl ColorScheme {
             _ => *rng.choose(&self.pool),
         }
     }
+
+    /// A pool colour guaranteed different from `avoid` — the secondary (charge)
+    /// colour for a manor's banner design, so the charge always contrasts with
+    /// its family (field) colour. The pool always has ≥ 4 entries, so excluding
+    /// one never empties it.
+    fn distinct_from(&self, avoid: Color, rng: &mut RNG) -> Color {
+        let opts: Vec<Color> = self.pool.iter().copied().filter(|&c| c != avoid).collect();
+        if opts.is_empty() { avoid } else { *rng.choose(&opts) }
+    }
 }
 
 pub async fn generate_town(
@@ -329,7 +338,7 @@ pub async fn generate_town(
         })
         .collect();
     let ind_nodes: Vec<Point3D> = ind_footprints.values()
-        .map(|cells| {
+        .filter_map(|cells| {
             let c = cells.iter().fold(Point2D::ZERO, |a, p| a + *p) / cells.len().max(1) as i32;
             editor.world().add_height(c)
         })
@@ -365,11 +374,17 @@ pub async fn generate_town(
         println!("--- path[0] sample: road_y vs ground_h vs ocean_h ---");
         for p in path.points().iter().take(25) {
             let xz = p.drop_y();
+            let (Some(ground_h), Some(ocean_h)) = (
+                editor.world().get_height_at(xz),
+                editor.world().get_ocean_floor_height_at(xz),
+            ) else {
+                continue;
+            };
             println!(
                 "  ({:>4},{:>4})  road_y={:>3}  ground_h={:>3}  ocean_h={:>3}",
                 xz.x, xz.y, p.y,
-                editor.world().get_height_at(xz),
-                editor.world().get_ocean_floor_height_at(xz),
+                ground_h,
+                ocean_h,
             );
         }
     }
@@ -432,7 +447,7 @@ pub async fn generate_town(
                 for dz in -WIN..=WIN {
                     let n = Point2D::new(c.x + dx, c.y + dz);
                     if !urban.contains(&n) { continue; }
-                    let h = editor.world().get_ocean_floor_height_at(n);
+                    let Some(h) = editor.world().get_ocean_floor_height_at(n) else { continue; };
                     lo = lo.min(h);
                     hi = hi.max(h);
                 }
@@ -503,7 +518,7 @@ pub async fn generate_town(
     // alley path), but DON'T build them yet — we build after the houses so
     // house-foundation earth can't bury the road. Houses are placed first and
     // sit their floor at the level of the road they front (see `road_h`).
-    let alley_pts: Vec<Point3D> = alley_band.iter().map(|c| editor.world().add_height(*c)).collect();
+    let alley_pts: Vec<Point3D> = alley_band.iter().filter_map(|c| editor.world().add_height(*c)).collect();
     let alley_path = Path::new(alley_pts, 1, MaterialId::new(collector_mat.to_string()), PathPriority::Low);
     let mut all_paths = paths.clone();
     all_paths.push(alley_path);
@@ -725,6 +740,14 @@ pub async fn generate_town(
         "Town colours: dominant={:?}, second={:?}; manor family colours={:?}",
         color_scheme.town[0], color_scheme.town[1], color_scheme.manor,
     );
+    // Per-manor name signs are planned during the building loop (geometry known
+    // once the door is cut) and lettered after the population pass rolls each
+    // family's surname. `sign_rng` keeps the designation draw off the placement
+    // streams. Designation varies per manor for flavour.
+    const MANOR_DESIGNATIONS: [&str; 4] = ["Manor", "Estate", "Hall", "House"];
+    let mut sign_rng = rng.derive();
+    let mut manor_sign_sites: Vec<crate::generator::buildings_v2::exterior::ManorSignSite> =
+        Vec::new();
 
     let mut total_buildings = 0usize;
     // Per-house NPC anchors + bed-derived population budget, gathered from every
@@ -868,6 +891,23 @@ pub async fn generate_town(
                     palette.primary_color = Some(
                         family_color.unwrap_or_else(|| color_scheme.next_color(&mut color_rng)),
                     );
+                    // A manor family also flies one heraldic banner design on
+                    // every banner it owns (door + interior): the family colour
+                    // is the field, a distinct second colour the charge. Stamped
+                    // via `palette.banner_data` wherever a banner is recoloured.
+                    // The blazon rides along to the household for the chronicle.
+                    palette.banner_data = None;
+                    let mut banner_blazon: Option<String> = None;
+                    if let Some(primary) = family_color {
+                        let secondary = color_scheme.distinct_from(primary, &mut color_rng);
+                        if let Some(b) = crate::generator::heraldry::pick_family_banner(
+                            primary, secondary, &mut color_rng,
+                        ) {
+                            println!("Manor banner: {}", b.blazon);
+                            palette.banner_data = Some(b.data);
+                            banner_blazon = Some(b.blazon);
+                        }
+                    }
                     // Roof style weighted by culture + size (irimoya skews to the
                     // grander buildings; see `roof_styles_for`).
                     let roof_styles = culture.roof_styles_for(size_class);
@@ -913,6 +953,14 @@ pub async fn generate_town(
                     // staying large enough and fall back to plain walls otherwise.
                     let (en, ed) = culture.engawa_chance(size_class);
                     bctx.engawa = ed > 0 && rng.rand_i32_range(0, ed as i32) < en as i32;
+                    // Roll the jetty per culture taste (medieval timber-frame
+                    // upper-floor overhang; see `jetty_chance`). Frame generation
+                    // gates on shape/floor-count/plot fit and silently no-ops when
+                    // ineligible, so an un-jettiable building just stays flush.
+                    // Engawa wins in the pipeline, but the cultures don't overlap
+                    // (jetty is medieval-only, engawa Japanese-only).
+                    let (jn, jd) = culture.jetty_chance();
+                    bctx.jetty = jd > 0 && rng.rand_i32_range(0, jd as i32) < jn as i32;
                     let mut bctx_editor = BuildCtx::new(editor, &data, &palette, &mut rng);
                     match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
                         Ok(output) => {
@@ -924,6 +972,17 @@ pub async fn generate_town(
                                 crate::generator::buildings_v2::exterior::place_family_banner(
                                     &mut bctx_editor, &output.wall_segs, color,
                                 ).await;
+                                // Plan its name sign now the door is known; it gets
+                                // lettered after the population pass names the family.
+                                let designation = MANOR_DESIGNATIONS[
+                                    sign_rng.rand_i32_range(0, MANOR_DESIGNATIONS.len() as i32) as usize
+                                ].to_string();
+                                if let Some(site) = crate::generator::buildings_v2::exterior::plan_manor_sign(
+                                    &output.wall_segs, &palette, &data.materials,
+                                    &mut sign_rng, town_anchors.len(), designation,
+                                ) {
+                                    manor_sign_sites.push(site);
+                                }
                             }
                             // Population budget tracks sleeping capacity, not bed
                             // furniture: a double/canopy bed sleeps two. Each
@@ -953,6 +1012,7 @@ pub async fn generate_town(
                                 wealth: crate::generator::population::Wealth::from_size_class(size_class),
                                 pos: output.footprint.bounds().midpoint(),
                                 family_color,
+                                banner_blazon,
                             });
                             // Mark every rect in the footprint (core + wings)
                             // as used so subsequent placements on this lot
@@ -1048,7 +1108,7 @@ pub async fn generate_town(
     let mut verge_total = 0usize;
     for (ti, cells) in tier_verge.iter().enumerate() {
         for c in cells {
-            let h = editor.world().get_ocean_floor_height_at(*c);
+            let Some(h) = editor.world().get_ocean_floor_height_at(*c) else { continue; };
             editor.place_block(&verge_blocks[ti], Point3D::new(c.x, h - 1, c.y)).await;
             verge_total += 1;
         }
@@ -1060,10 +1120,12 @@ pub async fn generate_town(
     // generator picks the lantern type city-wide.
     let city_rect = editor.world().world_rect_2d();
     let city_centre = (city_rect.origin + city_rect.max()) / 2;
-    let cold = {
-        let n = editor.world().get_surface_biome_at(city_centre);
-        let n = n.name();
-        n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
+    let cold = match editor.world().get_surface_biome_at(city_centre) {
+        Some(biome) => {
+            let n = biome.name();
+            n.contains("snowy") || n.contains("frozen") || n.contains("taiga")
+        }
+        None => false,
     };
     let street_lantern: crate::minecraft::Block = if cold {
         "minecraft:soul_lantern".into()
@@ -1274,6 +1336,16 @@ pub async fn generate_town(
         // is legible in the console without needing a debugger.
         log_population_stats(&population);
         log_sample_households(&population, 8);
+
+        // Letter each manor's name sign now its household surname is known.
+        for site in &manor_sign_sites {
+            if let Some(hh) = population.households.iter().find(|h| h.home == site.anchor_idx) {
+                println!("Manor sign: {} {}", hh.surname, site.designation());
+                crate::generator::buildings_v2::exterior::place_manor_sign(
+                    editor, site, &hh.surname,
+                ).await;
+            }
+        }
 
         // Bind residents to workplaces before seating anyone at home. The draft
         // weights each unplaced adult by qualification (proximity-led) and spawns
@@ -1592,7 +1664,7 @@ fn discover_worker_slots(
         workplaces += 1;
         for &stand in candidates.iter().take(want) {
             // Stand on the ground at the cell; face the footprint centroid.
-            let y = editor.world().get_ocean_floor_height_at(stand);
+            let Some(y) = editor.world().get_ocean_floor_height_at(stand) else { continue; };
             let stand3 = Point3D::new(stand.x, y, stand.y);
             let centre3 = Point3D::new(centroid.x, y, centroid.y);
             let facing = yaw_toward(stand3, centre3);

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -11,7 +11,7 @@ use crate::generator::placement::{resolve_rural_production, try_place_rural, Pla
 use crate::generator::resource_chain::paint_production_area_for;
 use crate::generator::terrain::{flatten_urban_area, force_height, log_trees};
 use crate::geometry::{Point2D, Point3D};
-use crate::minecraft::Block;
+use crate::minecraft::{Block, Color};
 use crate::noise::{Seed, RNG};
 
 /// Full town-generation pipeline: feathered urban flatten + tiered A* road
@@ -27,6 +27,47 @@ use crate::noise::{Seed, RNG};
 /// `max(1, round(beds * POPULATION_PER_BED))`, so a single-bed house houses ~2
 /// and a double bed (which sleeps two) ~3 — enough to read as lived-in.
 const POPULATION_PER_BED: f32 = 1.5;
+
+/// The settlement's colour identity. Picked once per town from the culture's
+/// curated [`Culture::color_pool`], it gives the town two recurring colours plus
+/// a unique family colour per manor, so a street reads as a coherent palette
+/// with two dominant hues and occasional variety rather than 16 random dyes.
+struct ColorScheme {
+    /// The two recurring town colours: `town[0]` is dominant, `town[1]` second.
+    town: [Color; 2],
+    /// One family colour per manor (`MANOR_CAP` entries), handed out in
+    /// placement order. Drawn freely from the pool — they may coincide with a
+    /// town colour, but never with each other.
+    manor: Vec<Color>,
+    /// The full culture pool, sampled for the occasional off-scheme accent.
+    pool: Vec<Color>,
+}
+
+impl ColorScheme {
+    /// Pick two distinct town colours and `manor_count` distinct manor colours
+    /// from the culture pool. The pool always has ≥ 4 entries (see
+    /// `Culture::color_pool`), so the distinct draws never run dry.
+    fn new(culture: crate::generator::buildings_v2::Culture, manor_count: usize, rng: &mut RNG) -> Self {
+        let pool = culture.color_pool();
+        let mut town_pick = pool.clone();
+        rng.shuffle(&mut town_pick);
+        let town = [town_pick[0], town_pick[1 % town_pick.len()]];
+        let mut manor_pick = pool.clone();
+        rng.shuffle(&mut manor_pick);
+        let manor: Vec<Color> = manor_pick.into_iter().take(manor_count.max(1)).collect();
+        Self { town, manor, pool }
+    }
+
+    /// A colour for one ordinary building: 50% the dominant town colour, 25% the
+    /// second town colour, 25% a random pool colour for variety.
+    fn next_color(&self, rng: &mut RNG) -> Color {
+        match rng.rand_i32_range(0, 100) {
+            0..=49 => self.town[0],
+            50..=74 => self.town[1],
+            _ => *rng.choose(&self.pool),
+        }
+    }
+}
 
 pub async fn generate_town(
     editor: &mut Editor,
@@ -597,17 +638,74 @@ pub async fn generate_town(
         } else {
             (eligible_for_band(&collector_band), 1, "collector (arterial empty)")
         };
-    let manor_lots: HashSet<usize> = {
-        let mut pool = eligible.clone();
-        rng.derive().shuffle(&mut pool);
-        pool.into_iter().take(MANOR_CAP).collect()
-    };
-    println!(
-        "Manor pre-pass: {} {}-eligible lots, chose {} to host Manors",
-        eligible.len(),
-        manor_tier_label,
-        manor_lots.len(),
-    );
+    // Japanese manors are always engawa, which insets the interior by 2 cells a
+    // side and so makes the default Manor footprint feel cramped. For that
+    // culture only, run a candidate scan: dry-evaluate every eligible lot's manor
+    // tier, find the slice with the largest *usable interior* (floorspace left
+    // after the veranda inset), and build the two best at a widened, forced size.
+    // Other cultures keep the original behaviour — two random eligible lots, the
+    // standard Manor range, default random placement.
+    #[derive(Clone, Copy)]
+    struct ManorChoice { frontage_idx: usize, cursor: i32, fw: i32, depth: i32, score: i32 }
+    let (manor_lots, manor_choices): (HashSet<usize>, HashMap<usize, ManorChoice>) =
+        if culture == Culture::Japanese {
+            const MANOR_MIN_FIT_DEPTH: i32 = 5; // mirrors MIN_FIT_DEPTH in the build loop
+            // Widened range for engawa manors so the picked spot yields a grander
+            // hall once the veranda eats its ring. Engawa-only — does not touch
+            // the culture-agnostic `SizeClass::Manor` range other cultures use.
+            const ENGAWA_MANOR_FW: std::ops::RangeInclusive<i32> = 11..=14;
+            const ENGAWA_MANOR_DEPTH_HI: i32 = 16;
+            let manor_band: &HashSet<Point2D> =
+                if manor_tier_idx == 0 { &arterial_band } else { &collector_band };
+            let mut best_by_lot: Vec<(usize, ManorChoice)> = Vec::new();
+            for &lot_idx in &eligible {
+                let Some(plot) = plot_from_block(&sub_blocks[lot_idx]) else { continue; };
+                let mut best: Option<ManorChoice> = None;
+                for (fi, frontage) in frontage_from_roads(&sub_blocks[lot_idx], manor_band).into_iter().enumerate() {
+                    let chain_len = frontage.cells.len() as i32;
+                    let mut cursor = 0;
+                    while cursor + *ENGAWA_MANOR_FW.start() <= chain_len {
+                        // Largest front width that fits at this cursor, then the
+                        // deepest depth that fits — the biggest box this slice holds.
+                        for fw in ENGAWA_MANOR_FW.rev() {
+                            if cursor + fw > chain_len { continue; }
+                            let chain_slice = &frontage.cells[cursor as usize..(cursor + fw) as usize];
+                            let Some(depth) = (MANOR_MIN_FIT_DEPTH..=ENGAWA_MANOR_DEPTH_HI).rev()
+                                .find(|&d| plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, d)))
+                            else { continue; };
+                            // Usable interior after the 2-cell engawa inset a side.
+                            let score = (fw - 4).max(0) * (depth - 4).max(0);
+                            if best.map_or(true, |b| score > b.score) {
+                                best = Some(ManorChoice { frontage_idx: fi, cursor, fw, depth, score });
+                            }
+                            break; // largest fw at this cursor found
+                        }
+                        cursor += 1;
+                    }
+                }
+                if let Some(c) = best { best_by_lot.push((lot_idx, c)); }
+            }
+            // Highest usable interior first; lot index breaks ties for determinism.
+            best_by_lot.sort_by(|a, b| b.1.score.cmp(&a.1.score).then(a.0.cmp(&b.0)));
+            best_by_lot.truncate(MANOR_CAP);
+            println!(
+                "Manor pre-pass (engawa scan): {} {}-eligible lots, chose {} by largest interior (scores {:?})",
+                eligible.len(), manor_tier_label, best_by_lot.len(),
+                best_by_lot.iter().map(|(_, c)| c.score).collect::<Vec<_>>(),
+            );
+            let choices: HashMap<usize, ManorChoice> = best_by_lot.iter().copied().collect();
+            let lots: HashSet<usize> = choices.keys().copied().collect();
+            (lots, choices)
+        } else {
+            let mut pool = eligible.clone();
+            rng.derive().shuffle(&mut pool);
+            let lots: HashSet<usize> = pool.into_iter().take(MANOR_CAP).collect();
+            println!(
+                "Manor pre-pass: {} {}-eligible lots, chose {} to host Manors",
+                eligible.len(), manor_tier_label, lots.len(),
+            );
+            (lots, HashMap::new())
+        };
     // Iterate manor-lots first (in shuffled order), then everything else in
     // natural sub_block order. "Before the rest of the houses" is enforced
     // by the iteration order alone — no separate code path.
@@ -616,6 +714,17 @@ pub async fn generate_town(
         .copied()
         .chain((0..sub_blocks.len()).filter(|i| !manor_lots.contains(i)))
         .collect();
+
+    // Town colour identity: two recurring colours sampled per ordinary building
+    // (50/25/25 with a random accent) plus a unique family colour per manor. A
+    // dedicated derived RNG keeps colour draws from shifting the placement
+    // streams. The two town colours feed the settlement namer further below.
+    let color_scheme = ColorScheme::new(culture, MANOR_CAP, &mut rng.derive());
+    let mut color_rng = rng.derive();
+    println!(
+        "Town colours: dominant={:?}, second={:?}; manor family colours={:?}",
+        color_scheme.town[0], color_scheme.town[1], color_scheme.manor,
+    );
 
     let mut total_buildings = 0usize;
     // Per-house NPC anchors + bed-derived population budget, gathered from every
@@ -667,38 +776,73 @@ pub async fn generate_town(
 
         'tier_loop: for (ti, (band, pool)) in tiers_local.iter().enumerate() {
             let min_front = pool.iter().map(|s| *s.front_width_range().start()).min().unwrap_or(0);
-            for frontage in frontage_from_roads(lot, band) {
+            for (fi, frontage) in frontage_from_roads(lot, band).into_iter().enumerate() {
                 tier_cells[ti] += frontage.cells.len();
                 tier_frontage[ti].extend(&frontage.cells);
                 let chain_len = frontage.cells.len() as i32;
                 if chain_len < min_front { tier_short[ti] += 1; continue; }
-                let mut cursor: i32 = if min_front > 1 { rng.rand_i32_range(0, min_front) } else { 0 };
+                // On a manor lot's manor tier, place the one manor the scan sized
+                // at its chosen slice; skip every other frontage of that tier so
+                // no second, smaller manor gets seated.
+                let manor_here: Option<ManorChoice> = if is_manor_lot && ti == manor_tier_idx {
+                    match manor_choices.get(&lot_idx) {
+                        // Engawa scan picked this lot: build only at its chosen
+                        // slice, skipping the tier's other frontages.
+                        Some(c) if c.frontage_idx == fi => Some(*c),
+                        Some(_) => continue,
+                        // No scan (non-engawa culture): fall through to the
+                        // default random Manor placement on this tier.
+                        None => None,
+                    }
+                } else {
+                    None
+                };
+                let mut cursor: i32 = match manor_here {
+                    Some(c) => c.cursor,
+                    None => if min_front > 1 { rng.rand_i32_range(0, min_front) } else { 0 },
+                };
                 // Shallowest depth we'll accept on a slice that can't take the
                 // rolled depth — lets diagonal frontage (where an axis-aligned
                 // rect overruns the staircased ribbon) still seat a house.
                 const MIN_FIT_DEPTH: i32 = 5;
                 while cursor + min_front <= chain_len {
-                    let size_class = *rng.choose(pool);
-                    let fw = rng.rand_i32_range(*size_class.front_width_range().start(), *size_class.front_width_range().end() + 1);
-                    let max_depth = rng.rand_i32_range(*size_class.depth_range().start(), *size_class.depth_range().end() + 1);
-                    if cursor + fw > chain_len { cursor += 1; continue; }
+                    // A scanned manor forces its size + slice; everything else
+                    // rolls a size from the tier pool and the deepest fitting depth.
+                    let size_class = match manor_here {
+                        Some(_) => SizeClass::Manor,
+                        None => *rng.choose(pool),
+                    };
+                    let fw = match manor_here {
+                        Some(c) => c.fw,
+                        None => rng.rand_i32_range(*size_class.front_width_range().start(), *size_class.front_width_range().end() + 1),
+                    };
+                    if cursor + fw > chain_len {
+                        if manor_here.is_some() { break; }
+                        cursor += 1; continue;
+                    }
                     let chain_slice = &frontage.cells[cursor as usize..(cursor + fw) as usize];
-                    // Square-frontage bias: with the culture's square chance,
-                    // make the house a square (depth = front width) if it fits,
-                    // so it gets a dome. Guarded so a 0 bias never draws RNG.
-                    // Otherwise pick the deepest depth (down to MIN_FIT_DEPTH)
-                    // that fits, shrinking the house to hug a diagonal ribbon.
-                    let want_square = culture.square_bias() > 0
-                        && rng.percent(culture.square_bias())
-                        && plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, fw));
-                    let depth = if want_square {
-                        fw
-                    } else if let Some(d) = (MIN_FIT_DEPTH..=max_depth).rev()
-                        .find(|&d| plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, d)))
-                    {
-                        d
-                    } else {
-                        tier_unfit[ti] += 1; cursor += 1; continue;
+                    let depth = match manor_here {
+                        Some(c) => c.depth,
+                        None => {
+                            // Square-frontage bias: with the culture's square chance,
+                            // make the house a square (depth = front width) if it fits,
+                            // so it gets a dome. Guarded so a 0 bias never draws RNG.
+                            // Otherwise pick the deepest depth (down to MIN_FIT_DEPTH)
+                            // that fits, shrinking the house to hug a diagonal ribbon.
+                            let max_depth = rng.rand_i32_range(*size_class.depth_range().start(), *size_class.depth_range().end() + 1);
+                            let want_square = culture.square_bias() > 0
+                                && rng.percent(culture.square_bias())
+                                && plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, fw));
+                            if want_square {
+                                fw
+                            } else if let Some(d) = (MIN_FIT_DEPTH..=max_depth).rev()
+                                .find(|&d| plot.is_rect_usable(&rect_from_frontage(chain_slice, frontage.outward, d)))
+                            {
+                                d
+                            } else {
+                                tier_unfit[ti] += 1; cursor += 1; continue;
+                            }
+                        }
                     };
                     let rect = rect_from_frontage(chain_slice, frontage.outward, depth);
                     // The frontage rect becomes the core; try to grow wings
@@ -708,10 +852,22 @@ pub async fn generate_town(
 
                     // Desert keeps a uniform sandstone palette; other cultures
                     // roll wood/stone/roof variants per house for variety.
-                    let palette = match culture {
+                    let mut palette = match culture {
                         Culture::Desert => base_palette.clone(),
                         _ => roll_palette(&mut rng, &base_palette, &data, &wood_ids, &stone_ids, &roof_ids),
                     };
+                    // Apply the town colour identity: a manor flies its unique
+                    // family colour; every other building draws from the weighted
+                    // town scheme. This `primary_color` then tints the building's
+                    // dyed accents (banners, beds, carpets) via the recolour pass.
+                    let family_color: Option<Color> = if size_class == SizeClass::Manor {
+                        color_scheme.manor.get(manors_placed).copied()
+                    } else {
+                        None
+                    };
+                    palette.primary_color = Some(
+                        family_color.unwrap_or_else(|| color_scheme.next_color(&mut color_rng)),
+                    );
                     // Roof style weighted by culture + size (irimoya skews to the
                     // grander buildings; see `roof_styles_for`).
                     let roof_styles = culture.roof_styles_for(size_class);
@@ -760,6 +916,15 @@ pub async fn generate_town(
                     let mut bctx_editor = BuildCtx::new(editor, &data, &palette, &mut rng);
                     match build_house(&mut bctx_editor, footprint, &bctx, plot_bounds).await {
                         Ok(output) => {
+                            // A manor flies its family colour: banners flanking
+                            // the front door so the street reads the household
+                            // before you step inside. Other buildings carry their
+                            // colour only on interior accents.
+                            if let Some(color) = family_color {
+                                crate::generator::buildings_v2::exterior::place_family_banner(
+                                    &mut bctx_editor, &output.wall_segs, color,
+                                ).await;
+                            }
                             // Population budget tracks sleeping capacity, not bed
                             // furniture: a double/canopy bed sleeps two. Each
                             // bed-tagged item's capacity is its number of
@@ -787,6 +952,7 @@ pub async fn generate_town(
                                 population,
                                 wealth: crate::generator::population::Wealth::from_size_class(size_class),
                                 pos: output.footprint.bounds().midpoint(),
+                                family_color,
                             });
                             // Mark every rect in the footprint (core + wings)
                             // as used so subsequent placements on this lot
@@ -832,6 +998,9 @@ pub async fn generate_town(
                         Err(msg) => {
                             tier_fail[ti] += 1;
                             log::warn!("placement build_house failed: {}", msg);
+                            // A scanned manor gets one shot; on failure give up its
+                            // tier rather than retrying the forced size shifted over.
+                            if manor_here.is_some() { continue 'tier_loop; }
                             cursor += 1;
                         }
                     }
@@ -1322,13 +1491,13 @@ pub async fn generate_town(
     // Requires `enable-command-block=true` on the server.
     {
         let mut name_rng = RNG::new(seed).derive();
-        let name = crate::generator::naming::generate_settlement_name(
-            editor.world(), &urban, &civic_features, culture, &mut name_rng,
+        let named = crate::generator::naming::generate_settlement_name(
+            editor.world(), &urban, &civic_features, culture, &color_scheme.town, &mut name_rng,
         );
         crate::generator::welcome::place_welcome_title(
-            editor, &urban, &name, "Welcome, traveller",
+            editor, &urban, &named.name, &named.subtitle,
         ).await;
-        println!("Placed welcome-title sensor for \"{}\"", name);
+        println!("Placed welcome-title sensor for \"{}\" ({})", named.name, named.subtitle);
     }
 
     editor.flush_buffer().await;

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -45,7 +45,7 @@ pub async fn feathered_flatten(
     // Natural surface height at each region cell (skipping tree canopy).
     let natural: HashSet<Point3D> = region
         .iter()
-        .map(|p| editor.world().add_non_tree_height(*p))
+        .filter_map(|p| editor.world().add_non_tree_height(*p))
         .collect();
 
     // Smoothed target surface: repeated wide averaging flattens local relief
@@ -149,7 +149,9 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
         }
         // Heightmap convention (see World::new / blend_terrain): the surface
         // value is the first air block; the top solid sits at `value - 1`.
-        let terrain_y = editor.world().get_ocean_floor_height_at(xz);
+        let Some(terrain_y) = editor.world().get_ocean_floor_height_at(xz) else {
+            continue;
+        };
         let target_y = point.y;
 
         // Keep the terraformed cap in the natural surface material: grass stays
@@ -250,9 +252,9 @@ pub async fn smooth_terrain(points: &HashSet<Point2D>, strength: f32, editor: &m
     let points_3d: HashSet<Point3D> = points
         .iter()
         .filter(|&&p| !editor.world().is_water(p))
-        .map(|&p| {
-            let y = editor.world().get_non_tree_height(p);
-            Point3D::new(p.x, y, p.y)
+        .filter_map(|&p| {
+            let y = editor.world().get_non_tree_height(p)?;
+            Some(Point3D::new(p.x, y, p.y))
         })
         .collect();
 

--- a/src/generator/terrain/test.rs
+++ b/src/generator/terrain/test.rs
@@ -165,7 +165,9 @@ mod tests {
             planted.push(c);
 
             let tree = SPECIES[rng.rand_i32(SPECIES.len() as i32) as usize];
-            let height = editor.world().get_ocean_floor_height_at(c);
+            let Some(height) = editor.world().get_ocean_floor_height_at(c) else {
+                continue;
+            };
             generate_tree_feature(tree, &editor, Point3D::new(c.x, height, c.y), &mut rng)
                 .await
                 .expect("place feature failed");

--- a/src/generator/terrain/tree_cutter.rs
+++ b/src/generator/terrain/tree_cutter.rs
@@ -32,7 +32,9 @@ pub fn group_trees(cells: &HashSet<Point2D>, editor: &Editor) -> Vec<TreeGroup> 
         .iter()
         .copied()
         .filter(|&p| {
-            let base_y = world.get_non_tree_height(p);
+            let Some(base_y) = world.get_non_tree_height(p) else {
+                return false;
+            };
             editor.get_block(p.add_y(base_y)).id.is_log()
         })
         .collect();
@@ -70,7 +72,9 @@ pub fn group_trees(cells: &HashSet<Point2D>, editor: &Editor) -> Vec<TreeGroup> 
         if trunk_cells.contains(&p) {
             continue; // already owned by its trunk group
         }
-        let top_y = world.get_motion_blocking_height_at(p) - 1;
+        let Some(top_y) = world.get_motion_blocking_height_at(p).map(|h| h - 1) else {
+            continue; // out of bounds — not our cell
+        };
         if !editor.get_block(p.add_y(top_y)).id.is_tree() {
             continue; // not a canopy cell
         }
@@ -88,7 +92,10 @@ pub fn group_trees(cells: &HashSet<Point2D>, editor: &Editor) -> Vec<TreeGroup> 
 
 pub async fn log_stems(editor: &Editor, points: HashSet<Point2D>) {
     for point in points {
-        let height = editor.world().get_height_at(point) - 1; // checking ground
+        let Some(height) = editor.world().get_height_at(point) else {
+            continue;
+        };
+        let height = height - 1; // checking ground
         let mut block_id = editor.get_block(Point3D::new(point.x, height, point.y)).id;
 
         if !block_id.is_tree() {
@@ -129,7 +136,9 @@ pub async fn log_trees(editor: &Editor, points: HashSet<Point2D>) {
 
     // 1. Seed from every log in each input column (full-depth scan, no window).
     for &point in &points {
-        let top = editor.world().get_motion_blocking_height_at(point) - 1;
+        let Some(top) = editor.world().get_motion_blocking_height_at(point).map(|h| h - 1) else {
+            continue; // out of bounds — no column to scan
+        };
         for y in (top - MAX_SCAN_DEPTH..=top).rev() {
             let pos = Point3D::new(point.x, y, point.y);
             // `try_get_block`, not `get_block`: the deep scan can run past the world
@@ -170,7 +179,9 @@ pub async fn log_trees(editor: &Editor, points: HashSet<Point2D>) {
     //    dirt back to grass. No fixed window, so a log left low under an overhang
     //    is reached.
     for &point in &columns {
-        let top = editor.world().get_motion_blocking_height_at(point) - 1;
+        let Some(top) = editor.world().get_motion_blocking_height_at(point).map(|h| h - 1) else {
+            continue; // out of bounds — not our column
+        };
         if !editor.get_block(point.add_y(top)).id.is_tree() {
             continue; // column surface isn't a tree — leave it untouched
         }

--- a/src/generator/welcome.rs
+++ b/src/generator/welcome.rs
@@ -131,7 +131,9 @@ pub async fn place_welcome_title(
 
     // Bury at the town centre, still inside a chunk that loads when players are
     // in town.
-    let surface_y = editor.world().get_height_at(centre);
+    let Some(surface_y) = editor.world().get_height_at(centre) else {
+        return;
+    };
     let base = Point3D::new(centre.x, surface_y - BURY_DEPTH, centre.y);
 
     // Chain (west→east): subtitle → title → tag. Each fires the next on the same

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,14 +79,29 @@ async fn run_generation(server: &visualizer::VisualizerServer) {
     server.update_phase(visualizer::GenerationPhase::Done);
 }
 
+/// A fresh seed for an interactive run, taken from the wall clock. Generation is
+/// fully deterministic in the seed, so the value printed by [`run_generation_once`]
+/// reproduces the exact town (pass it to `generate_town` to rebuild it).
+fn random_seed() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(12345)
+}
+
 async fn run_generation_once() {
     let provider = GDMCHTTPProvider::new();
     let world = World::new(&provider).await.unwrap();
     let mut editor = world.get_editor();
+    // Random per-run seed so each interactive run is a different town; printed so
+    // a good one can be reproduced. `generate_town` takes the seed as a parameter,
+    // so tests can still pin it to a fixed value for determinism.
+    let seed = crate::noise::Seed(random_seed());
+    println!("Generating town with seed {}", seed.0);
     crate::generator::settlement::generate_town(
         &mut editor,
-        crate::noise::Seed(12345),
-        crate::generator::buildings_v2::Culture::Japanese,
+        seed,
+        crate::generator::buildings_v2::Culture::Medieval,
     ).await;
 }
 

--- a/src/minecraft/color.rs
+++ b/src/minecraft/color.rs
@@ -63,6 +63,26 @@ impl Into<String> for Color {
     }
 }
 
+impl Color {
+    /// An English surname root for this colour, or `None` for colours that don't
+    /// read as a family name. Combined with a place-name suffix (`-well`,
+    /// `-wood`, …) to mint a colour-derived house name — `Black` + `well` =
+    /// `Blackwell`. Used to tie a manor's family name to its family colour.
+    pub fn surname_root(self) -> Option<&'static str> {
+        match self {
+            Color::Black => Some("Black"),
+            Color::White => Some("White"),
+            Color::Gray | Color::LightGray => Some("Grey"),
+            Color::Green => Some("Green"),
+            Color::Brown => Some("Brown"),
+            Color::Red => Some("Red"),
+            Color::Yellow => Some("Gold"),
+            Color::Blue => Some("Blue"),
+            _ => None,
+        }
+    }
+}
+
 const SWAPPABLE_STRINGS: &[&str] = &[
     "wool",
     "carpet",

--- a/src/util/compass.rs
+++ b/src/util/compass.rs
@@ -2,7 +2,7 @@ use crate::{editor::Editor, geometry::{EAST, NORTH, SOUTH, UP, WEST}};
 
 pub async fn build_compass(editor: &Editor) {
     let midpoint = editor.world().world_rect_2d().size / 2;
-    let point = editor.world().add_height(midpoint);
+    let Some(point) = editor.world().add_height(midpoint) else { return; };
     let offset = UP * 30;
     let point = point + offset;
 


### PR DESCRIPTION
Bundles the `jd/colours` branch: the town colour-identity work plus an out-of-bounds-safety refactor of the World map accessors, medieval jetty wiring, and manor name-sign/heraldry WIP.

## OOB-safe World map accessors (panic elimination)
World's 2D-map accessors (`get_height_at`, `get_ground_block`, `get_ocean_floor_height_at`, `get_motion_blocking_height_at`, `get_surface_biome_at`, `get_non_tree_height`, `add_height`, `add_non_tree_height`, parcel/district/claim lookups) panicked on out-of-bounds access. The nastiest case: a *negative* coordinate, where `point.x as usize` wraps to a ~4-billion index and panics instantly — so any neighbour/road-band probe past the build edge could crash a whole generation run.

- All map reads now funnel through one checked `cell_2d` helper that rejects negative **and** past-edge coords and returns `Option`. It's structurally impossible to panic-index those maps now.
- OOB access is traced (`RUST_LOG=trace`) — quiet in normal runs (edge-probing is expected), but leaves a coordinate trail when chasing a "why is this silently missing?" bug.
- The `.expect()` chains on `get_block`/`get_biome` (`is_water_3d`, surface biome, tree-walking, world construction) degrade gracefully instead of aborting.
- ~210 call sites updated to skip-on-`None` / propagate. **In-bounds behaviour is unchanged**; only genuine OOB now skips instead of panicking.

## Medieval jetty
Wired `jetty_chance` into the settlement build loop — medieval buildings jetty their upper floors (2/3 chance, still frame-gated on shape/floor-count/plot fit). Desert/Japanese unaffected (engawa stays the Japanese signature; the two are mutually exclusive by culture).

## Also included
- Town colour-identity work (commit 3290874).
- Manor name-sign / heraldry WIP: per-family banner patterns (`heraldry.rs`, `data/banners.yaml`).

## Testing
- `cargo check` + `cargo check --tests` clean.
- `build_furnished_houses_offline` and all 4 `pipeline_invariants_property_test*` (incl. jetty/engawa/multirect) pass.
- Reviewed the OOB diff with focused finders (world.rs core, judgment-call sites, jetty math, collection-misalignment) — no correctness bugs surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)