### PR TITLE
Building styles, per-district palettes, climate-driven culture & town character

### DIFF
--- a/data/materials/misc/green_terracotta.json
+++ b/data/materials/misc/green_terracotta.json
@@ -1,0 +1,7 @@
+{
+    "id" : "green_terracotta",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:green_terracotta"
+    }
+}

--- a/data/materials/misc/light_blue_terracotta.json
+++ b/data/materials/misc/light_blue_terracotta.json
@@ -1,0 +1,7 @@
+{
+    "id" : "light_blue_terracotta",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:light_blue_terracotta"
+    }
+}

--- a/data/materials/misc/orange_terracotta.json
+++ b/data/materials/misc/orange_terracotta.json
@@ -1,0 +1,7 @@
+{
+    "id" : "orange_terracotta",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:orange_terracotta"
+    }
+}

--- a/data/materials/misc/red_concrete.json
+++ b/data/materials/misc/red_concrete.json
@@ -1,0 +1,7 @@
+{
+    "id" : "red_concrete",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:red_concrete"
+    }
+}

--- a/data/materials/wood/log/acacia_log.json
+++ b/data/materials/wood/log/acacia_log.json
@@ -1,0 +1,8 @@
+{
+    "id" : "acacia_log",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:acacia_log",
+        "shelf" : "minecraft:acacia_shelf"
+    }
+}

--- a/data/materials/wood/log/stripped_mangrove_log.json
+++ b/data/materials/wood/log/stripped_mangrove_log.json
@@ -1,0 +1,8 @@
+{
+    "id" : "stripped_mangrove_log",
+    "connections" : {},
+    "blocks" : {
+        "block" : "minecraft:stripped_mangrove_log",
+        "shelf" : "minecraft:mangrove_shelf"
+    }
+}

--- a/data/npcs.yaml
+++ b/data/npcs.yaml
@@ -199,6 +199,57 @@ cultures:
       - Yuki
       - Yumi
       - Yuriko
+    # Anglicized place-name surnames (same structure as medieval — root +
+    # land-form ending) but themed to Japanese imagery: pine, bamboo, crane,
+    # maple, mist, river. Pine + vale -> Pinevale, Crane + brook -> Cranebrook.
+    surname_prefixes:
+      # — flora —
+      - Pine
+      - Bamboo
+      - Maple
+      - Cherry
+      - Plum
+      - Cedar
+      - Reed
+      - Lotus
+      # — fauna —
+      - Crane
+      - Heron
+      - Sparrow
+      # — element & sky —
+      - Mist
+      - Snow
+      - Moon
+      - Cloud
+      - Frost
+      - Jade
+      - Pearl
+      # — land & water —
+      - River
+      - Stone
+      - East
+      - High
+    surname_suffixes:
+      # — land form —
+      - vale
+      - hill
+      - ridge
+      - field
+      - dale
+      - grove
+      - hollow
+      - moor
+      - rise
+      # — water —
+      - brook
+      - spring
+      - shore
+      - mere
+      - falls
+      # — built —
+      - gate
+      - bridge
+      - garden
   desert:
     # Arabic given names for the desert culture.
     first_names:
@@ -270,6 +321,59 @@ cultures:
       - Zahra
       - Zaynab
       - Zubaida
+    # Anglicized place-name surnames (same structure as medieval — root +
+    # land-form ending) but themed to desert imagery: sand, dune, sun, palm,
+    # amber. Sand + ford -> Sandford, Sun + mere -> Sunmere, Black + sand ->
+    # Blacksand (the manor colour-surname picks up these suffixes too).
+    surname_prefixes:
+      # — terrain (Sand/Dune are suffix-only to avoid "Sandsand") —
+      - Dust
+      - Stone
+      - Salt
+      - Ash
+      - Clay
+      - Rock
+      # — sun & sky —
+      - Sun
+      - Day
+      - Star
+      - Dawn
+      - Fire
+      - Ember
+      # — flora & oasis —
+      - Palm
+      - Reed
+      - Cactus
+      # — quality & beast —
+      - Amber
+      - Gold
+      - Bright
+      - Hawk
+      - Jackal
+    surname_suffixes:
+      # — land form —
+      - reach
+      - ridge
+      - hollow
+      - mere
+      - vale
+      - rise
+      - mount
+      - cliff
+      # — water (rarer, desert oases) —
+      - ford
+      - well
+      - spring
+      - oasis
+      # — built —
+      - gate
+      - stead
+      - hold
+      - watch
+      - bazaar
+      # — terrain —
+      - sand
+      - dune
 
 # Surnames are generated on demand by concatenating a `surname_prefix` (capitalized,
 # noun-like root) with a `surname_suffix` (lowercase place-name ending). All
@@ -278,6 +382,11 @@ cultures:
 # suffixes the effective name space is ~875 surnames, so collisions across a
 # town of ~120 residents are rare. See `Npc.surname` and `roll_surname` in
 # `src/generator/population.rs`.
+#
+# These top-level pools are the MEDIEVAL / default surname vibe. Cultures that
+# define their own `surname_prefixes`/`surname_suffixes` under `cultures.<name>`
+# (japanese, desert) override these for that culture; the structure is the same
+# (root + land-form ending), only the imagery changes.
 surname_prefixes:
   # — trees & growth —
   - Ash
@@ -384,6 +493,20 @@ small_talk:
   - "Market's busy today."
   - "Watch yourself after dark."
   - "Good to see a new face."
+  - "Rain's coming. I can feel it in my knees."
+  - "Another day, another copper, eh?"
+  - "You're not from these parts, are you?"
+  - "Mind the mud by the gate — it'll have your boots."
+  - "Quiet morning. I like it that way."
+  - "Off to the market? Tell them I sent you."
+  - "Bless you and yours, traveller."
+  - "Don't trust the weather this time of year."
+  - "Long road behind you, by the look of it."
+  - "Stay for the festival, if you can. It's a sight."
+  - "The harvest's been kind to us this year."
+  - "Keep your purse close on the square, friend."
+  - "Cold enough to freeze the ale, isn't it?"
+  - "You'll find no better folk than ours, I'll say that."
 
 # Context dialogue pools, keyed by activity. A furniture anchor names one of
 # these keys (in its `anchors:` block); the same key can be shared by several
@@ -396,43 +519,91 @@ dialogue:
     - "A good stew needs a slow flame."
     - "Smells done, doesn't it?"
     - "Bread's in. Come back at dusk."
+    - "My mother's recipe, this. Never fails."
+    - "A pinch more salt and it's perfect."
+    - "Hungry work, feeding a whole house."
+    - "Taste that — go on, tell me it's not the best in town."
+    - "The trick is to never rush a roast."
+    - "Wood's near gone. I'll need more before nightfall."
+    - "Stir it slow, or it catches and burns."
+    - "There's enough here for an army, near enough."
   # A child at the hearth (an `any_age` cooking slot — house/rooftop only).
   cooking_child:
     - "Is it ready yet? I'm starving!"
     - "Can I stir it? Pleeease?"
     - "It smells so good. Just one taste?"
     - "Ow — the fire's too hot to sit near."
+    - "Why does it take soooo long?"
+    - "I licked the spoon. Don't tell!"
+    - "Can I have the crusty bit at the end?"
+    - "I'm helping! See? I'm a good helper."
+    - "What's that one? It looks funny."
   crafting:
     - "Steady hands, that's the trick."
     - "One more and it's finished."
     - "Measure twice, they always say."
     - "This'll fetch a fair price."
     - "Honest work, this."
+    - "Learned this trade from my father, I did."
+    - "No shortcuts. Folk can always tell."
+    - "A blister or two, but worth it in the end."
+    - "Good tools make half the work."
+    - "I could do this with my eyes shut by now."
+    - "Cheap goods break twice. Mine break never."
+    - "There's a rhythm to it, once you find it."
+    - "Slow and right beats quick and wrong."
   reading:
     - "Shh — I've nearly found the passage."
     - "So much here I'll never read it all."
     - "A quiet corner and a good book. Bliss."
     - "Now where did I leave off..."
+    - "This author writes a fine line, I'll grant."
+    - "There's whole worlds in these pages, you know."
+    - "One more chapter. Just one, I promise."
+    - "The ink's faded here. Old, this one."
+    - "I'd trade a week's wages for the ending."
+    - "Quiet, please. The hero's in peril."
   # A child with a book at an `any_age` reading slot (shelf, lectern, desk).
   reading_child:
     - "Look at the pictures in this one!"
     - "What's this big word mean?"
     - "I read a whole page all by myself!"
     - "Is this the one with the sea monster?"
+    - "Read me the dragon part again!"
+    - "Are there any with knights in them?"
+    - "I'm getting better at the long words!"
+    - "Does this story have a happy ending?"
   sorting:
     - "Swear I had more of these yesterday."
     - "Everything in its place, that's my way."
     - "Plenty stocked for the winter."
     - "Now where did that get to?"
+    - "A tidy store is a happy store."
+    - "Count it twice, trust it once."
+    - "Mice have been at the grain again, the wretches."
+    - "I know exactly where everything is. Mostly."
+    - "Stack it high and stack it straight."
+    - "Inventory's the dullest day of the week."
   conversation:
     - "You won't believe what I heard at the market."
     - "It's been too long, friend."
     - "Between you and me..."
+    - "Now don't go repeating this, but..."
+    - "Sit, sit — I've news worth hearing."
+    - "Have you a moment? I've much to tell."
+    - "You always did know how to listen."
+    - "Where was I? Ah, yes..."
   resting:
     - "Long day. I've earned a sit-down."
     - "Just turning in. Quiet night, I hope."
     - "These old bones need their rest."
     - "Wake me at first light, would you?"
+    - "Ahh. Off my feet at last."
+    - "A warm bed and a full belly. What more's there?"
+    - "I'll just close my eyes a moment..."
+    - "Tomorrow's troubles can wait for tomorrow."
+    - "Nothing like a sit-down after a hard day."
+    - "Pull up a stool. Rest those legs."
   # Spoken by a child filling a `resting` slot (an `any_age` bed). When a
   # `<key>_child` pool exists, children draw from it instead of the adult lines.
   resting_child:
@@ -440,6 +611,10 @@ dialogue:
     - "Can I stay up just a little longer?"
     - "Five more minutes, pleeease?"
     - "Tell me the one about the dragon again!"
+    - "But I'm NOT tired. ...yawn."
+    - "Can I sleep with the candle on?"
+    - "Is it morning yet? ...Aw."
+    - "One more story and I'll go, I promise!"
   # Market vendors hawking their wares from behind the stall counter. Rendered as
   # a "yelled" bubble — bigger and visible from across the square.
   market_cry:
@@ -451,6 +626,14 @@ dialogue:
     - "Hot from the oven — come and get it!"
     - "Half price before noon! Don't miss out!"
     - "Come buy, come buy! Won't be here long!"
+    - "Last of the season — they'll be gone by dark!"
+    - "Quality goods, fair prices, no haggling needed!"
+    - "Taste before you buy! Go on, no charge!"
+    - "Straight from the farm this morning, still dewy!"
+    - "A bargain like this won't come twice, friend!"
+    - "Everything must go! Make me an offer!"
+    - "You there! Yes, you — come see what I've got!"
+    - "Finest in the land, and I'll stake my name on it!"
   # A performer up on the stage, calling out over the crowd. Also yelled.
   performing:
     - "Gather round, good folk, gather round!"
@@ -459,6 +642,12 @@ dialogue:
     - "One night only — you'll tell your grandchildren!"
     - "Strike up the tune! Let's have a dance!"
     - "Hear ye! Hear ye! A story worth the telling!"
+    - "Clap along, good people — you know this one!"
+    - "A penny in the hat keeps the song coming!"
+    - "Stay your feet a moment and hear a marvel!"
+    - "From lands afar I bring you this tale!"
+    - "Laugh, weep, and cheer — it's all to come!"
+    - "Never has the square seen the like of this!"
   # Idle onlookers browsing the stalls or watching the show.
   browsing:
     - "Now that's a fair price, I'll give them that."
@@ -467,6 +656,12 @@ dialogue:
     - "Busy on the square today, isn't it?"
     - "Wonder if they've any of those left..."
     - "My coin's near spent already."
+    - "I'll think on it and come back. Maybe."
+    - "Highway robbery, that price. Lovely though."
+    - "Just looking, just looking."
+    - "The cloth here's finer than last market."
+    - "Where's that smell of pies coming from?"
+    - "Half the town's out today, by the look of it."
   # A child loose in the market crowd (a `ChildOnly` onlooker slot).
   browsing_child:
     - "Can we get the honey cakes? Pleeease?"
@@ -474,6 +669,11 @@ dialogue:
     - "I want to see the puppets!"
     - "Mama said stay close, but look over there!"
     - "Are those sweets? Can I have one?"
+    - "That man's juggling! Look, look!"
+    - "Can I pet the pony? Just once?"
+    - "I found a coin! Can I spend it?"
+    - "What's THAT? I've never seen one of those!"
+    - "Wait for me! You walk too fast!"
   # Folk loitering at the village well — fetching water, trading gossip.
   at_the_well:
     - "Cold and clear today — good water this year."
@@ -481,11 +681,21 @@ dialogue:
     - "Mind the bucket, the rope's frayed near the top."
     - "Always someone to talk to at the well."
     - "Three trips already and the trough's still low."
+    - "They say this well's never once run dry."
+    - "Best water in the district, this. No question."
+    - "My grandmother fetched from this very well."
+    - "Careful — the stones get slick when it's wet."
+    - "Any news from the road? You hear it all here."
+    - "The whole town passes through here, sooner or later."
   at_the_well_child:
     - "Can I drop the bucket down? I'll be careful!"
     - "Hellooo! Hear it echo?"
     - "How deep does it go all the way down?"
     - "I carried the little pail all by myself!"
+    - "Is there a monster at the bottom? There might be!"
+    - "Drop a pebble — listen for the splash!"
+    - "The water's so cold it makes my teeth hurt!"
+    - "Can I have the first drink? Please?"
   # Folk idling around the fountain — resting, chatting, enjoying the spray.
   by_the_fountain:
     - "Nothing finer than the sound of water on a hot day."
@@ -493,22 +703,40 @@ dialogue:
     - "They say a coin in the basin brings luck."
     - "Cooler by the water, isn't it?"
     - "A fine spot to meet a friend."
+    - "I've made a wish here every spring since I was small."
+    - "The masons did fine work, didn't they?"
+    - "Lovers always seem to end up here. Sweet, really."
+    - "I could watch the water all afternoon."
+    - "Mind the children don't fall in, eh?"
   by_the_fountain_child:
     - "Watch me splash! Look, look!"
     - "I threw a coin in — now I get a wish!"
     - "The water's so cold! Feel it!"
     - "Can we stay just a bit longer?"
+    - "I can see my face in the water!"
+    - "Look how many coins are down there!"
+    - "Can I make a wish too? CAN I?"
+    - "I'm gonna catch one of those little fish!"
   # Folk pausing at the monument — paying respects, gazing up at the pillar.
   at_the_monument:
     - "They built it before my grandfather's time, they say."
     - "We owe the old names more than a glance."
     - "Stand a moment. It's only right."
     - "Quiet here. I like to stop and remember."
+    - "My own kin's name is carved here, somewhere."
+    - "Brave folk, the lot of them. We forget too easy."
+    - "I bring a flower every year. Seems the least I can do."
+    - "The stone's worn, but the names hold."
+    - "Hard to imagine the days they speak of."
   at_the_monument_child:
     - "Who's it for? Were they very brave?"
     - "It's so tall! Did giants make it?"
     - "Why do we have to be quiet here?"
     - "I can see the whole square from the steps!"
+    - "What do all the words say? Read them to me!"
+    - "Were there really battles here? Real ones?"
+    - "Can I climb up? Just a little bit?"
+    - "It's older than Grandpa? That's REALLY old."
   # Folk out in a park or garden — strolling, resting on the grass, taking the air.
   in_the_park:
     - "A fine day for a walk in the green."
@@ -517,12 +745,23 @@ dialogue:
     - "Nothing like a bit of shade and birdsong."
     - "Quiet out here, away from the square."
     - "Met my husband under a tree much like that one."
+    - "The blossoms came early this year, didn't they?"
+    - "I bring my needlework out here when it's fine."
+    - "Listen — you can almost forget the town's there."
+    - "Good for the soul, a bit of green."
+    - "The bench is taken? Ah well, the grass will do."
+    - "Watch the bees in the clover. Busy little things."
   in_the_park_child:
     - "Race you to the big tree!"
     - "Look how many flowers! Can I pick one?"
     - "I saw a frog! Over by the water!"
     - "Push me higher — I want to touch the leaves!"
     - "Let's play hide-and-seek in the bushes!"
+    - "I'm gonna climb all the way to the top!"
+    - "Watch me do a cartwheel! Watch!"
+    - "There's a butterfly! After it, quick!"
+    - "Can we have a picnic right here? Can we?"
+    - "I'm a knight and that tree's a dragon!"
   # Guards posted at a gate or on a wall tower, watching the approaches.
   guarding:
     - "State your business at the gate."
@@ -532,6 +771,14 @@ dialogue:
     - "Halt. ...Right, on you go."
     - "Quiet watch tonight, thank the gods."
     - "No weapons drawn inside the walls."
+    - "Papers, if you have them. Just routine."
+    - "Cold night for it. The road's mine till dawn."
+    - "Seen anything on the road we should know of?"
+    - "Trouble's rare here, and we aim to keep it so."
+    - "Behave yourself and we'll get along fine."
+    - "I've stood this post twenty winters now."
+    - "Curfew bell's soon. Best find your bed."
+    - "Long as the lamps stay lit, all's well."
 
 # Multi-person exchanges: each entry is one back-and-forth, its lines handed to
 # a scene's slots in order (line 0 = the opener, line 1 = the reply). Keyed like
@@ -552,6 +799,22 @@ exchanges:
       - "Don't say that too loud — you'll jinx it."
     - - "I heard wolves on the ridge last night."
       - "Best keep the gate barred, then."
+    - - "The tax man's due round again, I hear."
+      - "Already? Where does the year go?"
+    - - "Your garden's coming on a treat this year."
+      - "It's all the rain. Can't take the credit."
+    - - "Did you see the lights over the hills?"
+      - "Aye. Spirits, my mother would've said."
+    - - "The price of salt's gone up again."
+      - "Robbery, that's what it is. Plain robbery."
+    - - "I'm telling you, I saw it with my own eyes."
+      - "You and your tales. Pull the other one."
+    - - "How's the little one? Walking yet?"
+      - "Running, more like. Can't catch her."
+    - - "Heard the old mill's to be rebuilt at last."
+      - "About time. It's stood ruined ten years."
+    - - "Cold's coming early this year, mark me."
+      - "Then I'd best lay in the firewood now."
   # Stage performances, bucketed by cast size. The stage rolls 1–3 performers and
   # staff_scene draws a `performing` entry with exactly that many lines (one per
   # performer). Solos, duets, and trios live side by side here; every line is
@@ -561,6 +824,9 @@ exchanges:
     - - "Gather round, good folk — a tale to chill your very blood!"
     - - "Lend me your ears, and I'll lend you a song you'll never forget!"
     - - "One night only! You'll be telling your grandchildren of this!"
+    - - "Behold! Wonders from lands beyond the farthest sea!"
+    - - "A copper for a song, a silver for a saga — your choice!"
+    - - "Sit you down and let an old fool make you laugh!"
     # — duets (2) —
     - - "Strike up the tune, my friend — let's give them a show!"
       - "Aye! And I'll sing it sweet enough to still the birds!"
@@ -568,6 +834,12 @@ exchanges:
       - "And I the wicked dragon — flee, good people, flee!"
     - - "Step closer for the ballad of the drowned sailor!"
       - "And mind you weep, for it's a sorry end he met!"
+    - - "I'll ask the riddles — see if you can answer!"
+      - "And I'll juggle the apples while you think on it!"
+    - - "Now here's the tale of two foolish brothers!"
+      - "One wise, one daft — and I'll let you guess which I am!"
+    - - "A duel of song! I say the sun's the fairer!"
+      - "And I the moon — now let the crowd decide!"
     # — trios (3) —
     - - "A play in three parts, good people — settle in!"
       - "I am the king, and I have lost my crown!"
@@ -575,6 +847,12 @@ exchanges:
     - - "Step up for the song of the three winds!"
       - "I am the north wind, cold and cruel!"
       - "And I the south — I'll thaw his frozen heart yet!"
+    - - "Hear now the legend of the three brave sisters!"
+      - "I am the eldest, who sailed to slay the beast!"
+      - "And we the younger two, who saved her in the end!"
+    - - "A ballad of the harvest, in three sweet voices!"
+      - "I'll sing the sowing, soft and low!"
+      - "And we the reaping — raise your cups and join us!"
 
 # Gate and tower guard fixture. `employment` is the job label baked onto each
 # guard and shown in the jobs summary; `looks` is the skin pool, rolled per guard

--- a/data/palettes/accents/accent_green_terracotta.json
+++ b/data/palettes/accents/accent_green_terracotta.json
@@ -1,0 +1,4 @@
+{
+  "id" : "accent_green_terracotta",
+  "accent" : "green_terracotta"
+}

--- a/data/palettes/accents/accent_light_blue_terracotta.json
+++ b/data/palettes/accents/accent_light_blue_terracotta.json
@@ -1,0 +1,4 @@
+{
+  "id" : "accent_light_blue_terracotta",
+  "accent" : "light_blue_terracotta"
+}

--- a/data/palettes/accents/accent_orange_terracotta.json
+++ b/data/palettes/accents/accent_orange_terracotta.json
@@ -1,0 +1,4 @@
+{
+  "id" : "accent_orange_terracotta",
+  "accent" : "orange_terracotta"
+}

--- a/data/palettes/desert/desert_prismarine.json
+++ b/data/palettes/desert/desert_prismarine.json
@@ -6,14 +6,13 @@
   "secondary_roof" : "dark_prismarine",
   "primary_wood" : "birch_planks",
   "secondary_wood" : "birch_planks",
-  "wood_pillar" : "stripped_birch_log",
+  "wood_pillar" : "smooth_sandstone",
   "primary_stone" : "smooth_sandstone",
   "secondary_stone" : "cut_sandstone",
-  "flower" : "japanese_flowers",
+  "flower" : "warm_flowers",
 
   "primary_color" : "red",
   "secondary_color" : "white",
-  
 
-  "tags" : ["japanese", "wet"]
+  "tags" : ["desert", "dry"]
 }

--- a/data/palettes/desert/desert_sandstone.json
+++ b/data/palettes/desert/desert_sandstone.json
@@ -6,10 +6,10 @@
   "secondary_roof" : "cut_sandstone",
   "primary_wood" : "birch_planks",
   "secondary_wood" : "birch_planks",
-  "wood_pillar" : "cut_sandstone",
+  "wood_pillar" : "smooth_sandstone",
   "primary_stone" : "smooth_sandstone",
   "secondary_stone" : "cut_sandstone",
-  "flower" : "japanese_flowers",
+  "flower" : "warm_flowers",
   "ground_floor" : "smooth_sandstone",
   "upper_floor" : "cut_sandstone",
 

--- a/data/palettes/japanese/japanese_red_lacquer.json
+++ b/data/palettes/japanese/japanese_red_lacquer.json
@@ -1,0 +1,19 @@
+{
+  "id" : "japanese_red_lacquer",
+
+  "primary_wall" : "red_concrete",
+  "primary_roof" : "warped_planks",
+  "secondary_roof" : "dark_prismarine",
+  "primary_wood" : "dark_oak_planks",
+  "secondary_wood" : "spruce_planks",
+  "ground_floor" : "bamboo_mosaic",
+  "wood_pillar" : "red_concrete",
+  "primary_stone" : "polished_blackstone_bricks",
+  "secondary_stone" : "polished_blackstone",
+  "flower" : "japanese_flowers",
+
+  "primary_color" : "red",
+  "secondary_color" : "white",
+
+  "tags" : ["japanese", "wet"]
+}

--- a/data/palettes/roofs/bamboo_roof.json
+++ b/data/palettes/roofs/bamboo_roof.json
@@ -1,0 +1,6 @@
+{
+  "id" : "bamboo_roof",
+
+  "primary_roof" : "bamboo_mosaic",
+  "secondary_roof" : "bamboo_mosaic"
+}

--- a/data/palettes/roofs/cherry_wood_roof.json
+++ b/data/palettes/roofs/cherry_wood_roof.json
@@ -1,0 +1,6 @@
+{
+  "id" : "cherry_wood_roof",
+
+  "primary_roof" : "cherry_planks",
+  "secondary_roof" : "mangrove_planks"
+}

--- a/data/palettes/wood/acacia.json
+++ b/data/palettes/wood/acacia.json
@@ -3,5 +3,5 @@
 
   "primary_wood": "acacia_planks",
   "secondary_wood": "jungle_planks",
-  "wood_pillar": "stripped_acacia_log"
+  "wood_pillar": "acacia_log"
 }

--- a/src/editor/editor.rs
+++ b/src/editor/editor.rs
@@ -71,6 +71,10 @@ impl Editor {
         self.buffer_size = size;
     }
 
+    pub fn buffer_size(&self) -> usize {
+        self.buffer_size
+    }
+
     /// Controls whether buffered blocks are flushed with block updates on
     /// (`true`, the default) or off. Flushes any pending buffer first so the
     /// switch only affects blocks placed afterwards. Disable around a structure

--- a/src/generator/buildings/placement.rs
+++ b/src/generator/buildings/placement.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::{HashMap, HashSet}, i32};
 
 use strum::IntoEnumIterator;
 
-use crate::{editor::Editor, generator::{BuildClaim, buildings::{BuildingData, Grid, build_floor, build_stairs, foundation::build_foundation, grid::DEFAULT_GRID_CELL_SIZE, roofs::build_roof, set::BuildingSetID, shape::BuildingShape, walls::build_walls}, chronicle::SettlementInfo, data::LoadedData, districts::{DistrictID, replace_ground_smooth}, materials::{MaterialId, MaterialRole, Palette, PaletteId}, nbts::Rotation, style::{DistrictStyle, Style}, terrain::force_height}, geometry::{ Cardinal, Point2D, UP, average_to_neighbours_5_away, get_edge, get_ordered_edge, get_outer_and_inner_points, voronoi_fill_with_recenter}, minecraft::{Biome, BiomeStonetype, BiomeWoodtype, Block}, noise::RNG};
+use crate::{editor::Editor, generator::{BuildClaim, buildings::{BuildingData, Grid, build_floor, build_stairs, foundation::build_foundation, grid::DEFAULT_GRID_CELL_SIZE, roofs::build_roof, set::BuildingSetID, shape::BuildingShape, walls::build_walls}, data::LoadedData, districts::{DistrictID, replace_ground_smooth}, materials::{MaterialId, MaterialRole, Palette, PaletteId}, nbts::Rotation, style::{DistrictStyle, Style}, terrain::force_height}, geometry::{ Cardinal, Point2D, UP, average_to_neighbours_5_away, get_edge, get_ordered_edge, get_outer_and_inner_points, voronoi_fill_with_recenter}, minecraft::{Biome, BiomeStonetype, BiomeWoodtype, Block}, noise::RNG};
 
 use super::BuildingID;
 
@@ -35,7 +35,7 @@ pub fn get_city_blocks_and_off_limits(editor : &mut Editor, rng : &mut RNG) -> (
     (city_blocks, off_limits)
 }
 
-pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &LoadedData, style : Style, core_palettes : Vec<&PaletteId>, settlement_info : &SettlementInfo) {
+pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &LoadedData, style : Style, core_palettes : Vec<&PaletteId>) {
     let mut outers : HashSet<Point2D> = HashSet::new();
     let mut inners : Vec<HashSet<Point2D>> = vec![];
     
@@ -128,7 +128,9 @@ pub async fn place_buildings(editor : &mut Editor, rng : &mut RNG, data : &Loade
     }
     
     let urban_area_edge = get_edge(&editor.world().get_urban_points());
-    smooth_and_pave_road(editor, rng, &outers.difference(&urban_area_edge).cloned().collect(), PavingType::from_biome(settlement_info.top_three_biomes[0].clone())).await;
+    let paving_biome = crate::generator::settlement::dominant_biome(editor.world())
+        .unwrap_or_else(Biome::unknown);
+    smooth_and_pave_road(editor, rng, &outers.difference(&urban_area_edge).cloned().collect(), PavingType::from_biome(paving_biome)).await;
 
     let sets = data.borrow().building_sets.iter().filter(|(_, set)| {
         set.style == style

--- a/src/generator/buildings/test.rs
+++ b/src/generator/buildings/test.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use log::info;
 
-    use crate::{data::Loadable, editor::World, generator::{buildings::{Grid, placement::{place_building, place_buildings}, shape::{BuildingShape, WallPlacement}, stairs::StairPlacement, walls::WallComponent}, chronicle::{SettlementInfo, generate_chronicle}, data::LoadedData, districts::{WallType, build_wall, generate_parcels}, materials::{Material, MaterialId, Placer}, nbts::Structure, style::Style, terrain::log_trees}, geometry::{Cardinal, NORTH, Point3D, UP}, http_mod::GDMCHTTPProvider, noise::RNG, util::init_logger};
+    use crate::{data::Loadable, editor::World, generator::{buildings::{Grid, placement::{place_building, place_buildings}, shape::{BuildingShape, WallPlacement}, stairs::StairPlacement, walls::WallComponent}, chronicle::generate_chronicle, data::LoadedData, districts::{WallType, build_wall, generate_parcels}, materials::{Material, MaterialId, Placer}, nbts::Structure, style::Style, terrain::log_trees}, geometry::{Cardinal, NORTH, Point3D, UP}, http_mod::GDMCHTTPProvider, noise::RNG, util::init_logger};
 
 
     #[tokio::test]
@@ -150,7 +150,6 @@ mod tests {
         let mut rng = RNG::new(32);
 
         generate_parcels(rng.next_i64().into(), &mut editor).await;
-        let mut info = SettlementInfo::new(editor.world());
 
         let data = LoadedData::load().expect("Failed to load generator data");
 
@@ -165,10 +164,12 @@ mod tests {
         let urban_points = &editor.world().get_urban_points();
         log_trees(&mut editor, urban_points.clone()).await;
 
-        place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()], &info).await;
-        info = SettlementInfo::new(editor.world());
+        place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()]).await;
         build_wall(urban_points, &mut editor, &mut rng.derive(), &mut placer, &material, &data.structures, WallType::Palisade, None).await;
-        let _ = generate_chronicle(&mut editor, &mut info).await;
+        let dossier = crate::generator::settlement::minimal_dossier(
+            &editor, crate::generator::buildings_v2::Culture::Medieval, &mut rng.derive(),
+        );
+        let _ = generate_chronicle(&mut editor, &dossier).await;
         editor.flush_buffer().await;
     }
     

--- a/src/generator/buildings_v2/climate.rs
+++ b/src/generator/buildings_v2/climate.rs
@@ -1,0 +1,233 @@
+//! Build-area climate → settlement culture selection.
+//!
+//! A settlement adopts one [`Culture`], chosen from the build area's biome map so
+//! the town fits its surroundings. The mapping:
+//!
+//! - **Arid** (desert, savanna, badlands) → Desert.
+//! - **Tropical** (jungle, swamp, mangrove, lush) → Japanese.
+//! - **Cherry grove** and **bamboo jungle** → Japanese, but weighted *much*
+//!   heavier ([`JAPANESE_SIGNAL_WEIGHT`]) — they're the iconic Japanese
+//!   landmarks, so even a modest grove inside the build area pulls the whole town
+//!   Japanese.
+//! - Everything else — temperate forest/plains and cold/boreal — → Medieval (the
+//!   default), plus oceans/rivers/unknown.
+//!
+//! Selection sums a per-cell culture weight over the whole biome map and makes one
+//! weighted random draw, so a build area straddling biomes leans toward its
+//! dominant climate but can still surface a minority culture — and a heavy cherry/
+//! bamboo cell outweighs many plain ones.
+
+use crate::minecraft::Biome;
+use crate::noise::RNG;
+
+use super::Culture;
+
+/// Per-cell Japanese weight for a cherry grove or bamboo jungle cell — the iconic
+/// Japanese landmark biomes. Set well above 1 so a comparatively small grove in
+/// the build area dominates the summed weights and flips the town Japanese, while
+/// staying a weight (not a hard override) so a lone stray cell among a sea of
+/// plains doesn't necessarily decide it. Raise it to make ever-smaller groves
+/// flip the town; lower it toward 1 to make cherry/bamboo just ordinary Japanese
+/// biomes.
+const JAPANESE_SIGNAL_WEIGHT: f32 = 10.0;
+
+/// Coarse climate class of one biome cell — the axis culture cares about
+/// (temperature + humidity), distinct from the wood/stone biome buckets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Climate {
+    /// Hot + dry: desert, savanna, badlands → Desert.
+    Arid,
+    /// Warm + wet: jungle, swamp, mangrove, lush → Japanese (ordinary weight).
+    Tropical,
+    /// Bamboo jungle → Japanese, weighted heavily ([`JAPANESE_SIGNAL_WEIGHT`]).
+    Bamboo,
+    /// Cherry grove → Japanese, weighted heavily ([`JAPANESE_SIGNAL_WEIGHT`]).
+    Cherry,
+    /// Cold: taiga, snowy, frozen, peaks → Medieval.
+    Boreal,
+    /// The temperate middle (plains, forest, birch, dark-forest, meadow) → the
+    /// Medieval default. Also the catch-all for oceans/rivers/unknown biomes.
+    Temperate,
+}
+
+impl Climate {
+    /// Classify a biome. Arid / Tropical / Bamboo / Cherry / Boreal are matched
+    /// explicitly; everything else (incl. unknown, ocean, river) is Temperate.
+    pub fn from_biome(biome: &Biome) -> Climate {
+        use Climate::*;
+        match biome.name() {
+            // Hot + dry.
+            "desert" | "desert_hills" | "desert_lakes"
+            | "savanna" | "savanna_plateau" | "shattered_savanna"
+            | "shattered_savanna_plateau" | "windswept_savanna"
+            | "badlands" | "badlands_plateau" | "wooded_badlands"
+            | "wooded_badlands_plateau" | "modified_badlands_plateau"
+            | "modified_wooded_badlands_plateau" | "eroded_badlands" => Arid,
+
+            // Bamboo — heavy Japanese signal.
+            "bamboo_jungle" | "bamboo_jungle_hills" => Bamboo,
+
+            // Cherry — heavy Japanese signal.
+            "cherry_grove" => Cherry,
+
+            // Other warm + wet → ordinary Japanese.
+            "jungle" | "jungle_hills" | "jungle_edge" | "modified_jungle"
+            | "modified_jungle_edge" | "sparse_jungle" | "swamp" | "swamp_hills"
+            | "mangrove_swamp" | "lush_caves" => Tropical,
+
+            // Cold.
+            "taiga" | "taiga_hills" | "taiga_mountains" | "snowy_taiga"
+            | "snowy_taiga_hills" | "snowy_taiga_mountains" | "giant_tree_taiga"
+            | "giant_tree_taiga_hills" | "giant_spruce_taiga"
+            | "giant_spruce_taiga_hills" | "old_growth_pine_taiga"
+            | "old_growth_spruce_taiga" | "snowy_tundra" | "snowy_plains"
+            | "snowy_mountains" | "snowy_forest" | "snowy_slopes" | "snowy_beach"
+            | "grove" | "frozen_peaks" | "jagged_peaks" | "stony_peaks"
+            | "ice_spikes" | "frozen_river" | "frozen_ocean" => Boreal,
+
+            // Plains, forests, meadows, oceans, rivers, unknown → temperate.
+            _ => Temperate,
+        }
+    }
+
+    /// Per-cell culture weights `(medieval, japanese, desert)`. Arid → Desert,
+    /// tropical/bamboo/cherry → Japanese (cherry & bamboo heavy), everything else
+    /// → Medieval.
+    fn culture_weights(self) -> (f32, f32, f32) {
+        match self {
+            Climate::Arid => (0.0, 0.0, 1.0),
+            Climate::Tropical => (0.0, 1.0, 0.0),
+            Climate::Bamboo | Climate::Cherry => (0.0, JAPANESE_SIGNAL_WEIGHT, 0.0),
+            Climate::Boreal | Climate::Temperate => (1.0, 0.0, 0.0),
+        }
+    }
+}
+
+/// Pick a settlement culture from the build area's biome map. Sums per-cell
+/// culture weights over every cell and makes one weighted random draw on `rng`,
+/// so the choice fits the dominant climate yet a straddling area can surface a
+/// minority culture — and a cherry/bamboo grove, weighted heavily, pulls the town
+/// Japanese even when it's a minority of the build area. Deterministic in `rng`;
+/// an empty/all-unknown map (e.g. the synthetic offline world) falls back to
+/// Medieval.
+pub fn select_culture(biome_map: &[Vec<Biome>], rng: &mut RNG) -> Culture {
+    let (mut med, mut jap, mut des) = (0.0f32, 0.0f32, 0.0f32);
+    for column in biome_map {
+        for biome in column {
+            let (m, j, d) = Climate::from_biome(biome).culture_weights();
+            med += m;
+            jap += j;
+            des += d;
+        }
+    }
+
+    if med + jap + des <= 0.0 {
+        return Culture::Medieval;
+    }
+
+    let weights = vec![
+        (Culture::Medieval, med),
+        (Culture::Japanese, jap),
+        (Culture::Desert, des),
+    ];
+    *rng.choose_weighted_vec(&weights)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn biome(name: &str) -> Biome {
+        Biome::from(name)
+    }
+
+    /// A uniform biome map of one biome name.
+    fn uniform(name: &str, n: usize) -> Vec<Vec<Biome>> {
+        vec![vec![biome(name); n]; n]
+    }
+
+    /// A square map that is `cherry_frac` of `signal` biome (top rows) and the
+    /// rest `base` — models a build area straddling a grove.
+    fn mixed(base: &str, signal: &str, signal_frac: f32, n: usize) -> Vec<Vec<Biome>> {
+        let signal_cols = (n as f32 * signal_frac).round() as usize;
+        let mut map = vec![vec![biome(base); n]; n];
+        for (i, col) in map.iter_mut().enumerate() {
+            if i < signal_cols {
+                for cell in col.iter_mut() {
+                    *cell = biome(signal);
+                }
+            }
+        }
+        map
+    }
+
+    #[test]
+    fn climate_buckets_cover_the_key_biomes() {
+        assert_eq!(Climate::from_biome(&biome("desert")), Climate::Arid);
+        assert_eq!(Climate::from_biome(&biome("savanna")), Climate::Arid);
+        assert_eq!(Climate::from_biome(&biome("jungle")), Climate::Tropical);
+        assert_eq!(Climate::from_biome(&biome("mangrove_swamp")), Climate::Tropical);
+        assert_eq!(Climate::from_biome(&biome("bamboo_jungle")), Climate::Bamboo);
+        assert_eq!(Climate::from_biome(&biome("cherry_grove")), Climate::Cherry);
+        assert_eq!(Climate::from_biome(&biome("snowy_taiga")), Climate::Boreal);
+        assert_eq!(Climate::from_biome(&biome("plains")), Climate::Temperate);
+        assert_eq!(Climate::from_biome(&biome("forest")), Climate::Temperate);
+        // Unknown / unmatched falls through to temperate.
+        assert_eq!(Climate::from_biome(&Biome::unknown()), Climate::Temperate);
+    }
+
+    /// Pure single-climate build areas resolve deterministically: arid → Desert,
+    /// tropical/cherry/bamboo → Japanese, temperate/boreal → Medieval.
+    #[test]
+    fn pure_climates_resolve_deterministically() {
+        for seed in 0..50i64 {
+            let mut rng = RNG::new(seed);
+            assert_eq!(select_culture(&uniform("desert", 8), &mut rng), Culture::Desert);
+            assert_eq!(select_culture(&uniform("jungle", 8), &mut rng), Culture::Japanese);
+            assert_eq!(select_culture(&uniform("cherry_grove", 8), &mut rng), Culture::Japanese);
+            assert_eq!(select_culture(&uniform("bamboo_jungle", 8), &mut rng), Culture::Japanese);
+            assert_eq!(select_culture(&uniform("plains", 8), &mut rng), Culture::Medieval);
+            assert_eq!(select_culture(&uniform("forest", 8), &mut rng), Culture::Medieval);
+            assert_eq!(select_culture(&uniform("snowy_taiga", 8), &mut rng), Culture::Medieval);
+        }
+    }
+
+    /// A modest cherry or bamboo grove inside an otherwise temperate build area
+    /// flips the town Japanese a clear majority of the time, because the grove is
+    /// weighted `JAPANESE_SIGNAL_WEIGHT`× a plain cell. With ~20% grove the
+    /// Japanese weight (0.20·10 = 2.0) dwarfs the Medieval weight (0.80).
+    #[test]
+    fn cherry_or_bamboo_grove_flips_temperate_town() {
+        for signal in ["cherry_grove", "bamboo_jungle"] {
+            let map = mixed("plains", signal, 0.20, 10);
+            let mut jap = 0;
+            const N: i64 = 2000;
+            for seed in 0..N {
+                let mut rng = RNG::new(seed);
+                if select_culture(&map, &mut rng) == Culture::Japanese {
+                    jap += 1;
+                }
+            }
+            let frac = jap as f32 / N as f32;
+            assert!(frac > 0.65, "{signal}: only {frac:.2} of towns went Japanese");
+        }
+    }
+
+    /// A tiny stray patch of cherry (a few cells at the edge) does *not* reliably
+    /// flip an overwhelmingly temperate build area — it's a heavy weight, not a
+    /// hard override, so the town usually stays Medieval.
+    #[test]
+    fn a_cherry_sliver_usually_stays_medieval() {
+        let map = mixed("plains", "cherry_grove", 0.03, 10); // ~3% cherry
+        let mut med = 0;
+        const N: i64 = 2000;
+        for seed in 0..N {
+            let mut rng = RNG::new(seed);
+            if select_culture(&map, &mut rng) == Culture::Medieval {
+                med += 1;
+            }
+        }
+        let frac = med as f32 / N as f32;
+        assert!(frac > 0.6, "a 3% cherry sliver flipped {:.2} of towns Japanese", 1.0 - frac);
+    }
+}

--- a/src/generator/buildings_v2/mod.rs
+++ b/src/generator/buildings_v2/mod.rs
@@ -7,10 +7,12 @@ pub mod floors;
 pub mod footprint;
 pub mod foundation;
 pub mod frame;
+pub mod climate;
 pub mod furnish;
 pub mod pipeline;
 pub mod roof;
 pub mod rooms;
+pub mod style;
 pub mod walls;
 
 pub use pipeline::{BuildCtx, HouseOutput, build_house};

--- a/src/generator/buildings_v2/roof/flat_roof.rs
+++ b/src/generator/buildings_v2/roof/flat_roof.rs
@@ -50,9 +50,14 @@ pub(super) async fn place_flat_roof(
     );
 
     let mut parapet_rng = rng.derive();
+    // Parapet draws on the Accent role, which backs off to PrimaryStone when a
+    // palette defines no accent (so plain sandstone styles are unchanged). A
+    // style that *does* set an accent (e.g. green terracotta) gets a coloured
+    // crown — see the solid-band branch below.
+    let has_accent = palette.materials.contains_key(&MaterialRole::Accent);
     let parapet_material = palette
-        .get_material(MaterialRole::PrimaryStone)
-        .expect("No primary stone material")
+        .get_material(MaterialRole::Accent)
+        .expect("No accent or stone material for parapet")
         .clone();
     let mut parapet_placer = MaterialPlacer::new(
         Placer::new(&data.materials, &mut parapet_rng),
@@ -149,6 +154,21 @@ pub(super) async fn place_flat_roof(
     // Place parapet blocks according to style
     use std::collections::HashMap;
     for &(point, roof_y) in &parapet_cells {
+        // Accented styles render a clean solid band instead of the random
+        // sandstone parapet styles: a full block on every parapet cell with a
+        // raised cap at corners. All Block form, so an accent material with no
+        // slab/wall variant (terracotta) never leaves gaps.
+        if has_accent {
+            parapet_placer
+                .place_block(editor, point.add_y(roof_y - 1), BlockForm::Block, None, None)
+                .await;
+            if is_corner(point) {
+                parapet_placer
+                    .place_block(editor, point.add_y(roof_y), BlockForm::Block, None, None)
+                    .await;
+            }
+            continue;
+        }
         let checkerboard = (point.x + point.y) % 2 == 0;
         match parapet_style {
             ParapetStyle::Crenellated => {

--- a/src/generator/buildings_v2/rooms/test.rs
+++ b/src/generator/buildings_v2/rooms/test.rs
@@ -609,6 +609,118 @@ async fn build_manors_with_signs() {
     build_single_class_with_signs("Manor", SizeClass::Manor, 12, 13).await;
 }
 
+/// Live: build the whole style catalog for one culture so the variants can be
+/// compared in-game and curated. Styles run as rows (north→south); each row is
+/// `SAMPLES` houses of one style (so high-variance styles show their jitter),
+/// and a sign on the first house of each row names the style. Run one culture at
+/// a time against a running GDMC server:
+///   cargo test build_medieval_catalog -- --nocapture
+///   cargo test build_japanese_catalog -- --nocapture
+///   cargo test build_desert_catalog   -- --nocapture
+async fn build_style_catalog(culture: crate::generator::buildings_v2::Culture, seed: i64) {
+    use crate::editor::World;
+    use crate::http_mod::GDMCHTTPProvider;
+    use crate::util::init_logger;
+    use crate::generator::data::LoadedData;
+    use crate::generator::buildings_v2::footprint::Footprint;
+    use crate::generator::buildings_v2::{BuildCtx, build_house, BuildingContext};
+
+    const SAMPLES: i32 = 3;  // houses per style — enough to read internal variance
+    const CELL: i32 = 16;    // grid spacing between house origins
+    const HOUSE_W: i32 = 11; // footprint extent on X
+    const HOUSE_D: i32 = 9;  // footprint extent on Z
+
+    init_logger();
+
+    let provider = GDMCHTTPProvider::new();
+    let world = World::new(&provider).await.unwrap();
+    let mut editor = world.get_editor();
+
+    let data = LoadedData::load().expect("Failed to load data");
+    let catalog = culture.style_catalog();
+
+    let world_rect = editor.world().world_rect_2d();
+    let center = world_rect.midpoint();
+    // Whole-area bounds passed to every build (used only for door-distance
+    // scoring; each foundation levels terrain around its own footprint).
+    let bounds = Rect2D::from_points(
+        Point2D::new(center.x - 100, center.y - 100),
+        Point2D::new(center.x + 100, center.y + 100),
+    );
+
+    // Local timber: variable wood pools lean toward whatever grows in the
+    // build-area biome (see `BuildingStyle::roll_palette`).
+    let local_wood = editor
+        .world()
+        .get_surface_biome_at(center)
+        .and_then(crate::generator::buildings_v2::style::local_wood_palette);
+    println!("Local wood bias: {local_wood:?}");
+
+    // Top-left origin of the grid, centred on the build area.
+    let origin_x = center.x - (SAMPLES * CELL) / 2;
+    let origin_z = center.y - (catalog.len() as i32 * CELL) / 2;
+
+    let size_class = SizeClass::House;
+    let roof_style = culture.roof_styles_for(size_class)[0];
+    let mut rng = RNG::new(seed);
+
+    for (s, bstyle) in catalog.iter().enumerate() {
+        let row_z = origin_z + s as i32 * CELL;
+        let mut placed = 0;
+
+        for j in 0..SAMPLES {
+            let x = origin_x + j * CELL;
+            let rect = Rect2D::from_points(
+                Point2D::new(x, row_z),
+                Point2D::new(x + HOUSE_W - 1, row_z + HOUSE_D - 1),
+            );
+            let footprint = Footprint::from_rect(rect);
+
+            // Roll this house's palette from the style's pools, then build.
+            let palette = bstyle.roll_palette(&mut rng, &data, local_wood.as_ref());
+            let house_res = {
+                let mut ctx = BuildCtx::new(&mut editor, &data, &palette, &mut rng);
+                let bctx = BuildingContext::new(culture, size_class, roof_style);
+                build_house(&mut ctx, footprint, &bctx, bounds).await
+            };
+
+            match house_res {
+                Ok(house) => {
+                    placed += 1;
+                    // Label the row on its first house's ground floor.
+                    if j == 0 {
+                        let cx = (rect.min().x + rect.max().x) / 2;
+                        let cz = (rect.min().y + rect.max().y) / 2;
+                        let y = house.frame.floor_y(0) + 1;
+                        let sign = sign_block(bstyle.name, &format!("{:?}", culture));
+                        editor.place_block_forced(&sign, Point3D::new(cx, y, cz)).await;
+                    }
+                }
+                Err(e) => println!("  style '{}' sample {j}: FAILED: {e}", bstyle.name),
+            }
+        }
+        println!("Style '{}' placed ({}/{} samples)", bstyle.name, placed, SAMPLES);
+    }
+
+    editor.flush_buffer().await;
+    println!("Done — {:?}: {} styles × {} samples", culture, catalog.len(), SAMPLES);
+}
+
+#[tokio::test]
+async fn build_medieval_catalog() {
+    build_style_catalog(crate::generator::buildings_v2::Culture::Medieval, 13).await;
+}
+
+#[tokio::test]
+async fn build_japanese_catalog() {
+    build_style_catalog(crate::generator::buildings_v2::Culture::Japanese, 13).await;
+}
+
+#[tokio::test]
+async fn build_desert_catalog() {
+    build_style_catalog(crate::generator::buildings_v2::Culture::Desert, 13).await;
+}
+
 /// Builds exactly one Manor for debugging. Change `SEED` and re-run to inspect
 /// different layouts in-game: `cargo test build_single_manor -- --nocapture`.
 /// Asserts the manor got a cellar so a dud seed fails loudly.

--- a/src/generator/buildings_v2/style.rs
+++ b/src/generator/buildings_v2/style.rs
@@ -1,0 +1,418 @@
+//! Per-culture building-style catalogs.
+//!
+//! A [`BuildingStyle`] is a *recipe* over existing palette files: a base palette
+//! plus per-axis variant pools (woods / stones / roofs). Rolling a style merges
+//! the base with one random pick from each non-empty pool, so **internal
+//! variance is just pool size** — a one-entry pool is a matched set, a four-entry
+//! pool jitters house-to-house.
+//!
+//! A settlement picks a few styles from its culture's catalog and applies them in
+//! a weighted 60/30/10 mix (dominant / secondary / accent) so a town reads as one
+//! coherent material story with a clear secondary texture and rare punctuation.
+//! See `settlement.rs` for the town-composition layer; this module only defines
+//! the catalog and how one style rolls into a concrete [`Palette`].
+
+use crate::generator::data::LoadedData;
+use crate::generator::materials::{Palette, PaletteId};
+use crate::minecraft::{Biome, BiomeWoodtype};
+use crate::noise::RNG;
+
+use super::Culture;
+
+/// Target share of buildings in a *variable*-wood style (pool >1 entry) that
+/// should use the biome's local timber, so a town visibly leans on what grows
+/// around it while keeping the curated variety. Locked single-entry pools ignore
+/// the bias entirely.
+const LOCAL_WOOD_FRACTION: f32 = 0.6;
+
+/// A named palette recipe: a base palette plus variant pools the build draws one
+/// pick each from. Empty pools are skipped (so e.g. desert's flat roofs keep the
+/// base roof material). The base palette carries the fixed identity — walls,
+/// interior floor, flowers, accent colours — that the pools never touch.
+#[derive(Debug, Clone)]
+pub struct BuildingStyle {
+    pub name: &'static str,
+    pub base: PaletteId,
+    pub woods: Vec<PaletteId>,
+    pub stones: Vec<PaletteId>,
+    pub roofs: Vec<PaletteId>,
+    /// Decorative accent palettes (set the `accent` material role). Picked like
+    /// the other uniform pools and merged onto the palette. The flat-roof
+    /// parapet renders the accent as a coloured band (see `flat_roof.rs`); other
+    /// roofs ignore it for now. Empty = no accent (parapet stays the base stone).
+    pub accents: Vec<PaletteId>,
+    /// A rare/landmark style. A settlement's [`StyleScheme`] keeps `rare` styles
+    /// out of the dominant/secondary slots so they never blanket a town — they
+    /// only ever appear as the ~10% accent.
+    pub rare: bool,
+}
+
+impl BuildingStyle {
+    /// Merge the base palette with one pick from each non-empty pool. Pool size
+    /// *is* the internal variance: a single-entry pool always yields the same
+    /// material (a matched set), a multi-entry pool rolls per call.
+    ///
+    /// When `local_wood` is set and the wood pool is *variable* (>1 entry), the
+    /// biome's local wood is weighted into the wood roll heavily enough to land
+    /// at ~[`LOCAL_WOOD_FRACTION`] of buildings, so a town leans on the timber
+    /// that grows around it. A locked single-entry wood pool ignores the bias,
+    /// keeping matched/accent styles intact. Pass `None` for no bias.
+    pub fn roll_palette(&self, rng: &mut RNG, data: &LoadedData, local_wood: Option<&PaletteId>) -> Palette {
+        let fetch = |id: &PaletteId| {
+            data.palettes
+                .get(id)
+                .unwrap_or_else(|| panic!("style '{}' palette {:?} not found", self.name, id))
+                .clone()
+        };
+
+        let mut palette = fetch(&self.base);
+
+        // Wood: biome-biased pick when the pool is variable.
+        if !self.woods.is_empty() {
+            // Only honour a local wood that actually has a palette file (some
+            // biomes — e.g. mangrove — have a wood type but no palette yet).
+            let local = local_wood.filter(|id| data.palettes.contains_key(*id));
+            let wood = pick_wood(rng, &self.woods, local);
+            palette = palette.merged_with(&fetch(&wood));
+        }
+
+        // Stone + roof + accent: uniform picks from the curated pool.
+        for pool in [&self.stones, &self.roofs, &self.accents] {
+            if pool.is_empty() {
+                continue;
+            }
+            let id = &pool[rng.rand_i32_range(0, pool.len() as i32) as usize];
+            palette = palette.merged_with(&fetch(id));
+        }
+
+        palette
+    }
+
+    /// Mark this style rare (landmark) — see [`BuildingStyle::rare`].
+    fn rare(mut self) -> Self {
+        self.rare = true;
+        self
+    }
+}
+
+/// Pick a wood-palette id from `pool`, biased toward `local`. A single-entry
+/// pool is locked (returns it, ignoring the bias). For a variable pool, curated
+/// entries each carry weight 1 and the local wood gets enough extra weight to
+/// win ~[`LOCAL_WOOD_FRACTION`] of rolls (it may also be a curated entry, which
+/// just stacks the odds slightly). `local` not in `pool` is injected.
+fn pick_wood(rng: &mut RNG, pool: &[PaletteId], local: Option<&PaletteId>) -> PaletteId {
+    let n = pool.len() as i32;
+    if n <= 1 {
+        return pool[0].clone();
+    }
+    let local = match local {
+        Some(id) => id,
+        None => return pool[rng.rand_i32_range(0, n) as usize].clone(),
+    };
+    // frac = w / (n + w)  ⇒  w = n * frac / (1 - frac)
+    let w = ((n as f32) * LOCAL_WOOD_FRACTION / (1.0 - LOCAL_WOOD_FRACTION))
+        .round()
+        .max(1.0) as i32;
+    let r = rng.rand_i32_range(0, n + w);
+    if r < n {
+        pool[r as usize].clone()
+    } else {
+        local.clone()
+    }
+}
+
+/// The wood-palette id matching a biome's local timber, if any (`None` for
+/// nether/end/cave biomes with no wood, or an unknown biome). Pass the result to
+/// [`BuildingStyle::roll_palette`] to bias a building toward local wood.
+pub fn local_wood_palette(biome: Biome) -> Option<PaletteId> {
+    BiomeWoodtype::from_biome(biome).map(|w| w.get_wood_palette_id())
+}
+
+/// Terse constructor: string slices in, [`PaletteId`]s out.
+fn style(name: &'static str, base: &str, woods: &[&str], stones: &[&str], roofs: &[&str]) -> BuildingStyle {
+    let ids = |xs: &[&str]| xs.iter().map(|s| PaletteId::from(*s)).collect();
+    BuildingStyle {
+        name,
+        base: base.into(),
+        woods: ids(woods),
+        stones: ids(stones),
+        roofs: ids(roofs),
+        accents: Vec::new(),
+        rare: false,
+    }
+}
+
+/// A desert decoration style: smooth-sandstone body (no wood/roof jitter) with a
+/// single terracotta accent that the flat-roof parapet renders as a coloured
+/// crown band.
+fn desert_accent(name: &'static str, stones: &[&str], accent: &str) -> BuildingStyle {
+    BuildingStyle { accents: vec![accent.into()], ..style(name, "desert_sandstone", &[], stones, &[]) }
+}
+
+impl Culture {
+    /// Catalog of building styles a settlement of this culture samples from. A
+    /// town picks a dominant / secondary / accent trio out of this list and
+    /// applies them 60/30/10, so the order here is just the menu — not a fixed
+    /// town composition. Styles vary in *internal* variance via their pool sizes
+    /// (see [`BuildingStyle`]): the everyday styles jitter wood/stone/roof for an
+    /// organic look, the prestige/accent styles stay tight so they read as
+    /// deliberate landmarks.
+    pub fn style_catalog(&self) -> Vec<BuildingStyle> {
+        match self {
+            // White-walled timber town. The everyday "wattle" style carries the
+            // variance; the stone hall is the rare imposing accent.
+            Culture::Medieval => vec![
+                // Tidy matched set — spruce frame, brick walls, plank roof.
+                style("Timber Spruce", "medieval_spruce", &["spruce"], &["stone_bricks"], &["medieval_roof"]),
+                // The bustling organic core: every axis jitters.
+                style("Whitewash Wattle", "medieval_spruce",
+                    &["oak", "birch", "spruce", "dark_oak"],
+                    &["cobblestone", "stone_bricks"],
+                    &["oak_wood_roof", "red_wood_roof", "brick_roof"]),
+                // Rougher cottages — cobble base, warm roofs.
+                style("Fieldstone", "medieval_spruce", &["oak", "dark_oak"], &["cobblestone"], &["brick_roof", "red_wood_roof"]),
+                // Dark timber-frame, the tudor look.
+                style("Dark Tudor", "medieval_spruce", &["dark_oak"], &["stone_bricks", "cobblestone"], &["red_wood_roof"]),
+                // Rare accent: all stone, deepslate + blackstone roof — a landmark.
+                style("Stone Hall", "medieval_spruce", &["dark_oak"], &["deepslate"], &["blackstone_roof"]).rare(),
+                // Warm accent: acacia trade house.
+                style("Acacia Trade", "medieval_spruce", &["acacia"], &["stone_bricks"], &["acacia_wood_roof"]).rare(),
+            ],
+            // Blackstone-and-timber register. Two bases (dark blackstone vs light
+            // cherry) give the cultural split; the shrine is the teal accent.
+            Culture::Japanese => vec![
+                style("Dark Blackstone", "japanese_dark_blackstone", &["dark_oak"], &["blackstone"], &["red_wood_roof"]),
+                // White-concrete walls under a blackstone-brick roof — the
+                // white-and-slate house (the Dark Blackstone base, slate roof).
+                style("White Slate", "japanese_dark_blackstone", &["dark_oak"], &["blackstone"], &["blackstone_roof"]),
+                // White-concrete walls under a bamboo-mosaic roof — the light,
+                // woven-bamboo house.
+                style("Bamboo Roof", "japanese_dark_blackstone", &["dark_oak"], &["blackstone"], &["bamboo_roof"]),
+                // White-concrete walls under a pink cherry-plank roof — the
+                // blossom house.
+                style("Cherry Roof", "japanese_dark_blackstone", &["dark_oak"], &["blackstone"], &["cherry_wood_roof"]),
+                style("Light Cherry", "japanese_light_cherry", &["cherry"], &["blackstone"], &["red_wood_roof"]),
+                style("Cypress Town", "japanese_dark_blackstone", &["dark_oak", "spruce"], &["blackstone"], &["red_wood_roof", "acacia_wood_roof"]),
+                style("Cherry & Ink", "japanese_light_cherry", &["cherry", "dark_oak"], &["blackstone", "deepslate"], &["red_wood_roof", "blue_wood_roof"]),
+                // Rare accent: teal/warped roof, ink-dark stone — temple/shrine.
+                style("Teal Shrine", "japanese_dark_blackstone", &["dark_oak"], &["deepslate"], &["blue_wood_roof"]).rare(),
+                // Rarest accent: red-concrete walls *and* posts under a teal
+                // (warped/prismarine) roof — the vermilion-and-teal temple. Empty
+                // wood pool so the base palette's concrete pillars survive; locked
+                // stone/roof so it always reads as the deliberate landmark it is.
+                style("Vermilion Hall", "japanese_red_lacquer", &[], &["blackstone"], &["blue_wood_roof"]).rare(),
+                // House-tier twin of the temple: same red-concrete walls/posts, but
+                // a blackstone-brick roof instead of the teal — the everyday
+                // vermilion house. Roof pool overrides the base's teal roof.
+                style("Vermilion House", "japanese_red_lacquer", &[], &["blackstone"], &["blackstone_roof"]),
+            ],
+            // Sun-bleached sandstone. Inherently low-variance — variety comes from
+            // base swaps (red sandstone, prismarine noble) rather than jitter.
+            // Roofs are flat, so the roof pool stays empty (base roof kept). Empty
+            // wood pool too: the base's sandstone pillar (matching the wall) stays
+            // instead of being overridden by a wood palette's stripped log.
+            Culture::Desert => vec![
+                style("Sandstone", "desert_sandstone", &[], &["sandstone"], &[]),
+                style("Red Sandstone", "desert_sandstone", &[], &["red_sandstone"], &[]),
+                style("Mixed Sands", "desert_sandstone", &[], &["sandstone", "red_sandstone"], &[]),
+                // Rare accent: dark-prismarine roof, the noble/coastal house.
+                style("Prismarine Noble", "desert_prismarine", &[], &["sandstone"], &[]).rare(),
+                // Sandstone bodies with a terracotta parapet crown — the painted-
+                // trim houses. The accent only colours the roofline band.
+                desert_accent("Green Trim", &["sandstone"], "accent_green_terracotta"),
+                desert_accent("Azure Trim", &["sandstone"], "accent_light_blue_terracotta"),
+                desert_accent("Ochre Trim", &["sandstone"], "accent_orange_terracotta"),
+            ],
+        }
+    }
+}
+
+/// A settlement's chosen style composition: a dominant / secondary / accent trio
+/// from the culture's catalog, applied to buildings in a weighted 60/30/10 mix so
+/// the town reads as one coherent material story with a clear secondary texture
+/// and rare punctuation. Built once per settlement (see `settlement.rs`), then
+/// [`district_variant`](StyleScheme::district_variant) derives a per-district
+/// twist.
+#[derive(Clone)]
+pub struct StyleScheme {
+    dominant: BuildingStyle,
+    secondary: BuildingStyle,
+    accent: BuildingStyle,
+}
+
+impl StyleScheme {
+    /// Pick the trio from `culture`'s catalog. Dominant and secondary are drawn
+    /// from the everyday styles, so a [`rare`](BuildingStyle::rare) landmark never
+    /// blankets a town; the 10% accent slot prefers a rare style, falling back to
+    /// a remaining everyday one. Deterministic in `rng`.
+    pub fn generate(culture: Culture, rng: &mut RNG) -> Self {
+        let catalog = culture.style_catalog();
+        let mut common: Vec<BuildingStyle> = catalog.iter().filter(|s| !s.rare).cloned().collect();
+        let mut rare: Vec<BuildingStyle> = catalog.into_iter().filter(|s| s.rare).collect();
+        // Degenerate catalog (everything flagged rare): treat them as common.
+        if common.is_empty() {
+            common = rare.clone();
+        }
+
+        fn take(v: &mut Vec<BuildingStyle>, rng: &mut RNG) -> BuildingStyle {
+            v.remove(rng.rand_i32_range(0, v.len() as i32) as usize)
+        }
+
+        let dominant = take(&mut common, rng);
+        let secondary = if common.is_empty() { dominant.clone() } else { take(&mut common, rng) };
+        let accent = if !rare.is_empty() {
+            take(&mut rare, rng)
+        } else if !common.is_empty() {
+            take(&mut common, rng)
+        } else {
+            secondary.clone()
+        };
+
+        Self { dominant, secondary, accent }
+    }
+
+    /// Derive a per-district variant of this town scheme so each quarter reads as
+    /// its own while staying clearly part of the city. The town's **dominant**
+    /// stays the district's dominant (so the 60% plurality material is constant
+    /// city-wide — the shared thread) and the town's **accent** is inherited
+    /// unchanged (landmarks stay consistent); only the 30% **secondary** is
+    /// re-rolled to a different everyday style from the culture's catalog, giving
+    /// the district its local texture. Deterministic in `rng`. Falls back to the
+    /// town scheme's own secondary when the catalog has no other everyday style.
+    pub fn district_variant(&self, culture: Culture, rng: &mut RNG) -> StyleScheme {
+        let alternatives: Vec<BuildingStyle> = culture
+            .style_catalog()
+            .into_iter()
+            .filter(|s| !s.rare && s.name != self.dominant.name)
+            .collect();
+        let secondary = if alternatives.is_empty() {
+            self.secondary.clone()
+        } else {
+            alternatives[rng.rand_i32_range(0, alternatives.len() as i32) as usize].clone()
+        };
+        StyleScheme {
+            dominant: self.dominant.clone(),
+            secondary,
+            accent: self.accent.clone(),
+        }
+    }
+
+    /// Pick a style for one building: 60% dominant, 30% secondary, 10% accent.
+    pub fn next_style(&self, rng: &mut RNG) -> &BuildingStyle {
+        match rng.rand_i32_range(0, 100) {
+            0..60 => &self.dominant,
+            60..90 => &self.secondary,
+            _ => &self.accent,
+        }
+    }
+
+    pub fn dominant(&self) -> &BuildingStyle { &self.dominant }
+    pub fn secondary(&self) -> &BuildingStyle { &self.secondary }
+    pub fn accent(&self) -> &BuildingStyle { &self.accent }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generator::data::LoadedData;
+
+    /// Every style in every culture's catalog must reference palette files that
+    /// exist — `roll_palette` panics on a missing base or variant id, so rolling
+    /// each style a few times offline catches a typo in the catalog without a
+    /// live server.
+    #[test]
+    fn catalog_styles_roll_cleanly() {
+        let data = LoadedData::load().expect("Failed to load data");
+        let mut rng = RNG::new(7);
+
+        for culture in [Culture::Medieval, Culture::Japanese, Culture::Desert] {
+            let catalog = culture.style_catalog();
+            assert!(catalog.len() >= 3, "{culture:?} needs ≥3 styles for a 60/30/10 mix");
+            for bstyle in &catalog {
+                // Roll several times so multi-entry pools exercise each branch,
+                // both unbiased and with a local-wood bias toward an existing
+                // (oak) and a missing (mangrove) wood palette.
+                let oak = PaletteId::from("oak");
+                let mangrove = PaletteId::from("mangrove"); // no palette file → ignored
+                for local in [None, Some(&oak), Some(&mangrove)] {
+                    for _ in 0..8 {
+                        let _ = bstyle.roll_palette(&mut rng, &data, local);
+                    }
+                }
+            }
+        }
+    }
+
+    /// In a variable wood pool, the local wood should win a clear majority
+    /// (~`LOCAL_WOOD_FRACTION`); a locked single-entry pool must ignore the bias.
+    #[test]
+    fn local_wood_bias_dominates_variable_pools() {
+        let variable = vec![PaletteId::from("oak"), PaletteId::from("spruce"), PaletteId::from("dark_oak")];
+        let locked = vec![PaletteId::from("dark_oak")];
+        let local = PaletteId::from("birch"); // not in either pool
+        let mut rng = RNG::new(99);
+
+        let mut local_hits = 0;
+        const N: i32 = 2000;
+        for _ in 0..N {
+            if pick_wood(&mut rng, &variable, Some(&local)) == local {
+                local_hits += 1;
+            }
+            // Locked pool never yields the (out-of-pool) local wood.
+            assert_eq!(pick_wood(&mut rng, &locked, Some(&local)), locked[0]);
+        }
+        let frac = local_hits as f32 / N as f32;
+        assert!((frac - LOCAL_WOOD_FRACTION).abs() < 0.06, "local fraction {frac} off target");
+    }
+
+    /// A district variant keeps the town's dominant and accent, only swaps the
+    /// secondary, and never promotes a rare style into the secondary slot.
+    #[test]
+    fn district_variant_keeps_dominant_and_accent() {
+        for culture in [Culture::Medieval, Culture::Japanese, Culture::Desert] {
+            let mut rng = RNG::new(3);
+            let town = StyleScheme::generate(culture, &mut rng);
+            let mut saw_different_secondary = false;
+            for _ in 0..40 {
+                let d = town.district_variant(culture, &mut rng);
+                assert_eq!(d.dominant().name, town.dominant().name, "{culture:?} dominant changed");
+                assert_eq!(d.accent().name, town.accent().name, "{culture:?} accent changed");
+                assert!(!d.secondary().rare, "{culture:?} district secondary is rare");
+                if d.secondary().name != town.secondary().name {
+                    saw_different_secondary = true;
+                }
+            }
+            // Every culture's catalog has ≥2 everyday styles, so the secondary
+            // should differ from the town's at least sometimes.
+            assert!(saw_different_secondary, "{culture:?} never varied the district secondary");
+        }
+    }
+
+    /// The scheme keeps rare styles out of the dominant/secondary slots and
+    /// applies the trio at roughly 60/30/10.
+    #[test]
+    fn scheme_excludes_rare_and_weights_60_30_10() {
+        for culture in [Culture::Medieval, Culture::Japanese, Culture::Desert] {
+            let mut rng = RNG::new(5);
+            for _ in 0..50 {
+                let scheme = StyleScheme::generate(culture, &mut rng);
+                assert!(!scheme.dominant().rare, "{culture:?} dominant is rare");
+                assert!(!scheme.secondary().rare, "{culture:?} secondary is rare");
+            }
+
+            // Distribution check on one scheme.
+            let scheme = StyleScheme::generate(culture, &mut rng);
+            let (mut d, mut s, mut a) = (0, 0, 0);
+            const N: i32 = 3000;
+            for _ in 0..N {
+                let name = scheme.next_style(&mut rng).name;
+                if name == scheme.dominant().name { d += 1; }
+                else if name == scheme.secondary().name { s += 1; }
+                else { a += 1; }
+            }
+            // Loose bounds (names can collide when slots fall back to a clone).
+            assert!(d >= s && s >= a, "{culture:?} weights out of order: {d}/{s}/{a}");
+            assert!(a > 0, "{culture:?} accent never appeared");
+        }
+    }
+}

--- a/src/generator/chronicle.rs
+++ b/src/generator/chronicle.rs
@@ -1,58 +1,160 @@
-use std::collections::HashMap;
 use anyhow::Ok;
 use log::{error, info};
 use schemars::JsonSchema;
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::Serialize;
 
-use crate::{ai::try_ai_json, editor::{Editor, World}, minecraft::Biome};
+use crate::{ai::try_ai_json, editor::Editor};
 
-pub struct SettlementInfo {
-    pub name : String,
-    pub top_three_biomes : Vec<Biome>,
-    pub house_count : usize,
+/// A single narratable place in the town — a road, manor, trade, park, gate, etc.
+/// This is a view-model: a flat, stringly-typed digest assembled from the typed
+/// generator state purely so the chronicle LLM can write about it. All fields are
+/// human-readable (colour words, road names, blazons), never raw ids/coords.
+#[derive(Debug, Clone, Serialize)]
+pub struct Landmark {
+    /// "road" | "industry" | "manor" | "park" | "gate" — groups the labelled block.
+    pub kind: String,
+    /// e.g. "Mill Lane", "the Blackwell Manor", "the flower garden".
+    pub name: String,
+    /// Coarse location relative to the town centre: "central", "eastern",
+    /// "on the northern edge". Deterministic, so it can't contradict the build.
+    pub quarter: String,
+    /// Named anchors the place sits by — usually the nearest road. Preferred over
+    /// `quarter` in prose because it matches the world's own signage.
+    pub near: Vec<String>,
+    /// Freeform type-specific detail: a manor's colour + blazon, a park's subtype.
+    pub notes: Vec<String>,
 }
 
-impl SettlementInfo {
-    pub fn new(world : &World) -> Self {
-        let mut biomes_by_count = world.parcel_analysis_data.iter()
-                .map(|(_, data)| data.biome_count())
-                .flatten()
-                .fold(HashMap::new(), |mut value, (biome, count)| {
-                    value.entry(biome)
-                        .and_modify(|e : &mut u32| *e += count)
-                        .or_insert(*count);
-                    value
-                })
-                .into_iter()
-                .collect::<Vec<_>>();
-        biomes_by_count.sort_by_key(|(_, count)| *count);
-        
-        SettlementInfo {
-            name : "".to_string(),
-            top_three_biomes: biomes_by_count.iter()
-                .rev()
-                .take(3)
-                .map(|(biome, _)| (*biome).clone())
-                .collect(),
-            house_count : world.buildings.len(),
-        }
-    }
+/// Everything the chronicle needs to write a guide to the town. Scalars describe
+/// what the place *is*; `landmarks` is what's *in* it. Assembled once at the end
+/// of `generate_town`, where every source is still in scope, and handed to
+/// [`generate_chronicle`]. Serializable so a run can dump it to inspect the exact
+/// facts the model was given.
+#[derive(Debug, Clone, Serialize)]
+pub struct CityDossier {
+    pub name: String,
+    /// English gloss of the name, e.g. "Dark Hill". May be empty.
+    pub subtitle: String,
+    /// Culture word ("medieval"/"desert"/"japanese"); empty if unknown.
+    pub culture: String,
+    /// Town colours as English words ("deep red", "black").
+    pub town_colours: Vec<String>,
+    /// Most common biomes, prettified ("forest", "river").
+    pub biomes: Vec<String>,
+    /// Size bucket ("hamlet"/"village"/"town"/"large town").
+    pub size: String,
+    pub walled: bool,
+    pub landmarks: Vec<Landmark>,
+}
 
-    pub async fn generate_name(&mut self) {
-        #[derive(Debug, Serialize, Deserialize, JsonSchema)]
-        pub struct NameQuery {
-            name : String
-        }
-
-        try_ai_json::<NameQuery>(&format!("Generate a name for a settlement with {} houses, and the following most common biomes: {:?}.", self.house_count, self.top_three_biomes)).await
-            .map(|query| {
-                self.name = query.name;
-            })
-            .unwrap_or_else(|| {
-                error!("Failed to generate settlement name, using default.");
-                self.name = "Blackbarrow".to_string();
-            });
+/// House-count → size word for prose.
+pub fn size_word(houses: usize) -> String {
+    match houses {
+        0..=7 => "hamlet",
+        8..=24 => "village",
+        25..=59 => "town",
+        _ => "large town",
     }
+    .to_string()
+}
+
+/// Join words naturally: `["a","b","c"]` → "a, b and c".
+fn join_natural(words: &[String]) -> String {
+    match words {
+        [] => String::new(),
+        [a] => a.clone(),
+        [a, b] => format!("{a} and {b}"),
+        [rest @ .., last] => format!("{} and {}", rest.join(", "), last),
+    }
+}
+
+/// One labelled fact block (e.g. all "industry" landmarks). Skips empty groups.
+fn push_block(s: &mut String, header: &str, marks: &[Landmark], kind: &str) {
+    let group: Vec<&Landmark> = marks.iter().filter(|m| m.kind == kind).collect();
+    if group.is_empty() {
+        return;
+    }
+    s.push_str(header);
+    s.push('\n');
+    for m in group {
+        let mut line = format!("  {}", m.name);
+        // Prefer "by <road>"; fall back to the coarse quarter.
+        if let Some(r) = m.near.first() {
+            line.push_str(&format!(" — by {r}"));
+        } else if !m.quarter.is_empty() {
+            line.push_str(&format!(" — {}", m.quarter));
+        }
+        if !m.notes.is_empty() {
+            line.push_str(&format!(" ({})", m.notes.join("; ")));
+        }
+        s.push_str(&line);
+        s.push('\n');
+    }
+    s.push('\n');
+}
+
+/// Build the content instruction for the chronicle book from the dossier. The
+/// formatting rules are appended later by [`give_player_book`]; this is purely
+/// the persona, the facts, and the grounding rules. Pure string-building — no
+/// I/O — so it's fully testable offline.
+pub fn build_instruction(d: &CityDossier) -> String {
+    let mut s = String::new();
+
+    // ── Persona: a brisk pocket fact-guide, not a story ──
+    s.push_str(&format!(
+        "You are writing a short visitor's guide to {name} — a pocket fact-sheet for a \
+         traveller passing through, not a story. Keep it brisk, concrete and skimmable: say \
+         what the town is and what is worth knowing, in plain present-tense English. Favour \
+         short, punchy lines over flowing prose.\n\n",
+        name = d.name,
+    ));
+
+    // ── Facts as labelled blocks the model selects from ──
+    s.push_str("Here is everything true about the town. Use ONLY what is listed here.\n\n");
+
+    s.push_str("THE PLACE\n");
+    if d.subtitle.is_empty() {
+        s.push_str(&format!("  Name: {}\n", d.name));
+    } else {
+        s.push_str(&format!("  Name: {} — \"{}\"\n", d.name, d.subtitle));
+    }
+    let walled = if d.walled { " walled" } else { "" };
+    if d.culture.is_empty() {
+        s.push_str(&format!("  A{walled} {}\n", d.size));
+    } else {
+        s.push_str(&format!("  A{walled} {} in the {} style\n", d.size, d.culture));
+    }
+    if !d.biomes.is_empty() {
+        s.push_str(&format!("  Set in {} country\n", join_natural(&d.biomes)));
+    }
+    if !d.town_colours.is_empty() {
+        s.push_str(&format!("  The town flies {}\n", join_natural(&d.town_colours)));
+    }
+    s.push('\n');
+
+    push_block(&mut s, "THE STREETS", &d.landmarks, "road");
+    push_block(&mut s, "TRADES", &d.landmarks, "industry");
+    push_block(&mut s, "FAMILIES", &d.landmarks, "manor");
+    push_block(&mut s, "GREENS & SQUARES", &d.landmarks, "park");
+    push_block(&mut s, "GATES", &d.landmarks, "gate");
+
+    // ── Shape + grounding ──
+    s.push_str(
+        "Organise the guide as a handful of SHORT titled sections, each opening with a brief \
+         bold heading and then a few crisp lines. Good sections to use: an 'At a glance' \
+         summary (what kind of town it is, its colours and setting); getting in (the gates \
+         and main streets); what to see (notable trades, greens and squares); who runs it \
+         (the families and their banners); and where life happens (markets and gathering \
+         places). Keep each page light — a section with several items should run across \
+         several short pages rather than one crowded page.\n\n\
+         Use ONLY the facts above. You may add light colour — a smell, a sound, the feel of a \
+         place — but invent NO new buildings, people, families, or places, and never \
+         contradict the facts. If something is not listed, the town does not have it. Do not \
+         name every street and trade; pick the ones worth a visitor's time. It should read \
+         like a fact-sheet a traveller can skim, not a tale.",
+    );
+
+    s
 }
 
 #[derive(Debug, serde_derive::Deserialize, Serialize, JsonSchema)]
@@ -116,20 +218,31 @@ struct Book {
     pages : Vec<Vec<Text>>,
 }
 
-pub async fn give_player_book(editor : &Editor, instruction : &str) -> anyhow::Result<()> {
+/// Run the instruction through the LLM and return a formatted [`Book`] — the
+/// network half, with no Minecraft I/O. Split out so the live model can be
+/// exercised in a test without a running server (see `tests::live_llm_*`).
+async fn write_book(instruction : &str) -> anyhow::Result<Book> {
     let user = &format!(r#"{}.
 
             Formatting rules — follow exactly:
+            - Each entry in `pages` is ONE physical Minecraft book page, which shows only ~14 narrow lines of about 19 characters each (so a normal sentence wraps to 2+ lines). Keep each page to AT MOST about 5 short lines / ~120 characters of text INCLUDING its heading. This is small on purpose — leaving a page half-empty is correct, and packing a page full means the bottom is CUT OFF in-game and lost.
+            - Use MANY pages — 8 to 14 is normal and good. A section with several facts must SPAN multiple pages rather than overfill one: continue it on the next page (repeat the heading, or add " (cont.)"). One fact or two per page is fine.
             - Body text is PLAIN by default: no color, no bold, no italics. This is true for the vast majority of the text.
-            - A page may open with a short heading that is bold (bold only, never colored).
+            - A page may open with a short heading that is bold (bold only, never colored). If it does, the heading's own text must END with a newline so it sits on its own line — the body must never run straight on from the heading (no "HeadingBody...").
             - Color at most ONE word or short phrase per page, and only for a genuinely important name or concept. Most pages should have NO colored text at all. Treat color like rare rubrication in an old manuscript, not a highlighter.
+            - NEVER use yellow text — it is illegible on the book's pale page. If a name's colour would be yellow (or gold/white), leave that text plain instead.
             - Never write "Keyword:" labels, glossaries, or lists of highlighted terms.
+            - Adjacent text components are concatenated with NO space added. Whenever you split text into multiple components (to color a word, or between sentences/paragraphs), put the needed spaces and line breaks INSIDE the components so the rendered run reads with normal spacing — never "endOfOne.startOfNext".
             - When in doubt, leave text plain.
 
             Keep the title and author under 32 characters each.
             Do NOT use § section codes or unicode escape codes — format only using the JSON elements."#, instruction);
-    let book: Book = try_ai_json::<Book>(user).await
-        .ok_or_else(|| anyhow::anyhow!("Failed to get or parse AI response for book"))?;
+    try_ai_json::<Book>(user).await
+        .ok_or_else(|| anyhow::anyhow!("Failed to get or parse AI response for book"))
+}
+
+pub async fn give_player_book(editor : &Editor, instruction : &str) -> anyhow::Result<()> {
+    let book: Book = write_book(instruction).await?;
 
     let pages: Vec<String> = book.pages.iter().map(|page| {
             // Wrap every component under a NEUTRAL empty root, so each keeps its
@@ -152,16 +265,11 @@ pub async fn give_player_book(editor : &Editor, instruction : &str) -> anyhow::R
     Ok(())
 }
 
-pub async fn generate_chronicle(editor: &Editor, settlement_info : &mut SettlementInfo) -> anyhow::Result<()> {
+pub async fn generate_chronicle(editor: &Editor, dossier : &CityDossier) -> anyhow::Result<()> {
     let retries = 3;
-    settlement_info.generate_name().await;
+    let instruction = build_instruction(dossier);
 
     for _ in 0..retries {
-        let instruction = format!("Generate a long book about a settlement named '{}', which has {} houses and the following most common biomes: {:?}.", 
-                              settlement_info.name, 
-                              settlement_info.house_count, 
-                              settlement_info.top_three_biomes);
-
         let result = give_player_book(editor, &instruction).await;
 
         match result {
@@ -176,4 +284,105 @@ pub async fn generate_chronicle(editor: &Editor, settlement_info : &mut Settleme
     }
 
     Err(anyhow::anyhow!("Failed to generate chronicle after {} retries", retries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> CityDossier {
+        CityDossier {
+            name: "Blackbarrow".to_string(),
+            subtitle: "Dark Hill".to_string(),
+            culture: "medieval".to_string(),
+            town_colours: vec!["deep red".to_string(), "black".to_string()],
+            biomes: vec!["forest".to_string(), "river".to_string()],
+            size: "town".to_string(),
+            walled: true,
+            landmarks: vec![
+                Landmark { kind: "road".into(), name: "High Street".into(), quarter: "central".into(), near: vec![], notes: vec![] },
+                Landmark { kind: "industry".into(), name: "the mill".into(), quarter: "eastern".into(), near: vec!["Mill Lane".into()], notes: vec![] },
+                Landmark { kind: "manor".into(), name: "the Blackwell Manor".into(), quarter: "eastern".into(), near: vec!["the Rivergate".into()], notes: vec!["deep red".into(), "a red cross on a black background".into()] },
+                Landmark { kind: "park".into(), name: "the flower garden".into(), quarter: "on the northern edge".into(), near: vec![], notes: vec![] },
+                Landmark { kind: "gate".into(), name: "the north gate".into(), quarter: "on the northern edge".into(), near: vec![], notes: vec![] },
+            ],
+        }
+    }
+
+    #[test]
+    fn instruction_carries_persona_facts_and_guardrails() {
+        let s = build_instruction(&sample());
+        // Persona frame.
+        assert!(s.contains("short visitor's guide to Blackbarrow"), "{s}");
+        assert!(s.contains("fact-sheet a traveller can skim"), "tldr shape missing:\n{s}");
+        // Scalars.
+        assert!(s.contains("Blackbarrow — \"Dark Hill\""), "{s}");
+        assert!(s.contains("walled town in the medieval style"), "{s}");
+        assert!(s.contains("forest and river country"), "{s}");
+        assert!(s.contains("flies deep red and black"), "{s}");
+        // Labelled blocks render with location + notes.
+        assert!(s.contains("THE STREETS"), "{s}");
+        assert!(s.contains("the mill — by Mill Lane"), "{s}");
+        assert!(s.contains("the Blackwell Manor — by the Rivergate (deep red; a red cross on a black background)"), "{s}");
+        assert!(s.contains("the flower garden — on the northern edge"), "{s}");
+        // Grounding rule present.
+        assert!(s.contains("invent NO new buildings"), "{s}");
+    }
+
+    /// Exercises the live LLM end of the chronicle (instruction → `write_book`)
+    /// with no Minecraft server. Hits the real API, so it's `#[ignore]`d by
+    /// default — run explicitly:
+    ///   cargo test chronicle::tests::live_llm_writes_a_book -- --ignored --nocapture
+    /// Needs the API key in `.env`. Prints the book so the prose can be eyeballed.
+    #[tokio::test]
+    #[ignore = "hits the live LLM API; run with --ignored"]
+    async fn live_llm_writes_a_book_from_dossier() {
+        dotenv::dotenv().ok();
+        let instruction = build_instruction(&sample());
+        println!("\n===== INSTRUCTION =====\n{instruction}\n");
+        let book = write_book(&instruction).await.expect("LLM returned a parseable book");
+        assert!(!book.title.is_empty(), "empty title");
+        assert!(!book.pages.is_empty(), "no pages");
+        println!("\n===== BOOK: {} — by {} =====", book.title, book.author);
+        let mut oversized: Vec<(usize, usize)> = Vec::new();
+        for (i, page) in book.pages.iter().enumerate() {
+            let text: String = page.iter().map(|t| t.text.as_str()).collect();
+            let chars = text.chars().count();
+            println!("\n--- page {} ({chars} chars) ---\n{text}", i + 1);
+            // A Minecraft page renders ~14 lines; well under 200 chars stays inside it.
+            if chars > 200 {
+                oversized.push((i + 1, chars));
+            }
+        }
+        assert!(
+            oversized.is_empty(),
+            "pages exceed the book render budget and will clip in-game: {oversized:?}",
+        );
+        // Grounding smoke check: the town's name should appear somewhere (title or body).
+        let all: String = book.pages.iter().flatten().map(|t| t.text.as_str()).collect();
+        assert!(
+            book.title.contains("Blackbarrow") || all.contains("Blackbarrow"),
+            "the town name never appears in the book (title or body)",
+        );
+    }
+
+    #[test]
+    fn empty_sections_are_skipped() {
+        let d = CityDossier {
+            name: "Nowhere".into(),
+            subtitle: String::new(),
+            culture: String::new(),
+            town_colours: vec![],
+            biomes: vec![],
+            size: "hamlet".into(),
+            walled: false,
+            landmarks: vec![],
+        };
+        let s = build_instruction(&d);
+        assert!(s.contains("Name: Nowhere\n"), "no bare-name line:\n{s}");
+        assert!(s.contains("A hamlet\n"), "{s}");
+        // No empty headers for absent groups.
+        assert!(!s.contains("THE STREETS"), "{s}");
+        assert!(!s.contains("FAMILIES"), "{s}");
+    }
 }

--- a/src/generator/city_houses/test.rs
+++ b/src/generator/city_houses/test.rs
@@ -144,7 +144,6 @@ async fn settlement_with_city_houses() {
     use crate::generator::city_houses::{
         default_interior_size_pool, fill_interior, place_block_frontage, plot_from_block,
     };
-    use crate::generator::chronicle::SettlementInfo;
     use crate::generator::districts::generate_parcels;
     use crate::generator::materials::PaletteId;
     use crate::generator::buildings_v2::roof::gable::GablePitch;
@@ -188,11 +187,7 @@ async fn settlement_with_city_houses() {
     outers.extend(off_limits.iter().copied());
     let road_points: HashSet<Point2D> = outers.difference(&urban_area_edge).copied().collect();
 
-    let settlement_info = SettlementInfo::new(editor.world());
-    let paving = settlement_info
-        .top_three_biomes
-        .first()
-        .cloned()
+    let paving = crate::generator::settlement::dominant_biome(editor.world())
         .map(PavingType::from_biome)
         .unwrap_or(PavingType::Stone);
     smooth_and_pave_road(&mut editor, &mut rng, &road_points, paving).await;

--- a/src/generator/districts/test.rs
+++ b/src/generator/districts/test.rs
@@ -1206,7 +1206,7 @@ mod tests {
         crate::generator::settlement::generate_town(
             &mut editor,
             Seed(12345),
-            crate::generator::buildings_v2::Culture::Medieval,
+            Some(crate::generator::buildings_v2::Culture::Medieval),
         ).await;
     }
 
@@ -1223,7 +1223,7 @@ mod tests {
         crate::generator::settlement::generate_town(
             &mut editor,
             Seed(12345),
-            crate::generator::buildings_v2::Culture::Desert,
+            Some(crate::generator::buildings_v2::Culture::Desert),
         ).await;
 
         let urban = editor.world().get_urban_points();

--- a/src/generator/open_space/park.rs
+++ b/src/generator/open_space/park.rs
@@ -32,7 +32,7 @@ use super::props::{
     chebyshev, edge_depth, flatten_blend, inward_dir, is_building, is_path, lay_soil,
     lay_soil_patch, place_bench, place_lantern_post, put, put_forced,
 };
-use super::theme::Theme;
+use super::theme::{Theme, CHERRY_CHANCE};
 use super::Region;
 
 /// What kind of park a region becomes.
@@ -146,11 +146,17 @@ fn biome_park_tree(biome: &Biome, rng: &mut RNG) -> Option<Tree> {
     Some(*rng.choose_weighted_vec(&weights))
 }
 
-/// The species for a park tree. A desert-*style* settlement always grows jungle
+/// The species for a park tree. A Japanese settlement has a [`CHERRY_CHANCE`]
+/// chance of a flowering cherry. A desert-*style* settlement always grows jungle
 /// trees — a lush, warm canopy that suits the sandstone palette — whatever the
 /// underlying biome. Every other style picks a biome-appropriate species, or
 /// `None` where a full-size tree looks out of place.
 fn park_tree(theme: &Theme, biome: &Biome, rng: &mut RNG) -> Option<Tree> {
+    // Japanese style: a flowering cherry now and then, whatever the biome.
+    if theme.cherry_blossom && rng.percent(CHERRY_CHANCE) {
+        let weights = vec![(Tree::MediumCherry, 3.0), (Tree::LargeCherry, 2.0)];
+        return Some(*rng.choose_weighted_vec(&weights));
+    }
     if theme.arid {
         let weights = vec![
             (Tree::MediumJungle, 3.0),

--- a/src/generator/open_space/props.rs
+++ b/src/generator/open_space/props.rs
@@ -11,7 +11,7 @@ use crate::geometry::{Point2D, Point3D, CARDINALS_2D};
 use crate::minecraft::{string_to_block, Biome};
 use crate::noise::RNG;
 
-use super::theme::Theme;
+use super::theme::{Theme, CHERRY_CHANCE};
 
 /// Place a single block from an id string (`"id"` or `"id[state=…]"`).
 pub(super) async fn put(editor: &Editor, x: i32, y: i32, z: i32, id: &str) {
@@ -106,12 +106,17 @@ pub(super) fn inward_dir(world: &World, c: Point2D, cells: &HashSet<Point2D>) ->
     None
 }
 
-/// A small tree species. A desert-*style* settlement always grows small jungle
-/// trees (matching its warm palette) whatever the biome; every other style
-/// picks a small, biome-appropriate species, or `None` for biomes where a tree
-/// looks out of place (desert/badlands/etc.). All returned variants have a
+/// A small tree species. A Japanese settlement has a [`CHERRY_CHANCE`] chance of
+/// a small flowering cherry. A desert-*style* settlement always grows small
+/// jungle trees (matching its warm palette) whatever the biome; every other
+/// style picks a small, biome-appropriate species, or `None` for biomes where a
+/// tree looks out of place (desert/badlands/etc.). All returned variants have a
 /// palette in the `small_mixed` forest.
 pub(super) fn biome_tree(theme: &Theme, biome: &Biome, rng: &mut RNG) -> Option<Tree> {
+    // Japanese style: a chance of a small flowering cherry, whatever the biome.
+    if theme.cherry_blossom && rng.percent(CHERRY_CHANCE) {
+        return Some(Tree::SmallCherry);
+    }
     if theme.arid {
         let weights = vec![(Tree::SmallJungle, 4.0), (Tree::MediumJungle, 1.0)];
         return Some(*rng.choose_weighted_vec(&weights));

--- a/src/generator/open_space/theme.rs
+++ b/src/generator/open_space/theme.rs
@@ -4,6 +4,11 @@
 
 use crate::generator::buildings_v2::Culture;
 
+/// Percent chance that any single park / nook tree in a [`Theme::cherry_blossom`]
+/// settlement (Japanese) grows as a flowering cherry instead of its usual
+/// biome species.
+pub const CHERRY_CHANCE: i32 = 35;
+
 /// Block ids (and a few option lists) the open-space furnishers draw from, so a
 /// desert town reads as sandstone instead of cobblestone.
 #[derive(Clone, Copy)]
@@ -41,6 +46,9 @@ pub struct Theme {
     /// Arid (desert) style: gates the cactus park and grows the wooded park as
     /// jungle trees, regardless of the underlying world biome.
     pub arid: bool,
+    /// Japanese style: any park / nook tree has a [`CHERRY_CHANCE`] chance to
+    /// grow as a flowering cherry instead of its biome species.
+    pub cherry_blossom: bool,
 }
 
 const MEDIEVAL: Theme = Theme {
@@ -70,6 +78,7 @@ const MEDIEVAL: Theme = Theme {
         "minecraft:mossy_stone_bricks",
     ],
     arid: false,
+    cherry_blossom: false,
 };
 
 const DESERT: Theme = Theme {
@@ -99,6 +108,7 @@ const DESERT: Theme = Theme {
         "minecraft:chiseled_sandstone",
     ],
     arid: true,
+    cherry_blossom: false,
 };
 
 /// Japanese: a green garden town whose worked stone is deepslate, matching the
@@ -130,6 +140,7 @@ const JAPANESE: Theme = Theme {
         "minecraft:cracked_deepslate_bricks",
     ],
     arid: false,
+    cherry_blossom: true,
 };
 
 impl Theme {

--- a/src/generator/population.rs
+++ b/src/generator/population.rs
@@ -487,14 +487,24 @@ pub struct Fixture {
 }
 
 
-/// Per-culture name pools (currently just first names). Loaded from the
-/// `cultures` map in `data/npcs.yaml`, keyed by [`culture_key`].
+/// Per-culture name pools. Loaded from the `cultures` map in `data/npcs.yaml`,
+/// keyed by [`culture_key`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct CultureNames {
     /// Localized first names, picked verbatim by [`roll_first_name`]. Mixes
     /// masculine and feminine names; one is assigned per NPC at random.
     #[serde(default)]
     pub first_names: Vec<String>,
+    /// Capitalized surname roots for this culture, combined with
+    /// [`Self::surname_suffixes`] in [`roll_surname`]. When non-empty (together
+    /// with the suffixes), supersedes the legacy top-level
+    /// `surname_prefixes`/`surname_suffixes` for this culture.
+    #[serde(default)]
+    pub surname_prefixes: Vec<String>,
+    /// Surname endings for this culture, appended to a
+    /// [`Self::surname_prefixes`] root. See [`roll_surname`].
+    #[serde(default)]
+    pub surname_suffixes: Vec<String>,
 }
 
 /// The `data/npcs.yaml` key for a culture's name pools.
@@ -771,16 +781,34 @@ fn roll_first_name(culture: Culture, data: &NpcData, rng: &mut RNG) -> String {
     format!("{}{}", prefix, suffix)
 }
 
-/// Mint a family name by combining a random prefix with a random suffix —
-/// "Ash" + "wood" → "Ashwood", "Under" + "hill" → "Underhill". Falls back to
-/// `"Townsfolk"` if either pool is empty (so a partial yaml doesn't panic).
-fn roll_surname(data: &NpcData, rng: &mut RNG) -> String {
-    if data.surname_prefixes.is_empty() || data.surname_suffixes.is_empty() {
+/// The surname prefix/suffix pools that apply to `culture`. Every culture keeps
+/// the same English place-name *structure* (prefix root + place-name ending) so
+/// names stay readable — only the word pools change to carry the culture's
+/// vibe: Anglo-Saxon for medieval (Ashwood), pine/crane/mist imagery for
+/// japanese (Pinevale, Cranebrook), sun/sand/dune imagery for desert
+/// (Sandford, Sunmere). Returns the culture's own pools when it defines both;
+/// otherwise the shared legacy top-level pools (so a partial yaml still works).
+fn surname_pools<'a>(culture: Culture, data: &'a NpcData) -> (&'a [String], &'a [String]) {
+    if let Some(names) = data.cultures.get(culture_key(culture)) {
+        if !names.surname_prefixes.is_empty() && !names.surname_suffixes.is_empty() {
+            return (&names.surname_prefixes, &names.surname_suffixes);
+        }
+    }
+    (&data.surname_prefixes, &data.surname_suffixes)
+}
+
+/// Mint a family name localized to `culture` by combining a random prefix with a
+/// place-name suffix — "Ash" + "wood" → "Ashwood" (medieval), "Pine" + "vale" →
+/// "Pinevale" (japanese), "Sand" + "ford" → "Sandford" (desert). The structure
+/// is shared across cultures; only the word pools differ (see [`surname_pools`]).
+/// Returns `"Townsfolk"` only if the pools are empty (so a partial yaml doesn't
+/// panic).
+fn roll_surname(culture: Culture, data: &NpcData, rng: &mut RNG) -> String {
+    let (prefixes, suffixes) = surname_pools(culture, data);
+    if prefixes.is_empty() || suffixes.is_empty() {
         return "Townsfolk".to_string();
     }
-    let prefix = rng.choose(&data.surname_prefixes);
-    let suffix = rng.choose(&data.surname_suffixes);
-    format!("{}{}", prefix, suffix)
+    format!("{}{}", rng.choose(prefixes), rng.choose(suffixes))
 }
 
 /// Roll an epithet for a member of `stage`, weighted toward elders. Elders
@@ -1010,7 +1038,7 @@ fn expand_shape(
     // back to the primary if every roll matches (small surname pool).
     let alt_surname = |rng: &mut RNG| -> String {
         for _ in 0..6 {
-            let s = roll_surname(data, rng);
+            let s = roll_surname(culture, data, rng);
             if s != primary_surname {
                 return s;
             }
@@ -1197,19 +1225,22 @@ pub fn build_households(
     for (h_idx, house) in houses.iter().enumerate() {
         let budget = house.population.max(1);
         let wealth = house.wealth;
-        // A manor usually takes its surname from its family colour (Black →
-        // Blackwell), matching the colour it flies on its banners; 40% of the
-        // time it falls back to a plain random surname. The colour choice is made
-        // once per house so the uniqueness loop re-rolls a fresh colour *suffix*
-        // (preserving the colour) rather than silently dropping it on collision.
+        // A manor usually takes its surname from its family colour, matching the
+        // colour it flies on its banners — the colour root joins the culture's
+        // own suffix pool (Black → Blackwood for medieval, Blacksand for desert,
+        // Blackvale for japanese); 40% of the time it falls back to a plain
+        // random surname. The colour choice is made once per house so the
+        // uniqueness loop re-rolls a fresh colour *suffix* (preserving the
+        // colour) rather than silently dropping it on collision.
         const COLOR_SURNAME_PCT: i32 = 40;
+        let (_, color_suffixes) = surname_pools(culture, data);
         let color_root = house.family_color.and_then(|c| c.surname_root());
         let use_color =
-            color_root.is_some() && !data.surname_suffixes.is_empty() && rng.percent(COLOR_SURNAME_PCT);
+            color_root.is_some() && !color_suffixes.is_empty() && rng.percent(COLOR_SURNAME_PCT);
         let roll = |rng: &mut RNG| -> String {
             match color_root {
-                Some(root) if use_color => format!("{root}{}", rng.choose(&data.surname_suffixes)),
-                _ => roll_surname(data, rng),
+                Some(root) if use_color => format!("{root}{}", rng.choose(color_suffixes)),
+                _ => roll_surname(culture, data, rng),
             }
         };
         let mut primary_surname = roll(rng);
@@ -1727,7 +1758,7 @@ pub fn build_roster(
             Npc {
                 id: alloc.next_id(),
                 first_name: roll_first_name(culture, data, rng),
-                surname: roll_surname(data, rng),
+                surname: roll_surname(culture, data, rng),
                 epithet: roll_epithet(stage, data, rng),
                 life_stage: stage,
                 biome,
@@ -2243,9 +2274,11 @@ mod tests {
         let data = NpcData::load().expect("load npcs.yaml");
         assert!(!data.surname_prefixes.is_empty(), "surname_prefixes must be non-empty");
         assert!(!data.surname_suffixes.is_empty(), "surname_suffixes must be non-empty");
-        // The combined surname is the literal prefix+suffix concat (no separator).
+        // Medieval has no culture-specific surname pool, so it falls back to the
+        // legacy top-level pools: the combined surname is the literal
+        // prefix+suffix concat (no separator).
         let mut sn_rng = RNG::new(Seed(123));
-        let sn = roll_surname(&data, &mut sn_rng);
+        let sn = roll_surname(Culture::Medieval, &data, &mut sn_rng);
         assert!(
             data.surname_prefixes.iter().any(|p| sn.starts_with(p)),
             "generated surname '{sn}' should start with one of the prefixes",
@@ -2293,6 +2326,38 @@ mod tests {
                 assert!(
                     pool.contains(&name),
                     "roll_first_name({}) produced '{name}', not in that culture's pool",
+                    culture_key(culture),
+                );
+            }
+        }
+    }
+
+    /// Japanese and desert define their own (anglicized, culturally-themed)
+    /// surname pools, and `roll_surname` draws from a culture's own prefix+suffix
+    /// pools when present (medieval falls back to the shared English pool).
+    /// Guards the per-culture surname blocks in `npcs.yaml` against drifting away
+    /// from the code. No server.
+    #[test]
+    fn surnames_are_localized_per_culture() {
+        let data = NpcData::load().expect("load npcs.yaml");
+        for culture in [Culture::Japanese, Culture::Desert] {
+            let pool = data
+                .cultures
+                .get(culture_key(culture))
+                .unwrap_or_else(|| panic!("npcs.yaml: no `cultures.{}` block", culture_key(culture)));
+            assert!(
+                !pool.surname_prefixes.is_empty() && !pool.surname_suffixes.is_empty(),
+                "culture '{}' has an empty surname pool",
+                culture_key(culture),
+            );
+            // Several draws all combine this culture's own prefix and suffix.
+            let mut rng = RNG::new(Seed(42));
+            for _ in 0..20 {
+                let sn = roll_surname(culture, &data, &mut rng);
+                assert!(
+                    pool.surname_prefixes.iter().any(|p| sn.starts_with(p))
+                        && pool.surname_suffixes.iter().any(|s| sn.ends_with(s)),
+                    "roll_surname({}) produced '{sn}', not from that culture's pool",
                     culture_key(culture),
                 );
             }

--- a/src/generator/settlement.rs
+++ b/src/generator/settlement.rs
@@ -78,13 +78,318 @@ impl ColorScheme {
     }
 }
 
+/// A manor family harvested during generation for the chronicle. Surname is only
+/// known after the population pass, so these are gathered when each manor sign is
+/// lettered (where surname + the house's `HouseAnchors` meet) and converted to a
+/// [`Landmark`] in [`assemble_dossier`].
+struct ManorFact {
+    surname: String,
+    designation: String,
+    pos: Point2D,
+    color: Option<Color>,
+    blazon: Option<String>,
+}
+
+/// Culture → its lowercase word for the dossier/prose.
+fn culture_word(culture: crate::generator::buildings_v2::Culture) -> String {
+    use crate::generator::buildings_v2::Culture;
+    match culture {
+        Culture::Medieval => "medieval",
+        Culture::Desert => "desert",
+        Culture::Japanese => "japanese",
+    }
+    .to_string()
+}
+
+/// A colour as an English word for prose ("light_blue" → "light blue").
+fn color_word(c: Color) -> String {
+    let s: String = c.into();
+    s.replace('_', " ")
+}
+
+/// Average of a set of cells (rounded). Empty → origin.
+fn cells_centroid(cells: &[Point2D]) -> Point2D {
+    if cells.is_empty() {
+        return Point2D::new(0, 0);
+    }
+    let (sx, sz) = cells.iter().fold((0i64, 0i64), |(x, z), p| (x + p.x as i64, z + p.y as i64));
+    let n = cells.len() as i64;
+    Point2D::new((sx / n) as i32, (sz / n) as i32)
+}
+
+/// Coarse adjectival quarter of `p` relative to the town centre: "central",
+/// "eastern", "on the northern edge". Deterministic, so it can't contradict the
+/// built town. `radius` is the town's outer reach (max cell distance from centre).
+fn quarter_of(p: Point2D, centre: Point2D, radius: f32) -> String {
+    let dx = (p.x - centre.x) as f32;
+    let dz = (p.y - centre.y) as f32; // Point2D.y is the Z (north/south) axis.
+    let dist = (dx * dx + dz * dz).sqrt();
+    if radius <= 0.0 || dist < radius * 0.30 {
+        return "central".to_string();
+    }
+    // North is -Z, south +Z, east +X, west -X.
+    let dir = if dx.abs() >= dz.abs() {
+        if dx >= 0.0 { "eastern" } else { "western" }
+    } else if dz >= 0.0 {
+        "southern"
+    } else {
+        "northern"
+    };
+    if dist > radius * 0.75 {
+        format!("on the {dir} edge")
+    } else {
+        dir.to_string()
+    }
+}
+
+/// Cardinal word of `p` relative to centre — for gates, which always sit on the
+/// perimeter, so "central" never applies.
+fn compass_word(p: Point2D, centre: Point2D) -> &'static str {
+    let dx = p.x - centre.x;
+    let dz = p.y - centre.y;
+    if dx.abs() >= dz.abs() {
+        if dx >= 0 { "east" } else { "west" }
+    } else if dz >= 0 {
+        "south"
+    } else {
+        "north"
+    }
+}
+
+/// The name of the labelled road nearest `p`, or `None` if the closest road is
+/// further than `max_d` cells (don't claim "by X" for something across town).
+fn nearest_road(
+    p: Point2D,
+    road_labels: &HashMap<Point2D, u32>,
+    road_names: &HashMap<u32, String>,
+    max_d: i32,
+) -> Option<String> {
+    let mut best: Option<(i32, u32)> = None;
+    for (&cell, &rid) in road_labels {
+        let dx = cell.x - p.x;
+        let dz = cell.y - p.y;
+        let d2 = dx * dx + dz * dz;
+        if best.map_or(true, |(bd, _)| d2 < bd) {
+            best = Some((d2, rid));
+        }
+    }
+    let (d2, rid) = best?;
+    if d2 > max_d * max_d {
+        return None;
+    }
+    road_names.get(&rid).cloned()
+}
+
+/// Biomes across the town's parcels, most common first.
+fn biome_counts(world: &crate::editor::World) -> Vec<(crate::minecraft::Biome, u32)> {
+    let mut by_count: Vec<(crate::minecraft::Biome, u32)> = world
+        .parcel_analysis_data
+        .iter()
+        .flat_map(|(_, data)| data.biome_count())
+        .fold(HashMap::new(), |mut acc, (biome, count)| {
+            *acc.entry(biome.clone()).or_insert(0u32) += *count;
+            acc
+        })
+        .into_iter()
+        .collect();
+    by_count.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+    by_count
+}
+
+/// Top-`n` biomes, prettified ("snowy_taiga" → "snowy taiga").
+fn top_biomes(world: &crate::editor::World, n: usize) -> Vec<String> {
+    biome_counts(world).into_iter().take(n).map(|(b, _)| b.name().replace('_', " ")).collect()
+}
+
+/// The single most common biome across the town's parcels — used by the legacy
+/// `place_buildings` pipeline to pick a paving type. `None` if no parcels were
+/// analysed.
+pub fn dominant_biome(world: &crate::editor::World) -> Option<crate::minecraft::Biome> {
+    biome_counts(world).into_iter().next().map(|(b, _)| b)
+}
+
+/// Assemble the chronicle's [`CityDossier`] from the final settlement state. All
+/// inputs are locals still in scope at the end of [`generate_town`]; this does the
+/// id→name / colour→word / coords→quarter conversion so the LLM sees only
+/// human-readable, relational facts. Roads are emitted first because they are the
+/// `near` vocabulary every other landmark anchors to.
+fn assemble_dossier(
+    editor: &Editor,
+    urban: &HashSet<Point2D>,
+    culture: crate::generator::buildings_v2::Culture,
+    named: &crate::generator::naming::SettlementName,
+    town_colors: &[Color],
+    road_names: &HashMap<u32, String>,
+    road_labels: &HashMap<Point2D, u32>,
+    place_labels: &[(Point2D, String)],
+    manor_facts: &[ManorFact],
+    house_count: usize,
+) -> crate::generator::chronicle::CityDossier {
+    use crate::generator::chronicle::{size_word, CityDossier, Landmark};
+    use crate::generator::BuildClaim;
+
+    let centre = cells_centroid(&urban.iter().copied().collect::<Vec<_>>());
+    let radius = urban
+        .iter()
+        .map(|&c| {
+            let dx = (c.x - centre.x) as f32;
+            let dz = (c.y - centre.y) as f32;
+            (dx * dx + dz * dz).sqrt()
+        })
+        .fold(0.0_f32, f32::max);
+
+    let mut landmarks: Vec<Landmark> = Vec::new();
+
+    // ── Roads first (the `near` vocabulary) ──
+    let mut road_cells: HashMap<u32, Vec<Point2D>> = HashMap::new();
+    for (&c, &rid) in road_labels {
+        road_cells.entry(rid).or_default().push(c);
+    }
+    let mut rids: Vec<u32> = road_names.keys().copied().collect();
+    rids.sort_unstable();
+    for rid in rids {
+        let Some(name) = road_names.get(&rid) else { continue };
+        let quarter = road_cells
+            .get(&rid)
+            .map(|cs| quarter_of(cells_centroid(cs), centre, radius))
+            .unwrap_or_default();
+        landmarks.push(Landmark { kind: "road".into(), name: name.clone(), quarter, near: vec![], notes: vec![] });
+    }
+
+    // ── Industries: distinct workplace structure types, by location ──
+    let mut scan: Vec<Point2D> = editor.world().get_urban_points().into_iter().collect();
+    for sd in editor.world().districts.values() {
+        if sd.data.parcel_type == ParcelType::Rural {
+            scan.extend(sd.data.points_2d.iter().copied());
+        }
+    }
+    let mut by_kind: HashMap<String, Vec<Point2D>> = HashMap::new();
+    for p in scan {
+        if let Some(BuildClaim::Structure(id)) = editor.world().get_claim(p) {
+            by_kind.entry(id.structure_type.0.clone()).or_default().push(p);
+        }
+    }
+    let mut kinds: Vec<String> = by_kind.keys().cloned().collect();
+    kinds.sort();
+    for kind in kinds {
+        let cen = cells_centroid(&by_kind[&kind]);
+        let quarter = quarter_of(cen, centre, radius);
+        let near = nearest_road(cen, road_labels, road_names, 6).into_iter().collect();
+        landmarks.push(Landmark {
+            kind: "industry".into(),
+            name: format!("the {}", kind.replace('_', " ")),
+            quarter,
+            near,
+            notes: vec![],
+        });
+    }
+
+    // ── Families (manors) ──
+    for mf in manor_facts {
+        let quarter = quarter_of(mf.pos, centre, radius);
+        let near = nearest_road(mf.pos, road_labels, road_names, 8).into_iter().collect();
+        let mut notes = Vec::new();
+        if let Some(c) = mf.color {
+            notes.push(color_word(c));
+        }
+        if let Some(b) = &mf.blazon {
+            notes.push(b.clone());
+        }
+        landmarks.push(Landmark {
+            kind: "manor".into(),
+            name: format!("the {} {}", mf.surname, mf.designation),
+            quarter,
+            near,
+            notes,
+        });
+    }
+
+    // ── Greens & squares (named open spaces) ──
+    for (pos, name) in place_labels {
+        let quarter = quarter_of(*pos, centre, radius);
+        let near = nearest_road(*pos, road_labels, road_names, 6).into_iter().collect();
+        landmarks.push(Landmark { kind: "park".into(), name: name.clone(), quarter, near, notes: vec![] });
+    }
+
+    // ── Gates (deduped by side) ──
+    let mut gate_names: HashSet<String> = HashSet::new();
+    for (gpos, _dir) in &editor.world().gate_locations {
+        let dir = compass_word(gpos.drop_y(), centre);
+        let name = format!("the {dir} gate");
+        if gate_names.insert(name.clone()) {
+            landmarks.push(Landmark {
+                kind: "gate".into(),
+                name,
+                quarter: format!("on the {dir} edge"),
+                near: vec![],
+                notes: vec![],
+            });
+        }
+    }
+
+    // Town colours as words, deduped.
+    let mut town_colours: Vec<String> = Vec::new();
+    for &c in town_colors {
+        let w = color_word(c);
+        if !town_colours.contains(&w) {
+            town_colours.push(w);
+        }
+    }
+
+    CityDossier {
+        name: named.name.clone(),
+        subtitle: named.subtitle.clone(),
+        culture: culture_word(culture),
+        town_colours,
+        biomes: top_biomes(editor.world(), 3),
+        size: size_word(house_count),
+        walled: !editor.world().gate_locations.is_empty(),
+        landmarks,
+    }
+}
+
+/// A bare dossier for callers that don't run the full town pipeline (the legacy
+/// `place_buildings` path / visualizer): a procedurally-named town with whatever
+/// industries and gates exist in the world, but no roads/families/greens. Gives
+/// the chronicle a real name without the old AI namer.
+pub fn minimal_dossier(
+    editor: &Editor,
+    culture: crate::generator::buildings_v2::Culture,
+    rng: &mut RNG,
+) -> crate::generator::chronicle::CityDossier {
+    let urban = editor.world().get_urban_points();
+    let named = crate::generator::naming::generate_settlement_name(
+        editor.world(), &urban, &[], culture, &[], rng,
+    );
+    let no_roads: HashMap<u32, String> = HashMap::new();
+    let no_labels: HashMap<Point2D, u32> = HashMap::new();
+    assemble_dossier(
+        editor, &urban, culture, &named, &[], &no_roads, &no_labels, &[], &[],
+        editor.world().buildings.len(),
+    )
+}
+
 pub async fn generate_town(
     editor: &mut Editor,
     seed: Seed,
-    culture: crate::generator::buildings_v2::Culture,
+    culture: Option<crate::generator::buildings_v2::Culture>,
 ) {
     let mut rng = RNG::new(seed);
     let mut rng2 = RNG::new(seed);
+
+    // Settlement culture: an explicit override (tests) wins; otherwise auto-select
+    // from the build area's climate so the town fits its biome while the cultures
+    // stay roughly even across worlds (see `buildings_v2::climate`). The selection
+    // RNG is keyed off the seed independently so it never perturbs `rng`/`rng2`.
+    let culture = culture.unwrap_or_else(|| {
+        let mut culture_rng = RNG::from_seed_and_string(seed, "culture_select");
+        let c = crate::generator::buildings_v2::climate::select_culture(
+            editor.world().get_ground_biome_map(),
+            &mut culture_rng,
+        );
+        println!("Auto-selected culture {c:?} from build-area climate");
+        c
+    });
 
     // Infrastructure materials follow the culture: a desert town gets sandstone
     // roads and walls, a Japanese town a blackstone wall (matching its palette-
@@ -483,10 +788,14 @@ pub async fn generate_town(
     // at the slice's interior extreme reaches `rise + depth` into the band).
     const RIBBON_DEPTH: i32 = 14;
     let mut sub_blocks: Vec<HashSet<Point2D>> = Vec::new();
+    // Block index each lot belongs to (parallel to `sub_blocks`), so a lot can be
+    // mapped back to its district's style scheme. A "district" here is one city
+    // block from `find_blocks`.
+    let mut lot_block: Vec<usize> = Vec::new();
     let mut alley_band: HashSet<Point2D> = HashSet::new();
     let mut ribbon_lot_count = 0usize;
     let mut ribbon_cells: HashSet<Point2D> = HashSet::new(); // DEBUG: all reserved ribbon cells
-    for block in &blocks {
+    for (block_idx, block) in blocks.iter().enumerate() {
         let (mut ribbon_lots, interior) =
             crate::generator::districts::subdivide::reserve_road_ribbon(block, &main_road_cells, RIBBON_DEPTH);
         let (subs, alleys) = crate::generator::districts::subdivide::subdivide_block(&interior, &mut rng, 24);
@@ -504,10 +813,13 @@ pub async fn generate_town(
 
         ribbon_lot_count += ribbon_lots.len();
         for rp in &ribbon_lots { ribbon_cells.extend(rp); }
+        let lots_this_block = ribbon_lots.len() + subs.len();
         sub_blocks.extend(ribbon_lots);
         alley_band.extend(&alleys);
         alley_band.extend(&connectors);
         sub_blocks.extend(subs);
+        // Every lot just added (ribbons then subs) belongs to this block.
+        lot_block.extend(std::iter::repeat(block_idx).take(lots_this_block));
     }
     println!(
         "Subdivided into {} lots ({} road-frontage ribbons), {} subdivider-road cells",
@@ -596,26 +908,42 @@ pub async fn generate_town(
     use crate::generator::materials::{Palette, PaletteId};
     use crate::geometry::Point2D as P2;
 
-    // Culture for this settlement. Medieval → spruce/stone palette, gable
-    // roofs, glass windows, and timber-frame jetties (square_bias 0, so no
-    // domes; per-house wood/stone/roof variety via roll_palette below).
-    let base_palette: Palette = data.palettes.get(&culture.palette_id())
-        .expect("base palette not found").clone();
-    let wood_ids: Vec<PaletteId> = vec!["oak".into(), "spruce".into(), "dark_oak".into()];
-    let stone_ids: Vec<PaletteId> = vec!["stone_bricks".into(), "cobblestone".into(), "deepslate".into()];
-    let roof_ids: Vec<PaletteId> = vec![
-        "acacia_wood_roof".into(), "brick_roof".into(), "oak_wood_roof".into(), "red_wood_roof".into(),
-    ];
-
-    fn roll_palette(rng: &mut RNG, base: &Palette, data: &LoadedData, woods: &[PaletteId], stones: &[PaletteId], roofs: &[PaletteId]) -> Palette {
-        let w = &woods[rng.rand_i32_range(0, woods.len() as i32) as usize];
-        let s = &stones[rng.rand_i32_range(0, stones.len() as i32) as usize];
-        let r = &roofs[rng.rand_i32_range(0, roofs.len() as i32) as usize];
-        base.clone()
-            .merged_with(data.palettes.get(w).expect("wood palette not found"))
-            .merged_with(data.palettes.get(s).expect("stone palette not found"))
-            .merged_with(data.palettes.get(r).expect("roof palette not found"))
-    }
+    // Per-settlement style composition: pick a dominant/secondary/accent trio
+    // from this culture's catalog and apply them to buildings in a weighted
+    // 60/30/10 mix (see StyleScheme), so the town reads as one coherent material
+    // story with rare landmark punctuation. Variable wood pools lean toward the
+    // local biome's timber. `style_rng` is derived so style selection doesn't
+    // perturb the placement RNG stream.
+    use crate::generator::buildings_v2::style::{StyleScheme, local_wood_palette};
+    let local_wood: Option<PaletteId> = editor
+        .world()
+        .get_surface_biome_at(editor.world().world_rect_2d().midpoint())
+        .and_then(local_wood_palette);
+    let mut style_rng = rng.derive();
+    let style_scheme = StyleScheme::generate(culture, &mut style_rng);
+    println!(
+        "Style scheme ({culture:?}): 60% {} / 30% {} / 10% {} — local wood {:?}",
+        style_scheme.dominant().name,
+        style_scheme.secondary().name,
+        style_scheme.accent().name,
+        local_wood.as_ref().map(|p| p.clone()),
+    );
+    // Per-district twist: each city block keeps the town's dominant (60%) and
+    // accent (10%) but re-rolls its 30% secondary to a different everyday style,
+    // so a quarter reads as its own while the city stays one place (see
+    // `StyleScheme::district_variant`). Keyed off the seed per block index so it's
+    // deterministic and independent of the placement streams. `lot_block` (built
+    // during subdivision) maps each lot to its block, hence to its scheme.
+    let district_schemes: Vec<StyleScheme> = (0..blocks.len())
+        .map(|bi| {
+            let mut drng = RNG::from_seed_and_string(seed, &format!("district_style_{bi}"));
+            style_scheme.district_variant(culture, &mut drng)
+        })
+        .collect();
+    println!(
+        "Per-district secondaries: {:?}",
+        district_schemes.iter().map(|s| s.secondary().name).collect::<Vec<_>>(),
+    );
     // Densest tier first; size pool per tier (houses on the main roads,
     // cottages on the back lanes).
     // House + Hall on every tier. Manor is no longer opportunistic — it's
@@ -748,6 +1076,9 @@ pub async fn generate_town(
     let mut sign_rng = rng.derive();
     let mut manor_sign_sites: Vec<crate::generator::buildings_v2::exterior::ManorSignSite> =
         Vec::new();
+    // Manor families for the chronicle, paired with their surname once the
+    // population pass names each household (see the manor-sign lettering loop).
+    let mut manor_facts: Vec<ManorFact> = Vec::new();
 
     let mut total_buildings = 0usize;
     // Per-house NPC anchors + bed-derived population budget, gathered from every
@@ -873,12 +1204,12 @@ pub async fn generate_town(
                     // road). Square_bias = 0 here matches the live town gen —
                     // domes on wings haven't been wired through yet.
 
-                    // Desert keeps a uniform sandstone palette; other cultures
-                    // roll wood/stone/roof variants per house for variety.
-                    let mut palette = match culture {
-                        Culture::Desert => base_palette.clone(),
-                        _ => roll_palette(&mut rng, &base_palette, &data, &wood_ids, &stone_ids, &roof_ids),
-                    };
+                    // Pick this building's style from its *district's* scheme
+                    // (60% town dominant / 30% district secondary / 10% town
+                    // accent) and roll its palette, leaning on the local wood.
+                    let mut palette = district_schemes[lot_block[lot_idx]]
+                        .next_style(&mut style_rng)
+                        .roll_palette(&mut style_rng, &data, local_wood.as_ref());
                     // Apply the town colour identity: a manor flies its unique
                     // family colour; every other building draws from the weighted
                     // town scheme. This `primary_color` then tints the building's
@@ -1337,10 +1668,20 @@ pub async fn generate_town(
         log_population_stats(&population);
         log_sample_households(&population, 8);
 
-        // Letter each manor's name sign now its household surname is known.
+        // Letter each manor's name sign now its household surname is known, and
+        // record the family for the chronicle (surname + the manor's location,
+        // colour, and blazon from its `HouseAnchors`).
         for site in &manor_sign_sites {
             if let Some(hh) = population.households.iter().find(|h| h.home == site.anchor_idx) {
                 println!("Manor sign: {} {}", hh.surname, site.designation());
+                let anchor = &town_anchors[site.anchor_idx];
+                manor_facts.push(ManorFact {
+                    surname: hh.surname.clone(),
+                    designation: site.designation().to_string(),
+                    pos: anchor.pos,
+                    color: anchor.family_color,
+                    blazon: anchor.banner_blazon.clone(),
+                });
                 crate::generator::buildings_v2::exterior::place_manor_sign(
                     editor, site, &hh.surname,
                 ).await;
@@ -1570,6 +1911,19 @@ pub async fn generate_town(
             editor, &urban, &named.name, &named.subtitle,
         ).await;
         println!("Placed welcome-title sensor for \"{}\" ({})", named.name, named.subtitle);
+
+        // Chronicle: digest the finished town into a dossier (name, colours,
+        // biomes, roads, trades, families, greens, gates) and have the AI write a
+        // guidebook, dropped into the player's inventory. Live-only — `give_player
+        // _book` posts to the server; failures are non-fatal.
+        let dossier = assemble_dossier(
+            editor, &urban, culture, &named, &color_scheme.town,
+            &road_names, &road_network.road_labels, &place_labels, &manor_facts,
+            total_buildings,
+        );
+        if let Err(e) = crate::generator::chronicle::generate_chronicle(&*editor, &dossier).await {
+            log::warn!("Chronicle generation failed: {e}");
+        }
     }
 
     editor.flush_buffer().await;

--- a/src/generator/terrain/terraforming.rs
+++ b/src/generator/terrain/terraforming.rs
@@ -130,6 +130,15 @@ pub fn terraform_layers(surface: &Block) -> (Block, Block) {
 }
 
 pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_water : bool) {
+    // Terraforming writes many blocks per column over a wide area. The default
+    // 32-block buffer flushes an HTTP PUT every 32 placements, so the cost is
+    // dominated by round-trip latency × request count. Batch much larger here
+    // (one PUT per ~4096 blocks instead of per 32) to cut the request count by
+    // two orders of magnitude, then flush and restore the caller's buffer size.
+    const TERRAFORM_BUFFER: usize = 4096;
+    let prev_buffer = editor.buffer_size();
+    editor.set_buffer_size(TERRAFORM_BUFFER);
+
     // Only the points we actually terraform may be written back to the
     // heightmap. Asserting heights for skipped water cells would make the map
     // claim land that was never built — downstream consumers (e.g. the wall's
@@ -236,6 +245,11 @@ pub async fn force_height(editor: &mut Editor, points: &HashSet<Point3D>, skip_w
             updated.insert(point.with_y(surface_air));
         }
     }
+
+    // With the large buffer, most placements above are still pending; flush
+    // them in as few requests as possible before restoring the caller's size.
+    editor.flush_buffer().await;
+    editor.set_buffer_size(prev_buffer);
 
     editor.world_mut().set_heights(&updated);
 }

--- a/src/generator/terrain/tree.rs
+++ b/src/generator/terrain/tree.rs
@@ -54,6 +54,12 @@ pub enum Tree {
     MediumOak,
     #[serde(rename = "small_oak")]
     SmallOak,
+    #[serde(rename = "small_cherry")]
+    SmallCherry,
+    #[serde(rename = "medium_cherry")]
+    MediumCherry,
+    #[serde(rename = "large_cherry")]
+    LargeCherry,
     #[serde(rename = "cactus")]
     Cactus,
 }
@@ -169,6 +175,10 @@ pub async fn generate_tree(
         Tree::SmallOak => {
             // Generate a small oak tree
             generate_small_oak(editor, point, &wood_block, &leaf_block, rng, 100).await
+        }
+        Tree::SmallCherry | Tree::MediumCherry | Tree::LargeCherry => {
+            // Cherry blossoms are only grown via the vanilla `place feature`
+            // path (see tree_feature.rs); there's no hand-authored variant.
         }
         Tree::Cactus => {
             // Cactus ignores the wood/leaf palette — it's a short column on sand.

--- a/src/generator/terrain/tree_feature.rs
+++ b/src/generator/terrain/tree_feature.rs
@@ -44,6 +44,9 @@ pub fn tree_feature_id(tree: Tree) -> &'static str {
             "minecraft:acacia"
         }
 
+        // Cherry blossom: the one vanilla cherry feature for every size.
+        Tree::SmallCherry | Tree::MediumCherry | Tree::LargeCherry => "minecraft:cherry",
+
         // Cactus has no vanilla tree feature — `generate_tree_feature` intercepts
         // it and builds a column directly, so this id is never actually queried.
         Tree::Cactus => "minecraft:cactus",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::{data::Loadable, editor::World, generator::{buildings::place_buildings, chronicle::{generate_chronicle, SettlementInfo}, data::LoadedData, districts::{build_wall, generate_parcels, WallType}, materials::{Material, MaterialId, Placer}, style::Style, terrain::log_trees}, http_mod::GDMCHTTPProvider, noise::RNG, util::init_logger};
+use crate::{data::Loadable, editor::World, generator::{buildings::place_buildings, chronicle::generate_chronicle, data::LoadedData, districts::{build_wall, generate_parcels, WallType}, materials::{Material, MaterialId, Placer}, style::Style, terrain::log_trees}, http_mod::GDMCHTTPProvider, noise::RNG, util::init_logger};
 
 
 pub mod geometry;
@@ -32,7 +32,6 @@ async fn run_generation(server: &visualizer::VisualizerServer) {
     // === Parcels ===
     server.update_phase(visualizer::GenerationPhase::Parcels);
     generate_parcels(rng.next_i64().into(), &mut editor).await;
-    let mut info = SettlementInfo::new(editor.world());
     let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Parcels);
     server.update_snapshot(snap);
 
@@ -52,8 +51,7 @@ async fn run_generation(server: &visualizer::VisualizerServer) {
 
     // === Buildings ===
     server.update_phase(visualizer::GenerationPhase::Buildings);
-    place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()], &info).await;
-    info = SettlementInfo::new(editor.world());
+    place_buildings(&mut editor, &mut rng.derive(), &data, Style::Medieval, vec![&"medieval_spruce".into()]).await;
     let snap = visualizer::snapshot::extract_full_snapshot(editor.world(), &visualizer::GenerationPhase::Buildings);
     server.update_snapshot(snap);
 
@@ -69,7 +67,10 @@ async fn run_generation(server: &visualizer::VisualizerServer) {
 
     // === Chronicle ===
     server.update_phase(visualizer::GenerationPhase::Chronicle);
-    if let Err(e) = generate_chronicle(&mut editor, &mut info).await {
+    let dossier = crate::generator::settlement::minimal_dossier(
+        &editor, crate::generator::buildings_v2::Culture::Medieval, &mut rng.derive(),
+    );
+    if let Err(e) = generate_chronicle(&mut editor, &dossier).await {
         server.log("warn", &format!("Chronicle generation failed: {e}"));
     }
 
@@ -98,11 +99,8 @@ async fn run_generation_once() {
     // so tests can still pin it to a fixed value for determinism.
     let seed = crate::noise::Seed(random_seed());
     println!("Generating town with seed {}", seed.0);
-    crate::generator::settlement::generate_town(
-        &mut editor,
-        seed,
-        crate::generator::buildings_v2::Culture::Medieval,
-    ).await;
+    // None → auto-select the culture from the build area's climate.
+    crate::generator::settlement::generate_town(&mut editor, seed, None).await;
 }
 
 #[tokio::main]


### PR DESCRIPTION
Branch-wide pass on settlement *character*: how a town picks its culture, how its buildings vary block-to-block, how it names and colours itself, and how it's chronicled. Six commits, grouped by feature below.

## Building style catalog & per-district palettes
- **Style catalog** (`buildings_v2/style.rs`): each culture defines a menu of `BuildingStyle` recipes — a base palette plus wood/stone/roof/accent variant *pools*. Rolling a style merges the base with one pick per pool, so **pool size = internal variance** (a 1-entry pool is a matched set, a 4-entry pool jitters house-to-house). A settlement's `StyleScheme` picks a **60/30/10 dominant/secondary/accent** trio, keeping rare landmark styles (stone halls, shrines, vermilion temples) out of the bulk.
- **Per-district variation**: every city block keeps the town's dominant (60%) and accent (10%) but re-rolls its own 30% **secondary** (`StyleScheme::district_variant`), so each quarter reads as its own — "the Dark Tudor lane," "the cherry-roof district" — while the city stays one coherent place.
- **Accent parapets**: flat desert roofs render a clean coloured terracotta crown band for the painted-trim styles.

## Climate-driven culture selection
- `generate_town` now **auto-selects the settlement's culture from the build-area biome map** (`buildings_v2/climate.rs`), so a town fits its surroundings:
  - **Arid** (desert/savanna/badlands) → Desert
  - **Tropical** (jungle/swamp/mangrove) → Japanese
  - **Cherry grove / bamboo jungle** → Japanese, weighted *heavily* so even a modest grove inside the build area flips the whole town
  - everything else (temperate/cold) → Medieval
- Selection sums a per-cell culture weight over the whole map and makes one weighted draw, so mixed build areas blend sensibly. `generate_town` takes `Option<Culture>` (`None` = auto-select; tests pass an explicit override).

## Town colour identity & procedural naming *(pre-existing on branch)*
- Each settlement gets **two recurring town colours** (applied ~50/25/25 with a random accent per building) plus a **unique family colour per manor**, flown as an exterior banner, with colour-weighted surnames (e.g. Blackwell) and colour-aware town naming.
- Procedural, feature-driven **settlement namer** with an English-gloss subtitle, replacing the AI namer; deterministic and seeded.

## NPC & flora character
- **Culture-localized surnames**: shared English place-name structure (root + land-form ending) over per-culture word pools — Anglo-Saxon (Ashwood), Japanese imagery (Pinevale, Cranebrook), desert imagery (Sandford, Sunmere).
- **Flowering cherry trees** grow in parks/nooks of Japanese settlements (35% chance), via new Small/Medium/Large cherry tree variants on the vanilla `minecraft:cherry` feature.

## Chronicle city dossier
- Replaces `SettlementInfo` with a `Landmark` / `CityDossier` **view-model** assembled from typed generator state (roads, manors, trades, parks, gates), handing the chronicle LLM only human-readable facts (colour words, road names, blazons) — never raw ids/coords. `place_buildings` drops its `settlement_info` parameter.

## Infrastructure
- OOB-safe `World` map accessors; medieval jetty; heraldry WIP *(pre-existing on branch)*.
- **Terraforming HTTP batching**: raise the editor buffer to 4096 during terraforming (≈2 orders of magnitude fewer PUTs), then flush and restore — large speedup on the wide terrain pass.

## Tests
Offline (no server): style catalog rolls cleanly, district-variant invariants, climate buckets + pure-climate determinism, cherry/bamboo grove-flip and sliver behaviour. Existing offline pipeline/invariant tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)